### PR TITLE
Bugfixes and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,59 @@
 # terraform-provider-apstra
 
-This is the beginning of a [Terraform](https://www.terraform.io)
+This is a [Terraform](https://www.terraform.io)
 [provider](https://developer.hashicorp.com/terraform/language/providers?page=providers)
 for Juniper Apstra. It relies on a Go client library at https://github.com/Juniper/apstra-go-sdk
 
 ## Getting Started
 
-You can build from source or use a precompiled binary.
+### Install Terraform
 
-#### Build from source
+Instructions for popular operating systems can be found [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli).
 
-1. Install [`Terraform`](https://www.terraform.io/downloads) and [`Go`](https://go.dev/dl/)
-   on your machine.
-1. Clone this repo to your local system:
-   ```shell
-   git clone git@github.com:Juniper/terraform-provider-apstra.git
-   ```
-1. Build the provider:
-   ```shell
-   cd terraform-provider-apstra
-   go install
-   ```
-   The provider binary should have appeared at `$GOROOT/bin/terraform-provider-apstra`. In my case, that's
-   `~/golang/bin/terraform-provider-apstra`.
+### Create a Terraform configuration
 
-#### Use a precompiled binary
-
-1. Head over to the repository's [releases](https://github.com/chrismarget-j/terraform-provider-apstra/releases)
-page, select a version, expand the `assets` tree, and download the zip file appropriate for your system.
-   
-1. Unpack the zip file and copy the `terraform-provider-apstra_vX.X.X` binary to wherever you keep this sort of thing.
-
-### Configure Terraform to use the provider binary
-
-Terraform needs to know that it should use the provider binary you've just compiled or downloaded, rather than 
-trying to fetch it from a registry server somewhere. The easiest way to do this is to use a `dev_overrides`
-directive.
-
-My `~/.terraformrc` looks like:
+The terraform configuration must:
+- be named with a `.tf` file extension.
+- reference this provider by its global address.
+  *registry.terraform.io/Juniper/apstra* or just: *Juniper/apstra*.
+- include a provider configuration block which tells the provider where to
+find the Apstra service.
 
 ```hcl
-provider_installation {
-
-    dev_overrides {
-        "registry.terraform.io/Juniper/apstra" = "/Users/cmarget/golang/bin"
+terraform {
+  required_providers {
+    apstra = {
+      source = "Juniper/apstra"
     }
+  }
+}
 
-    # For all other providers, install them directly from their origin provider
-    # registries as normal. If you omit this, Terraform will _only_ use
-    # the dev_overrides block, and so no other providers will be available.
-    direct {}
+provider "apstra" {
+  url = "<apstra-server-url>"
 }
 ```
 
-### Optional: Put credentials in the environment
-The provider allows you to set Apstra credentials in the `terraform` configuration,
-but can also get those details from the environment. Don't put passwords in config
-files. Use environment variables:
+### Terraform Init
 
+Run the following at a command prompt while in the same directory as the
+configuration file to fetch the Apstra provider plugin.
+```shell
+terraform init
+```
+
+### Supply Apstra credentials
+Apstra credentials can be supplied through environment variables:
 ```shell
 export APSTRA_USER=<username>
 export APSTRA_PASS=<password>
 ```
+
+Alternatively, credentials can be embedded in the URL using HTTP basic
+authentication format (we don't actually *do* basic authentication, but the
+format is: `https://user:password@host`). Any special characters in the username
+and password must be URL-encoded when using this approach.
+
+### Start configuring resources
+
+Full documentation for provider, resources and data sources can be found
+[here](https://registry.terraform.io/providers/Juniper/apstra/latest/docs).

--- a/apstra/provider.go
+++ b/apstra/provider.go
@@ -67,7 +67,8 @@ func (p *Provider) Schema(_ context.Context, req provider.SchemaRequest, resp *p
 				MarkdownDescription: "URL of the apstra server, e.g. `https://<user>:<password>@apstra.juniper.net:443/`\n" +
 					"If username or password are omitted from URL string, environment variables `" + envApstraUsername +
 					"` and `" + envApstraPassword + "` will be used.  If `url` is omitted, environment variable " +
-					envApstraUrl + " will be used.",
+					envApstraUrl + " will be used.  When the username or password are embedded in the URL string, any " +
+					"special characters must be URL-encoded. For example, `pass^word` would become `pass%5eword`. ",
 				Optional: true,
 			},
 			"tls_validation_disabled": schema.BoolAttribute{

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,4 +43,4 @@ APSTRA_PASS=password
 - `experimental` (Boolean) Sets a flag in the underlying Apstra SDK client object which enables 'experimental' features. At this time, the only effect is bypassing version compatibility checks.
 - `tls_validation_disabled` (Boolean) Set 'true' to disable TLS certificate validation.
 - `url` (String) URL of the apstra server, e.g. `https://<user>:<password>@apstra.juniper.net:443/`
-If username or password are omitted from URL string, environment variables `APSTRA_USER` and `APSTRA_PASS` will be used.  If `url` is omitted, environment variable APSTRA_URL will be used.
+If username or password are omitted from URL string, environment variables `APSTRA_USER` and `APSTRA_PASS` will be used.  If `url` is omitted, environment variable APSTRA_URL will be used.  When the username or password are embedded in the URL string, any special characters must be URL-encoded. For example, `pass^word` would become `pass%5eword`.

--- a/docs/resources/rack_type.md
+++ b/docs/resources/rack_type.md
@@ -12,18 +12,49 @@ This resource creates a Rack Type in the Apstra Design tab.
 ## Example Usage
 
 ```terraform
-resource "apstra_rack_type" "rt" {
-  name = "terraform"
-  description = "terraform did this"
+resource "apstra_rack_type" "example" {
+  name                       = "example rack type"
+  description                = "Created by Terraform"
   fabric_connectivity_design = "l3clos"
-  leaf_switches = [
-    {
-      name = "leafy"
-      logical_device_id = "AOS-7x10-Leaf"
-      spine_link_count = 1
-      spine_link_speed = "10G"
+  leaf_switches = { // leaf switches are a map keyed by switch name, so
+    leaf_switch = { // "leaf switch" on this line is the name used by links targeting this switch.
+      logical_device_id   = "AOS-24x10-2"
+      spine_link_count    = 1
+      spine_link_speed    = "10G"
+      redundancy_protocol = "esi"
     }
-  ]
+  }
+  access_switches = { // access switches are a map keyed by switch name, so
+    access_switch = { // "access_switch" on this line is the name used by links targeting this switch.
+      logical_device_id = "AOS-24x10-2"
+      count             = 1
+      esi_lag_info = {
+        l3_peer_link_count = 1
+        l3_peer_link_speed = "10G"
+      }
+      links = {
+        leaf_switch = {
+          speed              = "10G"
+          target_switch_name = "leaf_switch" // note "leaf_switch" corresponds to a map key above.
+          links_per_switch   = 1
+        }
+      }
+    }
+  }
+  generic_systems = {
+    webserver = {
+      count             = 2
+      logical_device_id = "AOS-4x10-1"
+      links = {
+        link = {
+          speed              = "10G"
+          target_switch_name = "access_switch" // note "access_switch" corresponds to a map key above.
+          lag_mode           = "lacp_active"
+          switch_peer        = "first"
+        }
+      }
+    }
+  }
 }
 ```
 

--- a/examples/resources/apstra_rack_type/example.tf
+++ b/examples/resources/apstra_rack_type/example.tf
@@ -1,13 +1,44 @@
-resource "apstra_rack_type" "rt" {
-  name = "terraform"
-  description = "terraform did this"
+resource "apstra_rack_type" "example" {
+  name                       = "example rack type"
+  description                = "Created by Terraform"
   fabric_connectivity_design = "l3clos"
-  leaf_switches = [
-    {
-      name = "leafy"
-      logical_device_id = "AOS-7x10-Leaf"
-      spine_link_count = 1
-      spine_link_speed = "10G"
+  leaf_switches = { // leaf switches are a map keyed by switch name, so
+    leaf_switch = { // "leaf switch" on this line is the name used by links targeting this switch.
+      logical_device_id   = "AOS-24x10-2"
+      spine_link_count    = 1
+      spine_link_speed    = "10G"
+      redundancy_protocol = "esi"
     }
-  ]
+  }
+  access_switches = { // access switches are a map keyed by switch name, so
+    access_switch = { // "access_switch" on this line is the name used by links targeting this switch.
+      logical_device_id = "AOS-24x10-2"
+      count             = 1
+      esi_lag_info = {
+        l3_peer_link_count = 1
+        l3_peer_link_speed = "10G"
+      }
+      links = {
+        leaf_switch = {
+          speed              = "10G"
+          target_switch_name = "leaf_switch" // note "leaf_switch" corresponds to a map key above.
+          links_per_switch   = 1
+        }
+      }
+    }
+  }
+  generic_systems = {
+    webserver = {
+      count             = 2
+      logical_device_id = "AOS-4x10-1"
+      links = {
+        link = {
+          speed              = "10G"
+          target_switch_name = "access_switch" // note "access_switch" corresponds to a map key above.
+          lag_mode           = "lacp_active"
+          switch_peer        = "first"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
The last list item below is a small logic change in the blueprint deployment `Read()` method.

Without this change, the state file will have a deployment comment template:
```
comment = "Commit by $USER"
```
But read offers a *rendered* comment template to the Terraform state, triggering unnecessary churn with each *apply*.
```
comment = "Commit by cmarget"
```

The remaining items on the list are strictly documentation changes: example.tf, README, MarkdownDdescription

- Update README to reflect availability from the registry (no custom installation hoops)
- Update provider schema to mention URL-encoding credentials with special characters
- Update rack_type documentation to reflect current map-oriented rack elements
- Bugfix deployment resource so that use of comment templating doesn't lead to apparent state churn
