### PR TITLE
Rosetta update

### DIFF
--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -13,10 +13,8 @@ const (
 	JunOSInterfaceLevelSet          = "interface_level_set"
 	JunOSInterfaceLevelDelete       = "interface_level_delete"
 
-	AsnAllocationSingle = "single"
 	AsnAllocationUnique = "unique"
 
-	OverlayControlProtocolEvpn   = "evpn"
 	OverlayControlProtocolStatic = "static"
 
 	RefDesignDataCenter = "datacenter"
@@ -79,8 +77,6 @@ func ApiStringerFromFriendlyString(target StringerWithFromString, in ...string) 
 
 func asnAllocationSchemeToFriendlyString(in apstra.AsnAllocationScheme) string {
 	switch in {
-	case apstra.AsnAllocationSchemeSingle:
-		return AsnAllocationSingle
 	case apstra.AsnAllocationSchemeDistinct:
 		return AsnAllocationUnique
 	}
@@ -119,8 +115,6 @@ func configletSectionToFriendlyString(in apstra.ConfigletSection, additionalInfo
 
 func overlayControlProtocolToFriendlyString(in apstra.OverlayControlProtocol) string {
 	switch in {
-	case apstra.OverlayControlProtocolEvpn:
-		return OverlayControlProtocolEvpn
 	case apstra.OverlayControlProtocolNone:
 		return OverlayControlProtocolStatic
 	}
@@ -191,8 +185,6 @@ func overlayControlProtocolFromFriendlyString(target *apstra.OverlayControlProto
 	}
 
 	switch in[0] {
-	case OverlayControlProtocolEvpn:
-		*target = apstra.OverlayControlProtocolEvpn
 	case OverlayControlProtocolStatic:
 		*target = apstra.OverlayControlProtocolNone
 	default:

--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -18,6 +18,8 @@ const (
 
 	OverlayControlProtocolEvpn   = "evpn"
 	OverlayControlProtocolStatic = "static"
+
+	RefDesignDataCenter = "datacenter"
 )
 
 type StringerWithFromString interface {
@@ -42,6 +44,8 @@ func StringersToFriendlyString(in ...fmt.Stringer) string {
 		return configletSectionToFriendlyString(in[0].(apstra.ConfigletSection), in[1:]...)
 	case apstra.OverlayControlProtocol:
 		return overlayControlProtocolToFriendlyString(in[0].(apstra.OverlayControlProtocol))
+	case apstra.RefDesign:
+		return refDesignToFriendlyString(in[0].(apstra.RefDesign))
 	}
 
 	return in[0].String()
@@ -66,6 +70,8 @@ func ApiStringerFromFriendlyString(target StringerWithFromString, in ...string) 
 		return configletSectionFromFriendlyString(target.(*apstra.ConfigletSection), in...)
 	case *apstra.OverlayControlProtocol:
 		return overlayControlProtocolFromFriendlyString(target.(*apstra.OverlayControlProtocol), in...)
+	case *apstra.RefDesign:
+		return refDesignFromFriendlyString(target.(*apstra.RefDesign), in...)
 	}
 
 	return target.FromString(in[0])
@@ -117,6 +123,15 @@ func overlayControlProtocolToFriendlyString(in apstra.OverlayControlProtocol) st
 		return OverlayControlProtocolEvpn
 	case apstra.OverlayControlProtocolNone:
 		return OverlayControlProtocolStatic
+	}
+
+	return in.String()
+}
+
+func refDesignToFriendlyString(in apstra.RefDesign) string {
+	switch in {
+	case apstra.RefDesignDatacenter:
+		return RefDesignDataCenter
 	}
 
 	return in.String()
@@ -180,6 +195,21 @@ func overlayControlProtocolFromFriendlyString(target *apstra.OverlayControlProto
 		*target = apstra.OverlayControlProtocolEvpn
 	case OverlayControlProtocolStatic:
 		*target = apstra.OverlayControlProtocolNone
+	default:
+		return target.FromString(in[0])
+	}
+
+	return nil
+}
+
+func refDesignFromFriendlyString(target *apstra.RefDesign, in ...string) error {
+	if len(in) == 0 {
+		return target.FromString("")
+	}
+
+	switch in[0] {
+	case RefDesignDataCenter:
+		*target = apstra.RefDesignDatacenter
 	default:
 		return target.FromString(in[0])
 	}

--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -7,17 +7,17 @@ import (
 )
 
 const (
-	JunOSTopLevelHierarchical       = "top_level_hierarchical"
-	JunOSTopLevelSetDelete          = "top_level_set_delete"
-	JunOSInterfaceLevelHierarchical = "interface_level_hierarchical"
-	JunOSInterfaceLevelSet          = "interface_level_set"
-	JunOSInterfaceLevelDelete       = "interface_level_delete"
+	junOSTopLevelHierarchical       = "top_level_hierarchical"
+	junOSTopLevelSetDelete          = "top_level_set_delete"
+	junOSInterfaceLevelHierarchical = "interface_level_hierarchical"
+	junOSInterfaceLevelSet          = "interface_level_set"
+	junOSInterfaceLevelDelete       = "interface_level_delete"
 
-	AsnAllocationUnique = "unique"
+	asnAllocationUnique = "unique"
 
-	OverlayControlProtocolStatic = "static"
+	overlayControlProtocolStatic = "static"
 
-	RefDesignDataCenter = "datacenter"
+	refDesignDataCenter = "datacenter"
 )
 
 type StringerWithFromString interface {
@@ -78,7 +78,7 @@ func ApiStringerFromFriendlyString(target StringerWithFromString, in ...string) 
 func asnAllocationSchemeToFriendlyString(in apstra.AsnAllocationScheme) string {
 	switch in {
 	case apstra.AsnAllocationSchemeDistinct:
-		return AsnAllocationUnique
+		return asnAllocationUnique
 	}
 
 	return in.String()
@@ -98,15 +98,15 @@ func configletSectionToFriendlyString(in apstra.ConfigletSection, additionalInfo
 	case apstra.PlatformOSJunos:
 		switch in {
 		case apstra.ConfigletSectionSystem:
-			return JunOSTopLevelHierarchical
+			return junOSTopLevelHierarchical
 		case apstra.ConfigletSectionSetBasedSystem:
-			return JunOSTopLevelSetDelete
+			return junOSTopLevelSetDelete
 		case apstra.ConfigletSectionSetBasedInterface:
-			return JunOSInterfaceLevelSet
+			return junOSInterfaceLevelSet
 		case apstra.ConfigletSectionDeleteBasedInterface:
-			return JunOSInterfaceLevelDelete
+			return junOSInterfaceLevelDelete
 		case apstra.ConfigletSectionInterface:
-			return JunOSInterfaceLevelHierarchical
+			return junOSInterfaceLevelHierarchical
 		}
 	}
 
@@ -116,7 +116,7 @@ func configletSectionToFriendlyString(in apstra.ConfigletSection, additionalInfo
 func overlayControlProtocolToFriendlyString(in apstra.OverlayControlProtocol) string {
 	switch in {
 	case apstra.OverlayControlProtocolNone:
-		return OverlayControlProtocolStatic
+		return overlayControlProtocolStatic
 	}
 
 	return in.String()
@@ -125,7 +125,7 @@ func overlayControlProtocolToFriendlyString(in apstra.OverlayControlProtocol) st
 func refDesignToFriendlyString(in apstra.RefDesign) string {
 	switch in {
 	case apstra.RefDesignDatacenter:
-		return RefDesignDataCenter
+		return refDesignDataCenter
 	}
 
 	return in.String()
@@ -137,7 +137,7 @@ func asnAllocationSchemeFromFriendlyString(target *apstra.AsnAllocationScheme, i
 	}
 
 	switch in[0] {
-	case AsnAllocationUnique:
+	case asnAllocationUnique:
 		*target = apstra.AsnAllocationSchemeDistinct
 	default:
 		return target.FromString(in[0])
@@ -162,15 +162,15 @@ func configletSectionFromFriendlyString(target *apstra.ConfigletSection, in ...s
 	}
 
 	switch section {
-	case JunOSTopLevelHierarchical:
+	case junOSTopLevelHierarchical:
 		*target = apstra.ConfigletSectionSystem
-	case JunOSInterfaceLevelHierarchical:
+	case junOSInterfaceLevelHierarchical:
 		*target = apstra.ConfigletSectionInterface
-	case JunOSTopLevelSetDelete:
+	case junOSTopLevelSetDelete:
 		*target = apstra.ConfigletSectionSetBasedSystem
-	case JunOSInterfaceLevelDelete:
+	case junOSInterfaceLevelDelete:
 		*target = apstra.ConfigletSectionDeleteBasedInterface
-	case JunOSInterfaceLevelSet:
+	case junOSInterfaceLevelSet:
 		*target = apstra.ConfigletSectionSetBasedInterface
 	default:
 		return target.FromString(section)
@@ -185,7 +185,7 @@ func overlayControlProtocolFromFriendlyString(target *apstra.OverlayControlProto
 	}
 
 	switch in[0] {
-	case OverlayControlProtocolStatic:
+	case overlayControlProtocolStatic:
 		*target = apstra.OverlayControlProtocolNone
 	default:
 		return target.FromString(in[0])
@@ -200,7 +200,7 @@ func refDesignFromFriendlyString(target *apstra.RefDesign, in ...string) error {
 	}
 
 	switch in[0] {
-	case RefDesignDataCenter:
+	case refDesignDataCenter:
 		*target = apstra.RefDesignDatacenter
 	default:
 		return target.FromString(in[0])

--- a/apstra/utils/rosetta_test.go
+++ b/apstra/utils/rosetta_test.go
@@ -27,6 +27,9 @@ func TestRosetta(t *testing.T) {
 
 		{string: "static", stringers: []fmt.Stringer{apstra.OverlayControlProtocolNone}},
 		{string: "evpn", stringers: []fmt.Stringer{apstra.OverlayControlProtocolEvpn}},
+
+		{string: "datacenter", stringers: []fmt.Stringer{apstra.RefDesignDatacenter}},
+		{string: "freeform", stringers: []fmt.Stringer{apstra.RefDesignFreeform}},
 	}
 
 	for i, tc := range testCases {
@@ -48,6 +51,13 @@ func TestRosetta(t *testing.T) {
 		case apstra.OverlayControlProtocol:
 			x := apstra.OverlayControlProtocol(-1)
 			target = &x
+		case apstra.RefDesign:
+			x := apstra.RefDesign(-1)
+			target = &x
+		}
+
+		if target == nil {
+			t.Fatalf("missing case above - target is nil")
 		}
 
 		// stringsWithContext is the []string sent to the rosetta function to populate target


### PR DESCRIPTION
This PR is built on #11, which should be merged first. It is intended to close [#68](https://github.com/chrismarget-j/terraform-provider-apstra/issues/68) from the old repo.


- Adds `apstra.RefDesign` (iota) support to rosetta and rosetta tests.
- Uses the new rosetta support in `data_source_blueprints.go` to replace a point solution for: 'datacenter' vs. 'two_stage_l3clos'
- Remove rosetta strings which don't get translated.
- Make rosetta string constants private (they're not being used outside of the `utils` package)