### PR TITLE
replace sliceWithout<type>() with sliceWithoutElement()

### DIFF
--- a/apstra/helpers.go
+++ b/apstra/helpers.go
@@ -20,13 +20,13 @@ func newKeyLogWriter(fileName string) (*os.File, error) {
 	return os.OpenFile(absPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 }
 
-// sliceWithoutString returns a copy of in with all occurrences of t removed.
+// sliceWithoutElement returns a copy of in with all occurrences of e removed.
 // the returned int indicates the number of occurrences removed.
-func sliceWithoutString(in []string, t string) ([]string, int) {
-	result := make([]string, len(in))
+func sliceWithoutElement[A comparable](in []A, e A) ([]A, int) {
+	result := make([]A, len(in))
 	var resultIdx int
 	for inIdx := range in {
-		if in[inIdx] == t {
+		if in[inIdx] == e {
 			continue
 		}
 		result[resultIdx] = in[inIdx]
@@ -34,46 +34,3 @@ func sliceWithoutString(in []string, t string) ([]string, int) {
 	}
 	return result[:resultIdx], len(in) - resultIdx
 }
-
-// sliceWithoutInt returns a copy of in with all instances of t removed.
-// the returned int indicates the number of instances removed.
-func sliceWithoutInt(in []int, t int) ([]int, int) {
-	result := make([]int, len(in))
-	var resultIdx int
-	for inIdx := range in {
-		if in[inIdx] == t {
-			continue
-		}
-		result[resultIdx] = in[inIdx]
-		resultIdx++
-	}
-	return result[:resultIdx], len(in) - resultIdx
-}
-
-//// getAllSystemsInfo returns map[string]apstra.ManagedSystemInfo keyed by
-//// device_key (switch serial number)
-//func getAllSystemsInfo(ctx context.Context, client *apstra.client, diags *diag.Diagnostics) map[string]apstra.ManagedSystemInfo {
-//	// pull SystemInfo for all switches managed by apstra
-//	asi, err := client.GetAllSystemsInfo(ctx) // pull all managed systems info from Apstra
-//	if err != nil {
-//		diags.AddError(errApiData, fmt.Sprintf("GetAllSystemsInfo error - %s", err.Error()))
-//		return nil
-//	}
-//
-//	// organize the []ManagedSystemInfo into a map by device key (serial number)
-//	deviceKeyToSystemInfo := make(map[string]apstra.ManagedSystemInfo, len(asi))
-//	for i := range asi {
-//		deviceKeyToSystemInfo[asi[i].DeviceKey] = asi[i]
-//	}
-//	return deviceKeyToSystemInfo
-//}
-//
-//func sliceAttrValueToSliceObjectId(in []attr.Value) []apstra.ObjectId {
-//	result := make([]apstra.ObjectId, len(in))
-//	stringSlice := sliceAttrValueToSliceString(in)
-//	for i, s := range stringSlice {
-//		result[i] = apstra.ObjectId(s)
-//	}
-//	return result
-//}
-//

--- a/apstra/resource_interface_map.go
+++ b/apstra/resource_interface_map.go
@@ -1,11 +1,11 @@
 package tfapstra
 
 import (
-	"github.com/Juniper/apstra-go-sdk/apstra"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -369,7 +369,7 @@ func (o *rInterfaceMap) validatePortSelections(ctx context.Context, ld *apstra.L
 	var bogusPortNames []string
 	var n int
 	for i = range plannedPortNames {
-		requiredPortNames, n = sliceWithoutString(requiredPortNames, plannedPortNames[i])
+		requiredPortNames, n = sliceWithoutElement(requiredPortNames, plannedPortNames[i])
 		if n == 0 {
 			bogusPortNames = append(bogusPortNames, plannedPortNames[i])
 		}
@@ -515,7 +515,7 @@ func (o *rInterfaceMap) iMapInterfaces(ctx context.Context, ld *apstra.LogicalDe
 		if transformInterfacesUnused, found := portIdToUnusedInterfaces[portId]; found {
 			// we've already been tracking this port+transform interfaces
 			// remove this interface ID from the per-transform list of unused interfaces
-			unused, _ := sliceWithoutInt(transformInterfacesUnused.interfaces, transformInterface.InterfaceId)
+			unused, _ := sliceWithoutElement(transformInterfacesUnused.interfaces, transformInterface.InterfaceId)
 			portIdToUnusedInterfaces[portId] = unusedInterfaces{
 				transformId: transformId,
 				interfaces:  unused,
@@ -524,7 +524,7 @@ func (o *rInterfaceMap) iMapInterfaces(ctx context.Context, ld *apstra.LogicalDe
 		} else {
 			// New port+transform.
 			// Add it to the tracking map with this interface ID removed from the list
-			unused, _ := sliceWithoutInt(transformation.InterfaceIds(), transformInterface.InterfaceId)
+			unused, _ := sliceWithoutElement(transformation.InterfaceIds(), transformInterface.InterfaceId)
 			portIdToUnusedInterfaces[portId] = unusedInterfaces{
 				transformId: transformId,
 				interfaces:  unused,


### PR DESCRIPTION
This PR closes #36

```
func sliceWithoutString(in []string, t string) ([]string, int)
```
and
```
func sliceWithoutInt(in []int, t int) ([]int, int)
```
are replaced by:
```
func sliceWithoutElement[A comparable](in []A, e A) ([]A, int)
```