### PR TITLE
Eliminate empty resource group name

### DIFF
--- a/apstra/resource_blueprint_deployment.go
+++ b/apstra/resource_blueprint_deployment.go
@@ -103,6 +103,9 @@ func (o *resourceBlueprintDeploy) Read(ctx context.Context, req resource.ReadReq
 		resp.State.RemoveResource(ctx)
 		return
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Create a new state object so we don't overwrite the comment template in Read().
 	newState := blueprint.Deploy{BlueprintId: state.BlueprintId}
@@ -137,6 +140,9 @@ func (o *resourceBlueprintDeploy) Update(ctx context.Context, req resource.Updat
 
 	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(plan.BlueprintId.ValueString()), &resp.Diagnostics) {
 		resp.State.RemoveResource(ctx)
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -181,6 +187,9 @@ func (o *resourceBlueprintDeploy) Delete(ctx context.Context, req resource.Delet
 
 	// No need to proceed if the blueprint no longer exists
 	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(state.BlueprintId.ValueString()), &resp.Diagnostics) {
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/apstra/resource_datacenter_blueprint.go
+++ b/apstra/resource_datacenter_blueprint.go
@@ -1,10 +1,10 @@
 package tfapstra
 
 import (
-	"github.com/Juniper/apstra-go-sdk/apstra"
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -183,6 +183,9 @@ func (o *resourceDatacenterBlueprint) Update(ctx context.Context, req resource.U
 	// Ensure the blueprint still exists.
 	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(plan.Id.ValueString()), &resp.Diagnostics) {
 		resp.State.RemoveResource(ctx)
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/apstra/resource_datacenter_device_allocation.go
+++ b/apstra/resource_datacenter_device_allocation.go
@@ -1,9 +1,9 @@
 package tfapstra
 
 import (
-	"github.com/Juniper/apstra-go-sdk/apstra"
 	"context"
 	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -53,6 +53,9 @@ func (o *resourceDeviceAllocation) Create(ctx context.Context, req resource.Crea
 	// Ensure the blueprint exists.
 	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(plan.BlueprintId.ValueString()), &resp.Diagnostics) {
 		resp.Diagnostics.AddError("blueprint not found", fmt.Sprintf("blueprint %q not found", plan.BlueprintId.ValueString()))
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -111,6 +114,9 @@ func (o *resourceDeviceAllocation) Read(ctx context.Context, req resource.ReadRe
 		resp.State.RemoveResource(ctx)
 		return
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	state.ReadSystemNode(ctx, o.client, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -161,6 +167,9 @@ func (o *resourceDeviceAllocation) Delete(ctx context.Context, req resource.Dele
 
 	// No need to proceed if the blueprint no longer exists
 	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(state.BlueprintId.ValueString()), &resp.Diagnostics) {
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/apstra/utils/resource_group.go
+++ b/apstra/utils/resource_group.go
@@ -4,9 +4,12 @@ import "github.com/Juniper/apstra-go-sdk/apstra"
 
 func AllResourceGroupNameStrings() []string {
 	argn := apstra.AllResourceGroupNames()
-	result := make([]string, len(argn))
-	for i := range argn {
-		result[i] = argn[i].String()
+	var result []string
+	for _, rgn := range argn {
+		if rgn == apstra.ResourceGroupNameNone {
+			continue
+		}
+		result = append(result, rgn.String())
 	}
 	return result
 }

--- a/apstra/utils/resource_group_test.go
+++ b/apstra/utils/resource_group_test.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"log"
+	"testing"
+)
+
+func TestAllResourceGroupNameStrings(t *testing.T) {
+	argns := AllResourceGroupNameStrings()
+	for i := range argns {
+		if argns[i] == "" {
+			t.Fatal("AllResourceGroupNameStrings() returned an empty string")
+		}
+	}
+	log.Println(argns)
+}


### PR DESCRIPTION
This PR resolves #19 by eliminating the empty string from the list of resource group names used by the terraform string validator.

With test.