### PR TITLE
Resolve crash due to nil pointer dereference

### DIFF
--- a/apstra/resource_blueprint_deployment.go
+++ b/apstra/resource_blueprint_deployment.go
@@ -103,6 +103,9 @@ func (o *resourceBlueprintDeploy) Read(ctx context.Context, req resource.ReadReq
 		resp.State.RemoveResource(ctx)
 		return
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Create a new state object so we don't overwrite the comment template in Read().
 	newState := blueprint.Deploy{BlueprintId: state.BlueprintId}
@@ -137,6 +140,9 @@ func (o *resourceBlueprintDeploy) Update(ctx context.Context, req resource.Updat
 
 	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(plan.BlueprintId.ValueString()), &resp.Diagnostics) {
 		resp.State.RemoveResource(ctx)
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -181,6 +187,9 @@ func (o *resourceBlueprintDeploy) Delete(ctx context.Context, req resource.Delet
 
 	// No need to proceed if the blueprint no longer exists
 	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(state.BlueprintId.ValueString()), &resp.Diagnostics) {
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/apstra/resource_datacenter_blueprint.go
+++ b/apstra/resource_datacenter_blueprint.go
@@ -1,10 +1,10 @@
 package tfapstra
 
 import (
-	"github.com/Juniper/apstra-go-sdk/apstra"
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -183,6 +183,9 @@ func (o *resourceDatacenterBlueprint) Update(ctx context.Context, req resource.U
 	// Ensure the blueprint still exists.
 	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(plan.Id.ValueString()), &resp.Diagnostics) {
 		resp.State.RemoveResource(ctx)
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/apstra/resource_datacenter_device_allocation.go
+++ b/apstra/resource_datacenter_device_allocation.go
@@ -1,9 +1,9 @@
 package tfapstra
 
 import (
-	"github.com/Juniper/apstra-go-sdk/apstra"
 	"context"
 	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -53,6 +53,9 @@ func (o *resourceDeviceAllocation) Create(ctx context.Context, req resource.Crea
 	// Ensure the blueprint exists.
 	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(plan.BlueprintId.ValueString()), &resp.Diagnostics) {
 		resp.Diagnostics.AddError("blueprint not found", fmt.Sprintf("blueprint %q not found", plan.BlueprintId.ValueString()))
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -111,6 +114,9 @@ func (o *resourceDeviceAllocation) Read(ctx context.Context, req resource.ReadRe
 		resp.State.RemoveResource(ctx)
 		return
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	state.ReadSystemNode(ctx, o.client, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -161,6 +167,9 @@ func (o *resourceDeviceAllocation) Delete(ctx context.Context, req resource.Dele
 
 	// No need to proceed if the blueprint no longer exists
 	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(state.BlueprintId.ValueString()), &resp.Diagnostics) {
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 


### PR DESCRIPTION
This PR fixes #24.

While scanning through that file for other error checking omissions, I found several calls to `BlueprintExists()` with the same problem.

In fact, that pattern was repeated in several files.

Now resolved.