### PR TITLE
improve error messages

### DIFF
--- a/apstra/provider.go
+++ b/apstra/provider.go
@@ -3,6 +3,7 @@ package tfapstra
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -14,8 +15,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
+	"strings"
 	"sync"
 	"terraform-provider-apstra/apstra/compatibility"
+	"terraform-provider-apstra/apstra/utils"
 	"time"
 )
 
@@ -27,6 +31,20 @@ const (
 	envApstraUrl      = "APSTRA_URL"
 
 	blueprintMutexMessage = "locked by terraform at $DATE"
+
+	osxCertErrStringMatch = "certificate is not trusted"
+	winCertErrStringMatch = "todo - fill this in" // todo
+	linCertErrStringMatch = "x509: cannot validate certificate for"
+
+	disableTlsValidationMsg = `!!! BAD IDEA WARNING !!!
+
+If you expected TLS validation to fail because the Apstra server is not
+configured with a trusted certificate, you might consider setting...
+
+	tls_validation_disabled = true
+
+...in the provider configuration block.
+https://registry.terraform.io/providers/Juniper/apstra/%s/docs#tls_validation_disabled`
 )
 
 var _ provider.Provider = &Provider{}
@@ -148,6 +166,23 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	// Parse the URL.
 	parsedUrl, err := url.Parse(apstraUrl)
 	if err != nil {
+		urlEncodeMsg := fmt.Sprintf(
+			"Note that when the Username or Password fields contain special characters and are embedded\n"+
+				"in the URL, they must be URL-encoded by substituting '%%XX' in place of the special character.\n"+
+				"The following table demonstrates some common substitutions:\n\n%s", utils.UrlEscapeTable())
+
+		if urlErr, ok := err.(*url.Error); ok && strings.Contains(urlErr.Error(), "invalid userinfo") {
+			// don't print the actual error here because it likely contains a password
+			resp.Diagnostics.AddError("Error parsing userinfo from URL", urlEncodeMsg)
+			return
+		}
+
+		var urlEE url.EscapeError
+		if errors.As(err, &urlEE) {
+			resp.Diagnostics.AddError("Error parsing URL", urlEncodeMsg)
+			return
+		}
+
 		resp.Diagnostics.AddError(fmt.Sprintf("error parsing URL '%s'", config.Url.ValueString()), err.Error())
 		return
 	}
@@ -158,7 +193,11 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		if val, ok := os.LookupEnv(envApstraUsername); ok {
 			user = val
 		} else {
-			resp.Diagnostics.AddError(errProviderInvalidConfig, "unable to determine apstra username")
+			resp.Diagnostics.AddError("unable to determine apstra username", fmt.Sprintf(
+				"Note that when the Username or Password fields contain special characters and are embedded\n"+
+					"in the URL, they must be URL-encoded by substituting '%%XX' in place of the special character.\n"+
+					"The following table might help:\n\n%s", utils.UrlEscapeTable(),
+			))
 			return
 		}
 	}
@@ -216,10 +255,26 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	// Create the Apstra client.
 	client, err := clientCfg.NewClient()
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"unable to create client",
-			fmt.Sprintf("error creating apstra client - %s", err),
-		)
+		ver := p.Version
+		if ver == "0.0.0" {
+			ver = "latest"
+		}
+		suggestion := fmt.Sprintf(disableTlsValidationMsg, ver)
+
+		var msg string
+		//goland:noinspection GoBoolExpressions // runtime.GOOS is not handled correctly
+		switch {
+		case runtime.GOOS == "windows" && strings.Contains(err.Error(), winCertErrStringMatch):
+			msg = fmt.Sprintf("error creating apstra client - %s\n\n%s", err.Error(), suggestion)
+		case runtime.GOOS == "darwin" && strings.Contains(err.Error(), osxCertErrStringMatch):
+			msg = fmt.Sprintf("error creating apstra client - %s\n\n%s", err.Error(), suggestion)
+		case runtime.GOOS == "linux" && strings.Contains(err.Error(), linCertErrStringMatch):
+			msg = fmt.Sprintf("error creating apstra client - %s\n\n%s", err.Error(), suggestion)
+		default:
+			msg = fmt.Sprintf("error creating apstra client - %s", err.Error())
+		}
+
+		resp.Diagnostics.AddError("unable to create client", msg)
 		return
 	}
 

--- a/apstra/utils/provider.go
+++ b/apstra/utils/provider.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	mustEscapeUrlChars = "\"#%/<>?[\\]^"
+)
+
+func UrlEscapeTable() string {
+	sb := strings.Builder{}
+	for i, b := range mustEscapeUrlChars {
+		if i%4 == 0 {
+			if i == 0 {
+				sb.WriteString("\t")
+			} else {
+				sb.WriteString("\n\t")
+			}
+		} else {
+			sb.WriteString("\t")
+		}
+		sb.WriteString(fmt.Sprintf("%s => %%%X", string(b), b))
+	}
+
+	return sb.String()
+}


### PR DESCRIPTION
This PR closes #16 and 2/3 closes #17 (still need an example error string from a Windows client).

#16:

When the username or password is embedded in the URL (environment or configuration file) and we seem to have failed parsing the URL as a result, the error message now looks like:
```
│ Note that when the Username or Password fields contain special characters and are
│ embedded in the URL, they must be URL-encoded by substituting '%<hex-value>' in
│ place of each special character. The following table demonstrates some common
│ substitutions:
│ 
│   " => %22        # => %23        % => %25        / => %2F
│   < => %3C        > => %3E        ? => %3F        [ => %5B
│   \ => %5C        ] => %5D        ^ => %5E
``` 

#17:

When we encounter a TLS validation error (detected by platform-specific error string matching) we *gently suggest* skipping validation:
```
│ error creating apstra client - error calling http.client.Do for url 'https://18.188.67.135:26609/api/versions/api?async=full' - Get "https://18.188.67.135:26609/api/versions/api?async=full": x509: “apstra.com”
│ certificate is not trusted
│ 
│ !!! BAD IDEA WARNING !!!
│ 
│ If you expected TLS validation to fail because the Apstra server is not
│ configured with a trusted certificate, you might consider setting...
│ 
│   tls_validation_disabled = true
│ 
│ ...in the provider configuration block.
│ https://registry.terraform.io/providers/Juniper/apstra/0.13.0/docs#tls_validation_disabled
```