### PR TITLE
sort configlet section markdown table

### DIFF
--- a/apstra/design/configlet_generator.go
+++ b/apstra/design/configlet_generator.go
@@ -57,9 +57,10 @@ func (o ConfigletGenerator) ResourceAttributesNested() map[string]resourceSchema
 			Validators: []validator.String{stringvalidator.OneOf(utils.AllPlatformOSNames()...)},
 		},
 		"section": resourceSchema.StringAttribute{
-			MarkdownDescription: fmt.Sprintf("Specifies where in the target device the configlet should be applied. Varies by network OS:%s", utils.ValidSectionsAsTable()),
-			Required:            true,
-			Validators:          []validator.String{stringvalidator.OneOf(utils.AllConfigletSectionNames()...)},
+			MarkdownDescription: fmt.Sprintf("Specifies where in the target device the configlet should be "+
+				" applied. Varies by network OS:\n\n%s", utils.ValidSectionsAsTable()),
+			Required:   true,
+			Validators: []validator.String{stringvalidator.OneOf(utils.AllConfigletSectionNames()...)},
 		},
 		"template_text": resourceSchema.StringAttribute{
 			MarkdownDescription: "Template Text",

--- a/apstra/utils/configlets.go
+++ b/apstra/utils/configlets.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"sort"
+	"strings"
 )
 
 func ConfigletSupportsPlatforms(configlet *apstra.Configlet, platforms []apstra.PlatformOS) bool {
@@ -58,18 +60,25 @@ func ConfigletValidSectionsMap() map[string][]string {
 
 func ValidSectionsAsTable() string {
 	m := ConfigletValidSectionsMap()
-	o := fmt.Sprintf("\n\n| **Config Style**  | **Section** |")
-	o += "\n|-|-|"
+
+	// collect map keys into a sorted slice so that the table renders in consistent order
+	keys := make([]string, len(m))
+	var i int
 	for k := range m {
-		s := ""
-		for _, i := range m[k] {
-			s = fmt.Sprintf("%v,%s", i, s)
-		}
-		s = s[:len(s)-1] //drop tha last comma
-		o += fmt.Sprintf("\n|%v|%v|", k, s)
+		keys[i] = k
+		i++
 	}
-	o += "\n"
-	return o
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	sb.WriteString("  | **Config Style**  | **Valid Sections** |\n")
+	sb.WriteString("  |---|---|\n")
+
+	for _, k := range keys {
+		sb.WriteString(fmt.Sprintf("  |%s|%s|\n", k, strings.Join(m[k], ", ")))
+	}
+
+	return sb.String()
 }
 
 func AllPlatformOSNames() []string {

--- a/apstra/utils/configlets_test.go
+++ b/apstra/utils/configlets_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestValidSectionsAsTable(t *testing.T) {
+	expected := `  | **Config Style**  | **Valid Sections** |
+  |---|---|
+  |cumulus|file, frr, interface, ospf, system|
+  |eos|interface, ospf, system, system_top|
+  |junos|interface_level_hierarchical, interface_level_delete, interface_level_set, top_level_hierarchical, top_level_set_delete|
+  |nxos|system, interface, system_top, ospf|
+  |sonic|file, frr, ospf, system|
+`
+	table := ValidSectionsAsTable()
+	if table != expected {
+		t.Fatalf("expected this:\n%s\ngot this:\n%s\n", expected, table)
+	}
+}

--- a/docs/resources/configlet.md
+++ b/docs/resources/configlet.md
@@ -55,15 +55,15 @@ resource "apstra_configlet" "example" {
 Required:
 
 - `config_style` (String) Specifies the switch platform, must be one of 'cumulus', 'nxos', 'eos', 'junos', 'sonic'.
-- `section` (String) Specifies where in the target device the configlet should be applied. Varies by network OS:
+- `section` (String) Specifies where in the target device the configlet should be  applied. Varies by network OS:
 
-| **Config Style**  | **Section** |
-|-|-|
-|nxos|ospf,system_top,interface,system|
-|eos|system_top,system,ospf,interface|
-|junos|top_level_set_delete,top_level_hierarchical,interface_level_set,interface_level_delete,interface_level_hierarchical|
-|sonic|system,ospf,frr,file|
-|cumulus|system,ospf,interface,frr,file|
+  | **Config Style**  | **Valid Sections** |
+  |---|---|
+  |cumulus|file, frr, interface, ospf, system|
+  |eos|interface, ospf, system, system_top|
+  |junos|interface_level_hierarchical, interface_level_delete, interface_level_set, top_level_hierarchical, top_level_set_delete|
+  |nxos|system, interface, system_top, ospf|
+  |sonic|file, frr, ospf, system|
 - `template_text` (String) Template Text
 
 Optional:


### PR DESCRIPTION
The configlet section table comes from a map. Where order isn't guaranteed.

The possibility exists when running `tfplugindocs` multiple times will render the table in a different order.

And this is exactly what was happening:

1st run: prior to commit, merge to main, etc...
2nd run: during the release process, to ensure the doc generation had been run.

The 2nd run was modifying the doc tree, leading to a "dirty" repo state, and interrupting the release.

This PR introduces some sort-by-keys logic so that the table is rendered consistently from one run to the next.