### PR TITLE
Resource managed device refactoring

### DIFF
--- a/apstra/data_source_logical_device.go
+++ b/apstra/data_source_logical_device.go
@@ -1,10 +1,10 @@
 package tfapstra
 
 import (
-	"github.com/Juniper/apstra-go-sdk/apstra"
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/apstra/provider.go
+++ b/apstra/provider.go
@@ -97,7 +97,7 @@ func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *pro
 			"experimental": schema.BoolAttribute{
 				MarkdownDescription: fmt.Sprintf("Sets a flag in the underlying Apstra SDK client object "+
 					"which enables *experimental* features. At this time, the only effect is bypassing version "+
-					"compatibility checks in the SDK. This provider release is tested with Apstra versions %s",
+					"compatibility checks in the SDK. This provider release is tested with Apstra versions %s.",
 					compatibility.SupportedApiVersionsPretty()),
 				Optional: true,
 			},

--- a/apstra/system_agents/managed_device.go
+++ b/apstra/system_agents/managed_device.go
@@ -1,1 +1,155 @@
-package system_agents
+package systemAgents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	apstravalidator "terraform-provider-apstra/apstra/apstra_validator"
+)
+
+type ManagedDevice struct {
+	AgentId        types.String `tfsdk:"agent_id"`
+	SystemId       types.String `tfsdk:"system_id"`
+	ManagementIp   types.String `tfsdk:"management_ip"`
+	DeviceKey      types.String `tfsdk:"device_key"`
+	AgentProfileId types.String `tfsdk:"agent_profile_id"`
+	OffBox         types.Bool   `tfsdk:"off_box"`
+}
+
+func (o *ManagedDevice) Request(_ context.Context, _ *diag.Diagnostics) *apstra.SystemAgentRequest {
+	return &apstra.SystemAgentRequest{
+		AgentTypeOffbox: apstra.AgentTypeOffbox(o.OffBox.ValueBool()),
+		ManagementIp:    o.ManagementIp.ValueString(),
+		Profile:         apstra.ObjectId(o.AgentProfileId.ValueString()),
+		OperationMode:   apstra.AgentModeFull,
+	}
+}
+
+func (o ManagedDevice) ResourceAttributes() map[string]resourceSchema.Attribute {
+	return map[string]resourceSchema.Attribute{
+		"agent_id": resourceSchema.StringAttribute{
+			MarkdownDescription: "Apstra ID for the Managed Device Agent.",
+			Computed:            true,
+			PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+		},
+		"system_id": resourceSchema.StringAttribute{
+			MarkdownDescription: "Apstra ID for the System onboarded by the Managed Device Agent.",
+			Computed:            true,
+			PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
+		},
+		"management_ip": resourceSchema.StringAttribute{
+			MarkdownDescription: "Management IP address of the system.",
+			Required:            true,
+			PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			Validators:          []validator.String{apstravalidator.ParseIp(false, false)},
+		},
+		"device_key": resourceSchema.StringAttribute{
+			MarkdownDescription: "Key which uniquely identifies a System asset. Possibly a MAC address or serial number.",
+			Optional:            true,
+			PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
+		},
+		"agent_profile_id": resourceSchema.StringAttribute{
+			MarkdownDescription: "ID of the Agent Profile used when instantiating the Agent. An Agent Profile is" +
+				"required to specify the login credentials and platform type.",
+			Required:   true,
+			Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
+		},
+		"off_box": resourceSchema.BoolAttribute{
+			MarkdownDescription: "Indicates that an *offbox* agent should be created (required for Junos devices, default: `true`)",
+			Required:            true,
+			PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+		},
+	}
+}
+
+func (o *ManagedDevice) LoadApiData(_ context.Context, in *apstra.SystemAgent, _ *diag.Diagnostics) {
+	o.SystemId = types.StringValue(string(in.Status.SystemId))
+	o.ManagementIp = types.StringValue(in.Config.ManagementIp)
+	o.AgentProfileId = types.StringValue(string(in.Config.Profile))
+	o.OffBox = types.BoolValue(bool(in.Config.AgentTypeOffBox))
+	o.AgentId = types.StringValue(string(in.Id))
+}
+
+func (o *ManagedDevice) ValidateAgentProfile(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
+	agentProfile, err := client.GetAgentProfile(ctx, apstra.ObjectId(o.AgentProfileId.ValueString()))
+	if err != nil {
+		var ace apstra.ApstraClientErr
+		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+			diags.AddAttributeError(
+				path.Root("agent_profile_id"),
+				"agent profile not found",
+				fmt.Sprintf("agent profile %q does not exist", o.AgentProfileId.ValueString()))
+		}
+		diags.AddError("error validating agent profile", err.Error())
+		return
+	}
+
+	// require credentials (we can't automate login otherwise)
+	if !agentProfile.HasCredentials() {
+		diags.AddAttributeError(
+			path.Root("agent_profile_id"),
+			"Agent Profile needs credentials",
+			fmt.Sprintf("selected agent_profile_id %q (%s) must have credentials - please fix via Web UI",
+				agentProfile.Label, agentProfile.Id))
+	}
+
+	// require platform (assignment will fail without platform)
+	if agentProfile.Platform == "" {
+		diags.AddAttributeError(
+			path.Root("agent_profile_id"),
+			"Agent Profile needs platform",
+			fmt.Sprintf("selected agent_profile_id %q (%s) must specify the platform type",
+				agentProfile.Label, agentProfile.Id))
+	}
+}
+
+func (o *ManagedDevice) Acknowledge(ctx context.Context, si *apstra.ManagedSystemInfo, client *apstra.Client, diags *diag.Diagnostics) {
+	// update with new SystemUserConfig
+	err := client.UpdateSystem(ctx, apstra.SystemId(o.SystemId.ValueString()), &apstra.SystemUserConfig{
+		AosHclModel: si.Facts.AosHclModel,
+		AdminState:  apstra.SystemAdminStateNormal,
+	})
+	if err != nil {
+		diags.AddError(
+			"error updating managed device",
+			fmt.Sprintf("unexpected error while updating user config: %s", err.Error()),
+		)
+		return
+	}
+
+}
+
+func (o *ManagedDevice) GetDeviceKey(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
+	// Get SystemInfo from API
+	systemInfo, err := client.GetSystemInfo(ctx, apstra.SystemId(o.SystemId.ValueString()))
+	if err != nil {
+		var ace apstra.ApstraClientErr
+		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		} else {
+			diags.AddError(
+				"error reading managed device system info",
+				fmt.Sprintf("Could not Read %q (%s) - %s", o.SystemId.ValueString(), o.ManagementIp.ValueString(), err),
+			)
+			return
+		}
+	}
+
+	// record device key and location if possible
+	if systemInfo == nil {
+		o.DeviceKey = types.StringNull()
+	} else {
+		o.DeviceKey = types.StringValue(systemInfo.DeviceKey)
+	}
+}

--- a/apstra/system_agents/managed_device.go
+++ b/apstra/system_agents/managed_device.go
@@ -1,0 +1,1 @@
+package system_agents

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ APSTRA_PASS=password
 
 - `blueprint_mutex_disabled` (Boolean) Blueprint mutexes are signals that changes are being made in the staging Blueprint and other automation processes (including other instances of Terraform)  should wait before beginning to make changes of their own. Set this attribute 'true' to skip locking the mutex(es) which signal exclusive Blueprint access for all Blueprint changes made in this project.
 - `blueprint_mutex_message` (String) Blueprint mutexes are signals that changes are being made in the staging Blueprint and other automation processes (including other instances of Terraform)  should wait before beginning to make changes of their own. The mutexes embed a human-readable field to reduce confusion in the event a mutex needs to be cleared manually. This attribute overrides the default message in that field: "locked by terraform at $DATE".
-- `experimental` (Boolean) Sets a flag in the underlying Apstra SDK client object which enables *experimental* features. At this time, the only effect is bypassing version compatibility checks in the SDK. This provider release is tested with Apstra versions 4.1.0, 4.1.1, and 4.1.2
+- `experimental` (Boolean) Sets a flag in the underlying Apstra SDK client object which enables *experimental* features. At this time, the only effect is bypassing version compatibility checks in the SDK. This provider release is tested with Apstra versions 4.1.0, 4.1.1, and 4.1.2.
 - `tls_validation_disabled` (Boolean) Set 'true' to disable TLS certificate validation.
 - `url` (String) URL of the apstra server, e.g. `https://apstra.example.com`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ description: |-
   The Apstra provider allows Terraform to control Juniper Apstra fabrics.
 ---
 
-# APSTRA Provider
+# Apstra Provider
 
 The Apstra provider allows Terraform to control Juniper Apstra fabrics.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module terraform-provider-apstra
 go 1.19
 
 require (
-	github.com/Juniper/apstra-go-sdk v0.0.0-20230407174653-236333bfa984
+	github.com/Juniper/apstra-go-sdk v0.0.0-20230410201948-7215adc4554f
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.2.0
@@ -12,7 +12,7 @@ require (
 )
 
 //                                                                                          HHMMSS
-//replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230407163453-95a45cfa135f
+//replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230410195130-d9da8aae87f4
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230407174653-236333bfa984 h1:q/giRDXXR8Qk8aTLseMZL+EOu2AbgSRZDXBKxBkrW3M=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230407174653-236333bfa984/go.mod h1:EZtDsV2etSqm1OY3MbVGTCRXlRHnFQb2Lgz67tsdf60=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230410201948-7215adc4554f h1:uELZEvXTO9Wm/1LSHlvDKDkmzYtfojz9dQKE4Zt1GGE=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230410201948-7215adc4554f/go.mod h1:EZtDsV2etSqm1OY3MbVGTCRXlRHnFQb2Lgz67tsdf60=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -4,7 +4,7 @@ description: |-
   The Apstra provider allows Terraform to control Juniper Apstra fabrics.
 ---
 
-# {{ .ProviderShortName | upper }} Provider
+# {{ .ProviderShortName | title }} Provider
 
 The Apstra provider allows Terraform to control Juniper Apstra fabrics.
 

--- a/test/provider.tf
+++ b/test/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     apstra = {
-      source = "registry.terraform.io/Juniper/apstra"
+      source = "Juniper/apstra"
     }
   }
 }


### PR DESCRIPTION
This PR moves the `ManagedDevice{}` into new package `systemAgents` to be consistent with design, blueprint and resource packaging.

It will close [#69 from the old repo](https://github.com/chrismarget-j/terraform-provider-apstra/issues/69).

Along the way I found some issues with agent job handling and streamlined the logic a bit.

There's also some cosmetic documentation fixes.