### PR TITLE
eliminate empty string from resource group name list

### DIFF
--- a/apstra/utils/resource_group.go
+++ b/apstra/utils/resource_group.go
@@ -4,9 +4,12 @@ import "github.com/Juniper/apstra-go-sdk/apstra"
 
 func AllResourceGroupNameStrings() []string {
 	argn := apstra.AllResourceGroupNames()
-	result := make([]string, len(argn))
-	for i := range argn {
-		result[i] = argn[i].String()
+	var result []string
+	for _, rgn := range argn {
+		if rgn == apstra.ResourceGroupNameNone {
+			continue
+		}
+		result = append(result, rgn.String())
 	}
 	return result
 }

--- a/apstra/utils/resource_group_test.go
+++ b/apstra/utils/resource_group_test.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"log"
+	"testing"
+)
+
+func TestAllResourceGroupNameStrings(t *testing.T) {
+	argns := AllResourceGroupNameStrings()
+	for i := range argns {
+		if argns[i] == "" {
+			t.Fatal("AllResourceGroupNameStrings() returned an empty string")
+		}
+	}
+	log.Println(argns)
+}


### PR DESCRIPTION
This PR resolves https://github.com/Juniper/terraform-provider-apstra/issues/19 by eliminating the empty string from the list of resource group names used by the terraform string validator.

With test.