### PR TITLE
update configlet validation

### DIFF
--- a/apstra/design/configlet_generator.go
+++ b/apstra/design/configlet_generator.go
@@ -54,10 +54,12 @@ func (o ConfigletGenerator) ResourceAttributesNested() map[string]resourceSchema
 			MarkdownDescription: fmt.Sprintf("Specifies the switch platform, must be one of '%s'.",
 				strings.Join(utils.AllPlatformOSNames(), "', '")),
 			Required:   true,
-			Validators: []validator.String{stringvalidator.OneOf(utils.AllPlatformOSNames()...)}},
+			Validators: []validator.String{stringvalidator.OneOf(utils.AllPlatformOSNames()...)},
+		},
 		"section": resourceSchema.StringAttribute{
-			MarkdownDescription: fmt.Sprintf("Specifies where in the target device the configlet should be applied. Valid values are %v", utils.ValidSectionsMap()),
+			MarkdownDescription: fmt.Sprintf("Specifies where in the target device the configlet should be applied. Valid values are %v", utils.ConfigletValidSectionsMap()),
 			Required:            true,
+			Validators:          []validator.String{stringvalidator.OneOf(utils.AllConfigletSectionNames()...)},
 		},
 		"template_text": resourceSchema.StringAttribute{
 			MarkdownDescription: "Template Text",

--- a/apstra/utils/configlets.go
+++ b/apstra/utils/configlets.go
@@ -16,7 +16,28 @@ func ConfigletSupportsPlatforms(configlet *apstra.Configlet, platforms []apstra.
 	return true
 }
 
-func SectionNamesByOS(os apstra.PlatformOS) []string {
+func AllConfigletSectionNames() []string {
+	platformToFriendlySectionName := ConfigletValidSectionsMap() // map of os -> friendly section names
+	friendlySectionNames := make(map[string]struct{})            // unique-ify the friendly section names here
+
+	for _, v := range platformToFriendlySectionName {
+		for _, friendlyName := range v {
+			friendlySectionNames[friendlyName] = struct{}{} // map keys are friendly names across all platforms
+		}
+	}
+
+	// turn the map into a list
+	var i int
+	result := make([]string, len(friendlySectionNames))
+	for k := range friendlySectionNames {
+		result[i] = k
+		i++
+	}
+
+	return result
+}
+
+func ConfigletSectionNamesByOS(os apstra.PlatformOS) []string {
 	var r []string
 	for _, v := range os.ValidSections() {
 		r = append(r, StringersToFriendlyString(v, os))
@@ -24,10 +45,10 @@ func SectionNamesByOS(os apstra.PlatformOS) []string {
 	return r
 }
 
-func ValidSectionsMap() map[string][]string {
+func ConfigletValidSectionsMap() map[string][]string {
 	var m = make(map[string][]string)
 	for _, i := range apstra.AllPlatformOSes() {
-		m[i.String()] = SectionNamesByOS(i)
+		m[i.String()] = ConfigletSectionNamesByOS(i)
 	}
 	return m
 }

--- a/apstra/utils/in.go
+++ b/apstra/utils/in.go
@@ -1,0 +1,10 @@
+package utils
+
+func ItemInSlice[A comparable](item A, slice []A) bool {
+	for i := range slice {
+		if item == slice[i] {
+			return true
+		}
+	}
+	return false
+}

--- a/apstra/utils/in_test.go
+++ b/apstra/utils/in_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestItemInSlice(t *testing.T) {
+	type testCase struct {
+		item     any
+		slice    []any
+		expected bool
+	}
+
+	testCases := []testCase{
+		{item: 1, slice: []any{1, 2, 3}, expected: true},
+		{item: 1, slice: []any{1, 2, 3, 1}, expected: true},
+		{item: 1, slice: []any{3, 2, 1}, expected: true},
+		{item: 0, slice: []any{1, 2, 3}, expected: false},
+		{item: 0, slice: []any{}, expected: false},
+		{item: 1, slice: []any{}, expected: false},
+		{item: "foo", slice: []any{"foo", "bar"}, expected: true},
+		{item: "foo", slice: []any{"bar", "foo"}, expected: true},
+		{item: "foo", slice: []any{"foo", "bar", "foo"}, expected: true},
+		{item: "foo", slice: []any{"bar", "baz"}, expected: false},
+		{item: "foo", slice: []any{""}, expected: false},
+		{item: "foo", slice: []any{"", ""}, expected: false},
+		{item: "foo", slice: []any{}, expected: false},
+		{item: "", slice: []any{"bar", "foo"}, expected: false},
+		{item: "", slice: []any{"bar", "", "foo"}, expected: true},
+		{item: "", slice: []any{}, expected: false},
+	}
+
+	var result bool
+	for i, tc := range testCases {
+		switch tc.item.(type) {
+		case int:
+			item := tc.item.(int)
+			slice := make([]int, len(tc.slice))
+			for j := range tc.slice {
+				slice[j] = tc.slice[j].(int)
+			}
+			result = ItemInSlice(item, slice)
+		case string:
+			item := tc.item.(string)
+			slice := make([]string, len(tc.slice))
+			for j := range tc.slice {
+				slice[j] = tc.slice[j].(string)
+			}
+			result = ItemInSlice(item, slice)
+		}
+		if result != tc.expected {
+			t.Fatalf("test case %d produced %t, epexcted %t", i, result, tc.expected)
+		}
+	}
+}

--- a/apstra/utils/in_test.go
+++ b/apstra/utils/in_test.go
@@ -49,7 +49,7 @@ func TestItemInSlice(t *testing.T) {
 			result = ItemInSlice(item, slice)
 		}
 		if result != tc.expected {
-			t.Fatalf("test case %d produced %t, epexcted %t", i, result, tc.expected)
+			t.Fatalf("test case %d produced %t, expected %t", i, result, tc.expected)
 		}
 	}
 }


### PR DESCRIPTION
- add `AllConfigletSectionNames()` to generate all possible friendly section names
- add configlet `section` attribute validator (uses `AllConfigletSectionNames()`) to help with usage statements
- introduce `ItemInSlice()` helper function with tests
- use `ItemInSlice()` helper function in configlet validator
- change configlet validator errors to `validatordiag` with path attribute
- add `filename` : `section` validation check
