### PR TITLE
Introduce resource + data source tests

### DIFF
--- a/apstra/data_source_ipv4_pool_test.go
+++ b/apstra/data_source_ipv4_pool_test.go
@@ -1,0 +1,98 @@
+package tfapstra
+
+import (
+	"context"
+	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const (
+	dataSourceIpv4PoolTemplateByNameHCL = `
+data "apstra_ipv4_pool" "test" {
+  name = "%s"
+}
+`
+
+	dataSourceIpv4PoolTemplateByIdHCL = `
+data "apstra_ipv4_pool" "test" {
+  id = "%s"
+}
+`
+)
+
+func TestAccDataSourceIpv4Pool_basic(t *testing.T) {
+	testAccResourceIpv4PoolCfg1Name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	clientCfg, err := NewClientConfig("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientCfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
+	client, err := clientCfg.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := client.CreateIp4Pool(context.Background(), &apstra.NewIpPoolRequest{
+		DisplayName: testAccResourceIpv4PoolCfg1Name,
+		Subnets:     []apstra.NewIpSubnet{{Network: "192.168.0.0/16"}},
+	})
+
+	defer func() {
+		err := client.DeleteIp4Pool(context.Background(), id)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	resource.Test(t, resource.TestCase{
+		//PreCheck:                 setup,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read by ID testing
+			{
+				Config: insecureProviderConfigHCL + fmt.Sprintf(dataSourceIpv4PoolTemplateByIdHCL, string(id)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify data source/resource fields match
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "id", string(id)),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "name", testAccResourceIpv4PoolCfg1Name),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "status", "not_in_use"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "total", "65536"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "used", "0"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "used_percentage", "0"),
+
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "subnets.#", "1"),
+
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "subnets.0.status", "pool_element_available"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "subnets.0.total", "65536"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "subnets.0.used", "0"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "subnets.0.used_percentage", "0"),
+				),
+			},
+			// Read by Name testing
+			{
+				Config: insecureProviderConfigHCL + fmt.Sprintf(dataSourceIpv4PoolTemplateByNameHCL, testAccResourceIpv4PoolCfg1Name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify data source/resource fields match
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "id", string(id)),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "name", testAccResourceIpv4PoolCfg1Name),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "status", "not_in_use"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "total", "65536"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "used", "0"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "used_percentage", "0"),
+
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "subnets.#", "1"),
+
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "subnets.0.status", "pool_element_available"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "subnets.0.total", "65536"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "subnets.0.used", "0"),
+					resource.TestCheckResourceAttr("data.apstra_ipv4_pool.test", "subnets.0.used_percentage", "0"),
+				),
+			},
+		},
+	})
+}

--- a/apstra/helpers.go
+++ b/apstra/helpers.go
@@ -1,25 +1,5 @@
 package tfapstra
 
-import (
-	"fmt"
-	"github.com/mitchellh/go-homedir"
-	"os"
-	"path/filepath"
-)
-
-func newKeyLogWriter(fileName string) (*os.File, error) {
-	absPath, err := homedir.Expand(fileName)
-	if err != nil {
-		return nil, fmt.Errorf("error expanding home directory '%s' - %w", fileName, err)
-	}
-
-	err = os.MkdirAll(filepath.Dir(absPath), os.FileMode(0600))
-	if err != nil {
-		return nil, err
-	}
-	return os.OpenFile(absPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-}
-
 // sliceWithoutElement returns a copy of in with all occurrences of e removed.
 // the returned int indicates the number of occurrences removed.
 func sliceWithoutElement[A comparable](in []A, e A) ([]A, int) {

--- a/apstra/provider_test.go
+++ b/apstra/provider_test.go
@@ -1,0 +1,27 @@
+package tfapstra
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+const (
+	providerConfigHCL = `
+provider "apstra" {
+  blueprint_mutex_disabled = true
+}
+`
+
+	insecureProviderConfigHCL = `
+provider "apstra" {
+  tls_validation_disabled = true
+  blueprint_mutex_disabled = true
+}
+`
+)
+
+var (
+	testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+		"apstra": providerserver.NewProtocol6WithError(NewProvider()),
+	}
+)

--- a/apstra/resource_asn_pool_test.go
+++ b/apstra/resource_asn_pool_test.go
@@ -10,41 +10,44 @@ import (
 )
 
 const (
-	resourceAsnPoolBasicCfg = `
-// provider config
-%s
-
+	resourceAsnPoolTemplateHCL = `
 // resource config
 resource "apstra_asn_pool" "test" {
   name = "%s"
   ranges = [%s]
 }
 `
-	resourceAsnPoolRange = "{first = %d, last = %d}"
+	resourceAsnPoolRangeTemplateHCL = "{first = %d, last = %d}"
+)
+
+var (
+	testAccResourceAsnPoolCfg1Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	testAccResourceAsnPoolCfg1Ranges = strings.Join([]string{
+		fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 10, 20),
+	}, ",")
+	testAccResourceAsnPoolCfg1 = fmt.Sprintf(resourceAsnPoolTemplateHCL, testAccResourceAsnPoolCfg1Name, testAccResourceAsnPoolCfg1Ranges)
+
+	testAccResourceAsnPoolCfg2Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	testAccResourceAsnPoolCfg2Ranges = strings.Join([]string{
+		fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 1, 3),
+		fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 5, 11),
+		fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 15, 25),
+	}, ",")
+	testAccResourceAsnPoolCfg2 = fmt.Sprintf(resourceAsnPoolTemplateHCL, testAccResourceAsnPoolCfg2Name, testAccResourceAsnPoolCfg2Ranges)
 )
 
 func TestAccResourceAsnPool_basic(t *testing.T) {
-	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	ranges1 := fmt.Sprintf(resourceAsnPoolRange, 10, 20)
-
-	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	ranges2 := strings.Join([]string{
-		fmt.Sprintf(resourceAsnPoolRange, 1, 3),
-		fmt.Sprintf(resourceAsnPoolRange, 5, 11),
-		fmt.Sprintf(resourceAsnPoolRange, 15, 25),
-	}, ",")
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: fmt.Sprintf(resourceAsnPoolBasicCfg, insecureProviderConfigHCL, name1, ranges1),
+				Config: insecureProviderConfigHCL + testAccResourceAsnPoolCfg1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_asn_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_asn_pool.test", "name", name1),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "name", testAccResourceAsnPoolCfg1Name),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "total", "11"),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "used", "0"),
@@ -62,12 +65,12 @@ func TestAccResourceAsnPool_basic(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: fmt.Sprintf(resourceAsnPoolBasicCfg, insecureProviderConfigHCL, name2, ranges2),
+				Config: insecureProviderConfigHCL + testAccResourceAsnPoolCfg2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_asn_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_asn_pool.test", "name", name2),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "name", testAccResourceAsnPoolCfg2Name),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "total", "21"),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "used", "0"),

--- a/apstra/resource_asn_pool_test.go
+++ b/apstra/resource_asn_pool_test.go
@@ -20,23 +20,23 @@ resource "apstra_asn_pool" "test" {
 	resourceAsnPoolRangeTemplateHCL = "{first = %d, last = %d}"
 )
 
-var (
-	testAccResourceAsnPoolCfg1Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	testAccResourceAsnPoolCfg1Ranges = strings.Join([]string{
-		fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 10, 20),
-	}, ",")
-	testAccResourceAsnPoolCfg1 = fmt.Sprintf(resourceAsnPoolTemplateHCL, testAccResourceAsnPoolCfg1Name, testAccResourceAsnPoolCfg1Ranges)
-
-	testAccResourceAsnPoolCfg2Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	testAccResourceAsnPoolCfg2Ranges = strings.Join([]string{
-		fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 1, 3),
-		fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 5, 11),
-		fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 15, 25),
-	}, ",")
-	testAccResourceAsnPoolCfg2 = fmt.Sprintf(resourceAsnPoolTemplateHCL, testAccResourceAsnPoolCfg2Name, testAccResourceAsnPoolCfg2Ranges)
-)
-
 func TestAccResourceAsnPool_basic(t *testing.T) {
+	var (
+		testAccResourceAsnPoolCfg1Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		testAccResourceAsnPoolCfg1Ranges = strings.Join([]string{
+			fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 10, 20),
+		}, ",")
+		testAccResourceAsnPoolCfg1 = fmt.Sprintf(resourceAsnPoolTemplateHCL, testAccResourceAsnPoolCfg1Name, testAccResourceAsnPoolCfg1Ranges)
+
+		testAccResourceAsnPoolCfg2Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		testAccResourceAsnPoolCfg2Ranges = strings.Join([]string{
+			fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 1, 3),
+			fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 5, 11),
+			fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 15, 25),
+		}, ",")
+		testAccResourceAsnPoolCfg2 = fmt.Sprintf(resourceAsnPoolTemplateHCL, testAccResourceAsnPoolCfg2Name, testAccResourceAsnPoolCfg2Ranges)
+	)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/apstra/resource_asn_pool_test.go
+++ b/apstra/resource_asn_pool_test.go
@@ -10,44 +10,41 @@ import (
 )
 
 const (
-	resourceAsnPoolTemplateHCL = `
+	resourceAsnPoolBasicCfg = `
+// provider config
+%s
+
 // resource config
 resource "apstra_asn_pool" "test" {
   name = "%s"
   ranges = [%s]
 }
 `
-	resourceAsnPoolRangeTemplateHCL = "{first = %d, last = %d}"
+	resourceAsnPoolRange = "{first = %d, last = %d}"
 )
 
 func TestAccResourceAsnPool_basic(t *testing.T) {
-	var (
-		testAccResourceAsnPoolCfg1Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-		testAccResourceAsnPoolCfg1Ranges = strings.Join([]string{
-			fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 10, 20),
-		}, ",")
-		testAccResourceAsnPoolCfg1 = fmt.Sprintf(resourceAsnPoolTemplateHCL, testAccResourceAsnPoolCfg1Name, testAccResourceAsnPoolCfg1Ranges)
+	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	ranges1 := fmt.Sprintf(resourceAsnPoolRange, 10, 20)
 
-		testAccResourceAsnPoolCfg2Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-		testAccResourceAsnPoolCfg2Ranges = strings.Join([]string{
-			fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 1, 3),
-			fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 5, 11),
-			fmt.Sprintf(resourceAsnPoolRangeTemplateHCL, 15, 25),
-		}, ",")
-		testAccResourceAsnPoolCfg2 = fmt.Sprintf(resourceAsnPoolTemplateHCL, testAccResourceAsnPoolCfg2Name, testAccResourceAsnPoolCfg2Ranges)
-	)
+	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	ranges2 := strings.Join([]string{
+		fmt.Sprintf(resourceAsnPoolRange, 1, 3),
+		fmt.Sprintf(resourceAsnPoolRange, 5, 11),
+		fmt.Sprintf(resourceAsnPoolRange, 15, 25),
+	}, ",")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: insecureProviderConfigHCL + testAccResourceAsnPoolCfg1,
+				Config: fmt.Sprintf(resourceAsnPoolBasicCfg, insecureProviderConfigHCL, name1, ranges1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_asn_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_asn_pool.test", "name", testAccResourceAsnPoolCfg1Name),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "name", name1),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "total", "11"),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "used", "0"),
@@ -65,12 +62,12 @@ func TestAccResourceAsnPool_basic(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: insecureProviderConfigHCL + testAccResourceAsnPoolCfg2,
+				Config: fmt.Sprintf(resourceAsnPoolBasicCfg, insecureProviderConfigHCL, name2, ranges2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_asn_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_asn_pool.test", "name", testAccResourceAsnPoolCfg2Name),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "name", name2),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "total", "21"),
 					resource.TestCheckResourceAttr("apstra_asn_pool.test", "used", "0"),

--- a/apstra/resource_asn_pool_test.go
+++ b/apstra/resource_asn_pool_test.go
@@ -1,0 +1,88 @@
+package tfapstra
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const (
+	resourceAsnPoolBasicCfg = `
+// provider config
+%s
+
+// resource config
+resource "apstra_asn_pool" "test" {
+  name = "%s"
+  ranges = [%s]
+}
+`
+	resourceAsnPoolRange = "{first = %d, last = %d}"
+)
+
+func TestAccResourceAsnPool_basic(t *testing.T) {
+	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	ranges1 := fmt.Sprintf(resourceAsnPoolRange, 10, 20)
+
+	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	ranges2 := strings.Join([]string{
+		fmt.Sprintf(resourceAsnPoolRange, 1, 3),
+		fmt.Sprintf(resourceAsnPoolRange, 5, 11),
+		fmt.Sprintf(resourceAsnPoolRange, 15, 25),
+	}, ",")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: fmt.Sprintf(resourceAsnPoolBasicCfg, insecureProviderConfigHCL, name1, ranges1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify ID has any value set
+					resource.TestCheckResourceAttrSet("apstra_asn_pool.test", "id"),
+					// Verify name and overall usage statistics
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "name", name1),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "status", "not_in_use"),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "total", "11"),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "used", "0"),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "used_percentage", "0"),
+					// Verify number of ranges
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.#", "1"),
+					// Verify first range
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.first", "10"),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.last", "20"),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.status", "pool_element_available"),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.total", "11"),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.used", "0"),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.used_percentage", "0"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: fmt.Sprintf(resourceAsnPoolBasicCfg, insecureProviderConfigHCL, name2, ranges2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify ID has any value set
+					resource.TestCheckResourceAttrSet("apstra_asn_pool.test", "id"),
+					// Verify name and overall usage statistics
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "name", name2),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "status", "not_in_use"),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "total", "21"),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "used", "0"),
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "used_percentage", "0"),
+					// Verify number of ranges
+					resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.#", "3"),
+					//// cannot verify ranges here because they're not sorted
+					//resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.first", "1"),
+					//resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.last", "3"),
+					//resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.status", "pool_element_available"),
+					//resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.total", "3"),
+					//resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.used", "0"),
+					//resource.TestCheckResourceAttr("apstra_asn_pool.test", "ranges.0.used_percentage", "0"),
+				),
+			},
+		},
+	})
+}

--- a/apstra/resource_ipv4_pool_test.go
+++ b/apstra/resource_ipv4_pool_test.go
@@ -1,0 +1,84 @@
+package tfapstra
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const (
+	resourceIpv4PoolBasicCfg = `
+// provider config
+%s
+
+// resource config
+resource "apstra_ipv4_pool" "test" {
+  name = "%s"
+  subnets = [%s]
+}
+`
+	resourceIpv4PoolSubnet = "{network = %q}"
+)
+
+func TestAccResourceIpv4Pool_basic(t *testing.T) {
+	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	subnets1 := fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.0.0/16")
+
+	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	subnets2 := strings.Join([]string{
+		fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.1.0/24"),
+		fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.0.0/24"),
+		fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.2.0/23"),
+	}, ",")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: fmt.Sprintf(resourceIpv4PoolBasicCfg, insecureProviderConfigHCL, name1, subnets1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify ID has any value set
+					resource.TestCheckResourceAttrSet("apstra_ipv4_pool.test", "id"),
+					// Verify name and overall usage statistics
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "name", name1),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "status", "not_in_use"),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "total", "65536"),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "used", "0"),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "used_percentage", "0"),
+					// Verify number of subnets
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "subnets.#", "1"),
+					// Verify first subnet
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "subnets.0.network", "192.168.0.0/16"),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "subnets.0.status", "pool_element_available"),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "subnets.0.total", "65536"),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "subnets.0.used", "0"),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "subnets.0.used_percentage", "0"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: fmt.Sprintf(resourceIpv4PoolBasicCfg, insecureProviderConfigHCL, name2, subnets2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify ID has any value set
+					resource.TestCheckResourceAttrSet("apstra_ipv4_pool.test", "id"),
+					// Verify name and overall usage statistics
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "name", name2),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "status", "not_in_use"),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "total", "1024"),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "used", "0"),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "used_percentage", "0"),
+					// Verify number of subnets
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "subnets.#", "3"),
+					//// cannot verify subnets here because they're not sorted
+					//resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "subnets.0.network", "192.168.0.0/24"),
+					//resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "subnets.1.network", "192.168.1.0/24"),
+					//resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "subnets.2.network", "192.168.2.0/23"),
+				),
+			},
+		},
+	})
+}

--- a/apstra/resource_ipv4_pool_test.go
+++ b/apstra/resource_ipv4_pool_test.go
@@ -10,41 +10,44 @@ import (
 )
 
 const (
-	resourceIpv4PoolBasicCfg = `
-// provider config
-%s
-
+	resourceIpv4PoolTemplateHCL = `
 // resource config
 resource "apstra_ipv4_pool" "test" {
   name = "%s"
   subnets = [%s]
 }
 `
-	resourceIpv4PoolSubnet = "{network = %q}"
+	resourceIpv4PoolSubnetTemplateHCL = "{network = %q}"
+)
+
+var (
+	testAccResourceIpv4PoolCfg1Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	testAccResourceIpv4PoolCfg1Subnets = strings.Join([]string{
+		fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.0.0/16"),
+	}, ",")
+	testAccResourceIpv4PoolCfg1 = fmt.Sprintf(resourceIpv4PoolTemplateHCL, testAccResourceIpv4PoolCfg1Name, testAccResourceIpv4PoolCfg1Subnets)
+
+	testAccResourceIpv4PoolCfg2Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	testAccResourceIpv4PoolCfg2Subnets = strings.Join([]string{
+		fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.1.0/24"),
+		fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.0.0/24"),
+		fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.2.0/23"),
+	}, ",")
+	testAccResourceIpv4PoolCfg2 = fmt.Sprintf(resourceIpv4PoolTemplateHCL, testAccResourceIpv4PoolCfg2Name, testAccResourceIpv4PoolCfg2Subnets)
 )
 
 func TestAccResourceIpv4Pool_basic(t *testing.T) {
-	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	subnets1 := fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.0.0/16")
-
-	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	subnets2 := strings.Join([]string{
-		fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.1.0/24"),
-		fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.0.0/24"),
-		fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.2.0/23"),
-	}, ",")
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: fmt.Sprintf(resourceIpv4PoolBasicCfg, insecureProviderConfigHCL, name1, subnets1),
+				Config: insecureProviderConfigHCL + testAccResourceIpv4PoolCfg1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_ipv4_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "name", name1),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "name", testAccResourceIpv4PoolCfg1Name),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "total", "65536"),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "used", "0"),
@@ -61,12 +64,12 @@ func TestAccResourceIpv4Pool_basic(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: fmt.Sprintf(resourceIpv4PoolBasicCfg, insecureProviderConfigHCL, name2, subnets2),
+				Config: insecureProviderConfigHCL + testAccResourceIpv4PoolCfg2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_ipv4_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "name", name2),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "name", testAccResourceIpv4PoolCfg2Name),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "total", "1024"),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "used", "0"),

--- a/apstra/resource_ipv4_pool_test.go
+++ b/apstra/resource_ipv4_pool_test.go
@@ -10,44 +10,41 @@ import (
 )
 
 const (
-	resourceIpv4PoolTemplateHCL = `
+	resourceIpv4PoolBasicCfg = `
+// provider config
+%s
+
 // resource config
 resource "apstra_ipv4_pool" "test" {
   name = "%s"
   subnets = [%s]
 }
 `
-	resourceIpv4PoolSubnetTemplateHCL = "{network = %q}"
+	resourceIpv4PoolSubnet = "{network = %q}"
 )
 
 func TestAccResourceIpv4Pool_basic(t *testing.T) {
-	var (
-		testAccResourceIpv4PoolCfg1Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-		testAccResourceIpv4PoolCfg1Subnets = strings.Join([]string{
-			fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.0.0/16"),
-		}, ",")
-		testAccResourceIpv4PoolCfg1 = fmt.Sprintf(resourceIpv4PoolTemplateHCL, testAccResourceIpv4PoolCfg1Name, testAccResourceIpv4PoolCfg1Subnets)
+	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	subnets1 := fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.0.0/16")
 
-		testAccResourceIpv4PoolCfg2Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-		testAccResourceIpv4PoolCfg2Subnets = strings.Join([]string{
-			fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.1.0/24"),
-			fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.0.0/24"),
-			fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.2.0/23"),
-		}, ",")
-		testAccResourceIpv4PoolCfg2 = fmt.Sprintf(resourceIpv4PoolTemplateHCL, testAccResourceIpv4PoolCfg2Name, testAccResourceIpv4PoolCfg2Subnets)
-	)
+	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	subnets2 := strings.Join([]string{
+		fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.1.0/24"),
+		fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.0.0/24"),
+		fmt.Sprintf(resourceIpv4PoolSubnet, "192.168.2.0/23"),
+	}, ",")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: insecureProviderConfigHCL + testAccResourceIpv4PoolCfg1,
+				Config: fmt.Sprintf(resourceIpv4PoolBasicCfg, insecureProviderConfigHCL, name1, subnets1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_ipv4_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "name", testAccResourceIpv4PoolCfg1Name),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "name", name1),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "total", "65536"),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "used", "0"),
@@ -64,12 +61,12 @@ func TestAccResourceIpv4Pool_basic(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: insecureProviderConfigHCL + testAccResourceIpv4PoolCfg2,
+				Config: fmt.Sprintf(resourceIpv4PoolBasicCfg, insecureProviderConfigHCL, name2, subnets2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_ipv4_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "name", testAccResourceIpv4PoolCfg2Name),
+					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "name", name2),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "total", "1024"),
 					resource.TestCheckResourceAttr("apstra_ipv4_pool.test", "used", "0"),

--- a/apstra/resource_ipv4_pool_test.go
+++ b/apstra/resource_ipv4_pool_test.go
@@ -20,23 +20,23 @@ resource "apstra_ipv4_pool" "test" {
 	resourceIpv4PoolSubnetTemplateHCL = "{network = %q}"
 )
 
-var (
-	testAccResourceIpv4PoolCfg1Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	testAccResourceIpv4PoolCfg1Subnets = strings.Join([]string{
-		fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.0.0/16"),
-	}, ",")
-	testAccResourceIpv4PoolCfg1 = fmt.Sprintf(resourceIpv4PoolTemplateHCL, testAccResourceIpv4PoolCfg1Name, testAccResourceIpv4PoolCfg1Subnets)
-
-	testAccResourceIpv4PoolCfg2Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	testAccResourceIpv4PoolCfg2Subnets = strings.Join([]string{
-		fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.1.0/24"),
-		fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.0.0/24"),
-		fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.2.0/23"),
-	}, ",")
-	testAccResourceIpv4PoolCfg2 = fmt.Sprintf(resourceIpv4PoolTemplateHCL, testAccResourceIpv4PoolCfg2Name, testAccResourceIpv4PoolCfg2Subnets)
-)
-
 func TestAccResourceIpv4Pool_basic(t *testing.T) {
+	var (
+		testAccResourceIpv4PoolCfg1Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		testAccResourceIpv4PoolCfg1Subnets = strings.Join([]string{
+			fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.0.0/16"),
+		}, ",")
+		testAccResourceIpv4PoolCfg1 = fmt.Sprintf(resourceIpv4PoolTemplateHCL, testAccResourceIpv4PoolCfg1Name, testAccResourceIpv4PoolCfg1Subnets)
+
+		testAccResourceIpv4PoolCfg2Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		testAccResourceIpv4PoolCfg2Subnets = strings.Join([]string{
+			fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.1.0/24"),
+			fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.0.0/24"),
+			fmt.Sprintf(resourceIpv4PoolSubnetTemplateHCL, "192.168.2.0/23"),
+		}, ",")
+		testAccResourceIpv4PoolCfg2 = fmt.Sprintf(resourceIpv4PoolTemplateHCL, testAccResourceIpv4PoolCfg2Name, testAccResourceIpv4PoolCfg2Subnets)
+	)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/apstra/resource_ipv6_pool_test.go
+++ b/apstra/resource_ipv6_pool_test.go
@@ -10,44 +10,41 @@ import (
 )
 
 const (
-	resourceIpv6PoolTemplateHCL = `
+	resourceIpv6PoolBasicCfg = `
+// provider config
+%s
+
 // resource config
 resource "apstra_ipv6_pool" "test" {
   name = "%s"
   subnets = [%s]
 }
 `
-	resourceIpv6PoolSubnetTemplateHCL = "{network = %q}"
+	resourceIpv6PoolSubnet = "{network = %q}"
 )
 
 func TestAccResourceIpv6Pool_basic(t *testing.T) {
-	var (
-		testAccResourceIpv6PoolCfg1Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-		testAccResourceIpv6PoolCfg1Subnets = strings.Join([]string{
-			fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8::/66"),
-		}, ",")
-		testAccResourceIpv6PoolCfg1 = fmt.Sprintf(resourceIpv6PoolTemplateHCL, testAccResourceIpv6PoolCfg1Name, testAccResourceIpv6PoolCfg1Subnets)
+	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	subnets1 := fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8::/66")
 
-		testAccResourceIpv6PoolCfg2Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-		testAccResourceIpv6PoolCfg2Subnets = strings.Join([]string{
-			fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:1::/96"),
-			fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:2::/96"),
-			fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:3::/96"),
-		}, ",")
-		testAccResourceIpv6PoolCfg2 = fmt.Sprintf(resourceIpv6PoolTemplateHCL, testAccResourceIpv6PoolCfg2Name, testAccResourceIpv6PoolCfg2Subnets)
-	)
+	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	subnets2 := strings.Join([]string{
+		fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8:1::/96"),
+		fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8:2::/96"),
+		fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8:3::/96"),
+	}, ",")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: insecureProviderConfigHCL + testAccResourceIpv6PoolCfg1,
+				Config: fmt.Sprintf(resourceIpv6PoolBasicCfg, insecureProviderConfigHCL, name1, subnets1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_ipv6_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "name", testAccResourceIpv6PoolCfg1Name),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "name", name1),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "total", "4611686018427387904"),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "used", "0"),
@@ -64,12 +61,12 @@ func TestAccResourceIpv6Pool_basic(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: insecureProviderConfigHCL + testAccResourceIpv6PoolCfg2,
+				Config: fmt.Sprintf(resourceIpv6PoolBasicCfg, insecureProviderConfigHCL, name2, subnets2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_ipv6_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "name", testAccResourceIpv6PoolCfg2Name),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "name", name2),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "total", "12884901888"),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "used", "0"),

--- a/apstra/resource_ipv6_pool_test.go
+++ b/apstra/resource_ipv6_pool_test.go
@@ -1,0 +1,84 @@
+package tfapstra
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const (
+	resourceIpv6PoolBasicCfg = `
+// provider config
+%s
+
+// resource config
+resource "apstra_ipv6_pool" "test" {
+  name = "%s"
+  subnets = [%s]
+}
+`
+	resourceIpv6PoolSubnet = "{network = %q}"
+)
+
+func TestAccResourceIpv6Pool_basic(t *testing.T) {
+	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	subnets1 := fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8::/66")
+
+	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	subnets2 := strings.Join([]string{
+		fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8:1::/96"),
+		fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8:2::/96"),
+		fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8:3::/96"),
+	}, ",")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: fmt.Sprintf(resourceIpv6PoolBasicCfg, insecureProviderConfigHCL, name1, subnets1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify ID has any value set
+					resource.TestCheckResourceAttrSet("apstra_ipv6_pool.test", "id"),
+					// Verify name and overall usage statistics
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "name", name1),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "status", "not_in_use"),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "total", "4611686018427387904"),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "used", "0"),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "used_percentage", "0"),
+					// Verify number of subnets
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "subnets.#", "1"),
+					// Verify first subnet
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "subnets.0.network", "2001:db8::/66"),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "subnets.0.status", "pool_element_available"),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "subnets.0.total", "4611686018427387904"),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "subnets.0.used", "0"),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "subnets.0.used_percentage", "0"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: fmt.Sprintf(resourceIpv6PoolBasicCfg, insecureProviderConfigHCL, name2, subnets2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify ID has any value set
+					resource.TestCheckResourceAttrSet("apstra_ipv6_pool.test", "id"),
+					// Verify name and overall usage statistics
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "name", name2),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "status", "not_in_use"),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "total", "12884901888"),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "used", "0"),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "used_percentage", "0"),
+					// Verify number of subnets
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "subnets.#", "3"),
+					//// cannot verify subnets here because they're not sorted
+					//resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "subnets.0.network", "2001:db8:1::/96"),
+					//resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "subnets.1.network", "2001:db8:2::/96"),
+					//resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "subnets.2.network", "2001:db8:3::/96"),
+				),
+			},
+		},
+	})
+}

--- a/apstra/resource_ipv6_pool_test.go
+++ b/apstra/resource_ipv6_pool_test.go
@@ -10,41 +10,44 @@ import (
 )
 
 const (
-	resourceIpv6PoolBasicCfg = `
-// provider config
-%s
-
+	resourceIpv6PoolTemplateHCL = `
 // resource config
 resource "apstra_ipv6_pool" "test" {
   name = "%s"
   subnets = [%s]
 }
 `
-	resourceIpv6PoolSubnet = "{network = %q}"
+	resourceIpv6PoolSubnetTemplateHCL = "{network = %q}"
+)
+
+var (
+	testAccResourceIpv6PoolCfg1Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	testAccResourceIpv6PoolCfg1Subnets = strings.Join([]string{
+		fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8::/66"),
+	}, ",")
+	testAccResourceIpv6PoolCfg1 = fmt.Sprintf(resourceIpv6PoolTemplateHCL, testAccResourceIpv6PoolCfg1Name, testAccResourceIpv6PoolCfg1Subnets)
+
+	testAccResourceIpv6PoolCfg2Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	testAccResourceIpv6PoolCfg2Subnets = strings.Join([]string{
+		fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:1::/96"),
+		fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:2::/96"),
+		fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:3::/96"),
+	}, ",")
+	testAccResourceIpv6PoolCfg2 = fmt.Sprintf(resourceIpv6PoolTemplateHCL, testAccResourceIpv6PoolCfg2Name, testAccResourceIpv6PoolCfg2Subnets)
 )
 
 func TestAccResourceIpv6Pool_basic(t *testing.T) {
-	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	subnets1 := fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8::/66")
-
-	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	subnets2 := strings.Join([]string{
-		fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8:1::/96"),
-		fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8:2::/96"),
-		fmt.Sprintf(resourceIpv6PoolSubnet, "2001:db8:3::/96"),
-	}, ",")
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: fmt.Sprintf(resourceIpv6PoolBasicCfg, insecureProviderConfigHCL, name1, subnets1),
+				Config: insecureProviderConfigHCL + testAccResourceIpv6PoolCfg1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_ipv6_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "name", name1),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "name", testAccResourceIpv6PoolCfg1Name),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "total", "4611686018427387904"),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "used", "0"),
@@ -61,12 +64,12 @@ func TestAccResourceIpv6Pool_basic(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: fmt.Sprintf(resourceIpv6PoolBasicCfg, insecureProviderConfigHCL, name2, subnets2),
+				Config: insecureProviderConfigHCL + testAccResourceIpv6PoolCfg2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_ipv6_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "name", name2),
+					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "name", testAccResourceIpv6PoolCfg2Name),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "total", "12884901888"),
 					resource.TestCheckResourceAttr("apstra_ipv6_pool.test", "used", "0"),

--- a/apstra/resource_ipv6_pool_test.go
+++ b/apstra/resource_ipv6_pool_test.go
@@ -20,23 +20,23 @@ resource "apstra_ipv6_pool" "test" {
 	resourceIpv6PoolSubnetTemplateHCL = "{network = %q}"
 )
 
-var (
-	testAccResourceIpv6PoolCfg1Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	testAccResourceIpv6PoolCfg1Subnets = strings.Join([]string{
-		fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8::/66"),
-	}, ",")
-	testAccResourceIpv6PoolCfg1 = fmt.Sprintf(resourceIpv6PoolTemplateHCL, testAccResourceIpv6PoolCfg1Name, testAccResourceIpv6PoolCfg1Subnets)
-
-	testAccResourceIpv6PoolCfg2Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	testAccResourceIpv6PoolCfg2Subnets = strings.Join([]string{
-		fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:1::/96"),
-		fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:2::/96"),
-		fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:3::/96"),
-	}, ",")
-	testAccResourceIpv6PoolCfg2 = fmt.Sprintf(resourceIpv6PoolTemplateHCL, testAccResourceIpv6PoolCfg2Name, testAccResourceIpv6PoolCfg2Subnets)
-)
-
 func TestAccResourceIpv6Pool_basic(t *testing.T) {
+	var (
+		testAccResourceIpv6PoolCfg1Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		testAccResourceIpv6PoolCfg1Subnets = strings.Join([]string{
+			fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8::/66"),
+		}, ",")
+		testAccResourceIpv6PoolCfg1 = fmt.Sprintf(resourceIpv6PoolTemplateHCL, testAccResourceIpv6PoolCfg1Name, testAccResourceIpv6PoolCfg1Subnets)
+
+		testAccResourceIpv6PoolCfg2Name    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		testAccResourceIpv6PoolCfg2Subnets = strings.Join([]string{
+			fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:1::/96"),
+			fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:2::/96"),
+			fmt.Sprintf(resourceIpv6PoolSubnetTemplateHCL, "2001:db8:3::/96"),
+		}, ",")
+		testAccResourceIpv6PoolCfg2 = fmt.Sprintf(resourceIpv6PoolTemplateHCL, testAccResourceIpv6PoolCfg2Name, testAccResourceIpv6PoolCfg2Subnets)
+	)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/apstra/resource_vni_pool_test.go
+++ b/apstra/resource_vni_pool_test.go
@@ -20,23 +20,23 @@ resource "apstra_vni_pool" "test" {
 	resourceVniPoolRangeTemplateHCL = "{first = %d, last = %d}"
 )
 
-var (
-	testAccResourceVniPoolCfg1Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	testAccResourceVniPoolCfg1Ranges = strings.Join([]string{
-		fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10010, 10020),
-	}, ",")
-	testAccResourceVniPoolCfg1 = fmt.Sprintf(resourceVniPoolTemplateHCL, testAccResourceVniPoolCfg1Name, testAccResourceVniPoolCfg1Ranges)
-
-	testAccResourceVniPoolCfg2Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	testAccResourceVniPoolCfg2Ranges = strings.Join([]string{
-		fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10001, 10003),
-		fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10005, 10011),
-		fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10015, 10025),
-	}, ",")
-	testAccResourceVniPoolCfg2 = fmt.Sprintf(resourceVniPoolTemplateHCL, testAccResourceVniPoolCfg2Name, testAccResourceVniPoolCfg2Ranges)
-)
-
 func TestAccResourceVniPool_basic(t *testing.T) {
+	var (
+		testAccResourceVniPoolCfg1Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		testAccResourceVniPoolCfg1Ranges = strings.Join([]string{
+			fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10010, 10020),
+		}, ",")
+		testAccResourceVniPoolCfg1 = fmt.Sprintf(resourceVniPoolTemplateHCL, testAccResourceVniPoolCfg1Name, testAccResourceVniPoolCfg1Ranges)
+
+		testAccResourceVniPoolCfg2Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		testAccResourceVniPoolCfg2Ranges = strings.Join([]string{
+			fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10001, 10003),
+			fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10005, 10011),
+			fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10015, 10025),
+		}, ",")
+		testAccResourceVniPoolCfg2 = fmt.Sprintf(resourceVniPoolTemplateHCL, testAccResourceVniPoolCfg2Name, testAccResourceVniPoolCfg2Ranges)
+	)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/apstra/resource_vni_pool_test.go
+++ b/apstra/resource_vni_pool_test.go
@@ -10,41 +10,44 @@ import (
 )
 
 const (
-	resourceVniPoolBasicCfg = `
-// provider config
-%s
-
+	resourceVniPoolTemplateHCL = `
 // resource config
 resource "apstra_vni_pool" "test" {
   name = "%s"
   ranges = [%s]
 }
 `
-	resourceVniPoolRange = "{first = %d, last = %d}"
+	resourceVniPoolRangeTemplateHCL = "{first = %d, last = %d}"
+)
+
+var (
+	testAccResourceVniPoolCfg1Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	testAccResourceVniPoolCfg1Ranges = strings.Join([]string{
+		fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10010, 10020),
+	}, ",")
+	testAccResourceVniPoolCfg1 = fmt.Sprintf(resourceVniPoolTemplateHCL, testAccResourceVniPoolCfg1Name, testAccResourceVniPoolCfg1Ranges)
+
+	testAccResourceVniPoolCfg2Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	testAccResourceVniPoolCfg2Ranges = strings.Join([]string{
+		fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10001, 10003),
+		fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10005, 10011),
+		fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10015, 10025),
+	}, ",")
+	testAccResourceVniPoolCfg2 = fmt.Sprintf(resourceVniPoolTemplateHCL, testAccResourceVniPoolCfg2Name, testAccResourceVniPoolCfg2Ranges)
 )
 
 func TestAccResourceVniPool_basic(t *testing.T) {
-	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	ranges1 := fmt.Sprintf(resourceVniPoolRange, 10010, 10020)
-
-	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	ranges2 := strings.Join([]string{
-		fmt.Sprintf(resourceVniPoolRange, 10001, 10003),
-		fmt.Sprintf(resourceVniPoolRange, 10005, 10011),
-		fmt.Sprintf(resourceVniPoolRange, 10015, 10025),
-	}, ",")
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: fmt.Sprintf(resourceVniPoolBasicCfg, insecureProviderConfigHCL, name1, ranges1),
+				Config: insecureProviderConfigHCL + testAccResourceVniPoolCfg1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_vni_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_vni_pool.test", "name", name1),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "name", testAccResourceVniPoolCfg1Name),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "total", "11"),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "used", "0"),
@@ -62,12 +65,12 @@ func TestAccResourceVniPool_basic(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: fmt.Sprintf(resourceVniPoolBasicCfg, insecureProviderConfigHCL, name2, ranges2),
+				Config: insecureProviderConfigHCL + testAccResourceVniPoolCfg2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_vni_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_vni_pool.test", "name", name2),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "name", testAccResourceVniPoolCfg2Name),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "total", "21"),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "used", "0"),

--- a/apstra/resource_vni_pool_test.go
+++ b/apstra/resource_vni_pool_test.go
@@ -1,0 +1,88 @@
+package tfapstra
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const (
+	resourceVniPoolBasicCfg = `
+// provider config
+%s
+
+// resource config
+resource "apstra_vni_pool" "test" {
+  name = "%s"
+  ranges = [%s]
+}
+`
+	resourceVniPoolRange = "{first = %d, last = %d}"
+)
+
+func TestAccResourceVniPool_basic(t *testing.T) {
+	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	ranges1 := fmt.Sprintf(resourceVniPoolRange, 10010, 10020)
+
+	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	ranges2 := strings.Join([]string{
+		fmt.Sprintf(resourceVniPoolRange, 10001, 10003),
+		fmt.Sprintf(resourceVniPoolRange, 10005, 10011),
+		fmt.Sprintf(resourceVniPoolRange, 10015, 10025),
+	}, ",")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: fmt.Sprintf(resourceVniPoolBasicCfg, insecureProviderConfigHCL, name1, ranges1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify ID has any value set
+					resource.TestCheckResourceAttrSet("apstra_vni_pool.test", "id"),
+					// Verify name and overall usage statistics
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "name", name1),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "status", "not_in_use"),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "total", "11"),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "used", "0"),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "used_percentage", "0"),
+					// Verify number of ranges
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.#", "1"),
+					// Verify first range
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.first", "10010"),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.last", "10020"),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.status", "pool_element_available"),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.total", "11"),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.used", "0"),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.used_percentage", "0"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: fmt.Sprintf(resourceVniPoolBasicCfg, insecureProviderConfigHCL, name2, ranges2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify ID has any value set
+					resource.TestCheckResourceAttrSet("apstra_vni_pool.test", "id"),
+					// Verify name and overall usage statistics
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "name", name2),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "status", "not_in_use"),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "total", "21"),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "used", "0"),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "used_percentage", "0"),
+					// Verify number of ranges
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.#", "3"),
+					//// cannot verify ranges here because they're not sorted
+					//resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.first", "10001"),
+					//resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.last", "10003"),
+					//resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.status", "pool_element_available"),
+					//resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.total", "3"),
+					//resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.used", "0"),
+					//resource.TestCheckResourceAttr("apstra_vni_pool.test", "ranges.0.used_percentage", "0"),
+				),
+			},
+		},
+	})
+}

--- a/apstra/resource_vni_pool_test.go
+++ b/apstra/resource_vni_pool_test.go
@@ -10,44 +10,41 @@ import (
 )
 
 const (
-	resourceVniPoolTemplateHCL = `
+	resourceVniPoolBasicCfg = `
+// provider config
+%s
+
 // resource config
 resource "apstra_vni_pool" "test" {
   name = "%s"
   ranges = [%s]
 }
 `
-	resourceVniPoolRangeTemplateHCL = "{first = %d, last = %d}"
+	resourceVniPoolRange = "{first = %d, last = %d}"
 )
 
 func TestAccResourceVniPool_basic(t *testing.T) {
-	var (
-		testAccResourceVniPoolCfg1Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-		testAccResourceVniPoolCfg1Ranges = strings.Join([]string{
-			fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10010, 10020),
-		}, ",")
-		testAccResourceVniPoolCfg1 = fmt.Sprintf(resourceVniPoolTemplateHCL, testAccResourceVniPoolCfg1Name, testAccResourceVniPoolCfg1Ranges)
+	name1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	ranges1 := fmt.Sprintf(resourceVniPoolRange, 10010, 10020)
 
-		testAccResourceVniPoolCfg2Name   = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-		testAccResourceVniPoolCfg2Ranges = strings.Join([]string{
-			fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10001, 10003),
-			fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10005, 10011),
-			fmt.Sprintf(resourceVniPoolRangeTemplateHCL, 10015, 10025),
-		}, ",")
-		testAccResourceVniPoolCfg2 = fmt.Sprintf(resourceVniPoolTemplateHCL, testAccResourceVniPoolCfg2Name, testAccResourceVniPoolCfg2Ranges)
-	)
+	name2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	ranges2 := strings.Join([]string{
+		fmt.Sprintf(resourceVniPoolRange, 10001, 10003),
+		fmt.Sprintf(resourceVniPoolRange, 10005, 10011),
+		fmt.Sprintf(resourceVniPoolRange, 10015, 10025),
+	}, ",")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: insecureProviderConfigHCL + testAccResourceVniPoolCfg1,
+				Config: fmt.Sprintf(resourceVniPoolBasicCfg, insecureProviderConfigHCL, name1, ranges1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_vni_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_vni_pool.test", "name", testAccResourceVniPoolCfg1Name),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "name", name1),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "total", "11"),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "used", "0"),
@@ -65,12 +62,12 @@ func TestAccResourceVniPool_basic(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: insecureProviderConfigHCL + testAccResourceVniPoolCfg2,
+				Config: fmt.Sprintf(resourceVniPoolBasicCfg, insecureProviderConfigHCL, name2, ranges2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify ID has any value set
 					resource.TestCheckResourceAttrSet("apstra_vni_pool.test", "id"),
 					// Verify name and overall usage statistics
-					resource.TestCheckResourceAttr("apstra_vni_pool.test", "name", testAccResourceVniPoolCfg2Name),
+					resource.TestCheckResourceAttr("apstra_vni_pool.test", "name", name2),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "status", "not_in_use"),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "total", "21"),
 					resource.TestCheckResourceAttr("apstra_vni_pool.test", "used", "0"),

--- a/apstra/test_utils/ipv4_pool.go
+++ b/apstra/test_utils/ipv4_pool.go
@@ -1,0 +1,145 @@
+package testutils
+
+import (
+	"context"
+	"errors"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"math"
+	"math/big"
+	"net"
+)
+
+func Ipv4PoolA(ctx context.Context) (*apstra.IpPool, func(context.Context) error, error) {
+	client, err := GetTestClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	request := apstra.NewIpPoolRequest{
+		DisplayName: name,
+		Subnets: []apstra.NewIpSubnet{
+			{Network: "192.168.0.0/16"},
+		},
+	}
+	id, err := client.CreateIp4Pool(ctx, &request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var z *big.Int
+	var ok bool
+
+	bigZero := new(big.Int)
+	z, ok = bigZero.SetString("0", 10)
+	if z == nil || !ok {
+		return nil, nil, errors.New("error setting 'bigZero' value")
+	}
+
+	subnets := make([]apstra.IpSubnet, len(request.Subnets))
+	total := new(big.Int)
+	for i := range request.Subnets {
+		_, net, err := net.ParseCIDR(request.Subnets[i].Network)
+		if err != nil {
+			return nil, nil, err
+		}
+		subnets[i] = apstra.IpSubnet{
+			Network:        net,
+			Status:         "pool_element_available",
+			Used:           *bigZero,
+			UsedPercentage: 0,
+		}
+		maskOnes, maskBits := net.Mask.Size()
+		subnets[i].Total.SetInt64(int64(math.Pow(2, float64(maskBits-maskOnes))))
+		total.Add(total, &subnets[i].Total)
+	}
+
+	pool := apstra.IpPool{
+		Id:             id,
+		DisplayName:    name,
+		Status:         apstra.PoolStatusUnused,
+		Used:           *bigZero,
+		Total:          *total,
+		UsedPercentage: 0,
+		Subnets:        subnets,
+	}
+
+	deleteFunc := func(ctx context.Context) error {
+		err := client.DeleteIp4Pool(ctx, id)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return &pool, deleteFunc, nil
+}
+
+func Ipv4PoolB(ctx context.Context) (*apstra.IpPool, func(context.Context) error, error) {
+	client, err := GetTestClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	request := apstra.NewIpPoolRequest{
+		DisplayName: name,
+		Subnets: []apstra.NewIpSubnet{
+			{Network: "192.168.0.0/24"},
+			{Network: "192.168.1.0/24"},
+			{Network: "192.168.2.0/23"},
+		},
+	}
+	id, err := client.CreateIp4Pool(ctx, &request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var z *big.Int
+	var ok bool
+
+	bigZero := new(big.Int)
+	z, ok = bigZero.SetString("0", 10)
+	if z == nil || !ok {
+		return nil, nil, errors.New("error setting 'bigZero' value")
+	}
+
+	subnets := make([]apstra.IpSubnet, len(request.Subnets))
+	total := new(big.Int)
+	for i := range request.Subnets {
+		_, net, err := net.ParseCIDR(request.Subnets[i].Network)
+		if err != nil {
+			return nil, nil, err
+		}
+		subnets[i] = apstra.IpSubnet{
+			Network:        net,
+			Status:         "pool_element_available",
+			Used:           *bigZero,
+			UsedPercentage: 0,
+		}
+		maskOnes, maskBits := net.Mask.Size()
+		subnets[i].Total.SetInt64(int64(math.Pow(2, float64(maskBits-maskOnes))))
+		total.Add(total, &subnets[i].Total)
+	}
+
+	pool := apstra.IpPool{
+		Id:             id,
+		DisplayName:    name,
+		Status:         apstra.PoolStatusUnused,
+		Used:           *bigZero,
+		Total:          *total,
+		UsedPercentage: 0,
+		Subnets:        subnets,
+	}
+
+	deleteFunc := func(ctx context.Context) error {
+		err := client.DeleteIp4Pool(ctx, id)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return &pool, deleteFunc, nil
+}

--- a/apstra/test_utils/test_utils.go
+++ b/apstra/test_utils/test_utils.go
@@ -1,0 +1,31 @@
+package testutils
+
+import (
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"net/http"
+	"sync"
+	"terraform-provider-apstra/apstra/utils"
+)
+
+var sharedClient *apstra.Client
+var testClientMutex sync.Mutex
+
+func GetTestClient() (*apstra.Client, error) {
+	testClientMutex.Lock()
+	defer testClientMutex.Unlock()
+
+	if sharedClient == nil {
+		clientCfg, err := utils.NewClientConfig("")
+		if err != nil {
+			return nil, err
+		}
+		clientCfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
+
+		sharedClient, err = clientCfg.NewClient()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return sharedClient, nil
+}

--- a/apstra/utils/client.go
+++ b/apstra/utils/client.go
@@ -1,0 +1,118 @@
+package utils
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+const (
+	EnvApstraUrl      = "APSTRA_URL"
+	EnvApstraUsername = "APSTRA_USER"
+	EnvApstraPassword = "APSTRA_PASS"
+	envApstraLogfile  = "APSTRA_LOG"
+	envTlsKeyLogFile  = "SSLKEYLOGFILE"
+
+	urlEncodeMsg = `
+Note that when the Username or Password fields contain special characters and are
+embedded in the URL, they must be URL-encoded by substituting '%%<hex-value>' in
+place of each special character. The following table demonstrates some common
+substitutions:
+
+%s`
+)
+
+func NewClientConfig(apstraUrl string) (*apstra.ClientCfg, error) {
+	// Populate raw URL string from config or environment.
+	if apstraUrl == "" {
+		apstraUrl = os.Getenv(EnvApstraUrl)
+	}
+
+	if apstraUrl == "" {
+		return nil, errors.New("missing Apstra URL")
+	}
+
+	// Parse the URL.
+	parsedUrl, err := url.Parse(apstraUrl)
+	if err != nil {
+		if urlErr, ok := err.(*url.Error); ok && strings.Contains(urlErr.Error(), "invalid userinfo") {
+			// don't print the actual error here because it likely contains a password
+			return nil, errors.New(
+				"error parsing userinfo from URL - " + fmt.Sprintf(urlEncodeMsg, UrlEscapeTable()))
+		}
+
+		var urlEE url.EscapeError
+		if errors.As(err, &urlEE) {
+			return nil, errors.New("error parsing URL - " + fmt.Sprintf(urlEncodeMsg, UrlEscapeTable()))
+		}
+
+		return nil, fmt.Errorf("error parsing URL %q - %w", apstraUrl, err)
+	}
+
+	// Determine the Apstra username.
+	user := parsedUrl.User.Username()
+	if user == "" {
+		if val, ok := os.LookupEnv(EnvApstraUsername); ok {
+			user = val
+		} else {
+			return nil, errors.New("unable to determine apstra username - " + fmt.Sprintf(urlEncodeMsg, UrlEscapeTable()))
+		}
+	}
+
+	// Determine  the Apstra password.
+	pass, found := parsedUrl.User.Password()
+	if !found {
+		if val, ok := os.LookupEnv(EnvApstraPassword); ok {
+			pass = val
+		} else {
+			return nil, errors.New("unable to determine apstra password")
+		}
+	}
+
+	// Remove credentials from the URL prior to rendering it into ClientCfg.
+	parsedUrl.User = nil
+
+	// Set up a logger.
+	var logger *log.Logger
+	if logFileName, ok := os.LookupEnv(envApstraLogfile); ok {
+		logFile, err := os.OpenFile(logFileName, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+		if err != nil {
+			return nil, err
+		}
+		logger = log.New(logFile, "", 0)
+	}
+
+	// Set up the TLS session key log.
+	var klw io.Writer
+	if fileName, ok := os.LookupEnv(envTlsKeyLogFile); ok {
+		klw, err = newKeyLogWriter(fileName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Create the client's httpClient
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				KeyLogWriter: klw,
+			},
+		},
+	}
+
+	// Create the clientCfg
+	return &apstra.ClientCfg{
+		Url:        parsedUrl.String(),
+		User:       user,
+		Pass:       pass,
+		Logger:     logger,
+		HttpClient: httpClient,
+	}, nil
+}

--- a/apstra/utils/sslKeyLogWriter.go
+++ b/apstra/utils/sslKeyLogWriter.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/mitchellh/go-homedir"
+	"os"
+	"path/filepath"
+)
+
+func newKeyLogWriter(fileName string) (*os.File, error) {
+	absPath, err := homedir.Expand(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("error expanding home directory '%s' - %w", fileName, err)
+	}
+
+	err = os.MkdirAll(filepath.Dir(absPath), os.FileMode(0600))
+	if err != nil {
+		return nil, err
+	}
+	return os.OpenFile(absPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.2.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0
+	github.com/hashicorp/terraform-plugin-go v0.14.3
+	github.com/hashicorp/terraform-plugin-testing v1.2.0
 	github.com/mitchellh/go-homedir v1.1.0
 )
 
@@ -18,24 +20,29 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
+	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/fatih/color v1.14.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.9 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/hc-install v0.5.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.16.2 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.18.1 // indirect
 	github.com/hashicorp/terraform-json v0.16.0 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.14.3 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.8.0 // indirect
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1 // indirect
 	github.com/hashicorp/terraform-registry-address v0.1.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
@@ -46,12 +53,15 @@ require (
 	github.com/mitchellh/cli v1.1.5 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	github.com/zclconf/go-cty v1.13.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,11 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
+github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
+github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -59,6 +62,7 @@ github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
 github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
 github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
+github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -84,6 +88,8 @@ github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 h1:1/D3zfFHttUKaCaGKZ/dR2roBXv0vKbSCnssIldfQdI=
+github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320/go.mod h1:EiZBMaudVLy8fmjf9Npq1dq9RalhveqZG5w/yz3mHWs=
 github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
 github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
@@ -99,6 +105,9 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hc-install v0.5.0 h1:D9bl4KayIYKEeJ4vUDe9L5huqxZXczKaykSRcmQ0xY0=
 github.com/hashicorp/hc-install v0.5.0/go.mod h1:JyzMfbzfSBSjoDCRPna1vi/24BEDxFaCPfdHtM5SCdo=
+github.com/hashicorp/hcl/v2 v2.16.2 h1:mpkHZh/Tv+xet3sy3F9Ld4FyI2tUpWe9x3XtPx9f1a0=
+github.com/hashicorp/hcl/v2 v2.16.2/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
+github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.18.1 h1:LAbfDvNQU1l0NOQlTuudjczVhHj061fNX5H8XZxHlH4=
 github.com/hashicorp/terraform-exec v0.18.1/go.mod h1:58wg4IeuAJ6LVsLUeD2DWZZoc/bYi6dzhLHzxM41980=
@@ -114,6 +123,10 @@ github.com/hashicorp/terraform-plugin-go v0.14.3 h1:nlnJ1GXKdMwsC8g1Nh05tK2wsC3+
 github.com/hashicorp/terraform-plugin-go v0.14.3/go.mod h1:7ees7DMZ263q8wQ6E4RdIdR6nHHJtrdt4ogX5lPkX1A=
 github.com/hashicorp/terraform-plugin-log v0.8.0 h1:pX2VQ/TGKu+UU1rCay0OlzosNKe4Nz1pepLXj95oyy0=
 github.com/hashicorp/terraform-plugin-log v0.8.0/go.mod h1:1myFrhVsBLeylQzYYEV17VVjtG8oYPRFdaZs7xdW2xs=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1 h1:G9WAfb8LHeCxu7Ae8nc1agZlQOSCUWsb610iAogBhCs=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1/go.mod h1:xcOSYlRVdPLmDUoqPhO9fiO/YCN/l6MGYeTzGt5jgkQ=
+github.com/hashicorp/terraform-plugin-testing v1.2.0 h1:pASRAe6BOZFO4xSGQr9WzitXit0nrQAYDk8ziuRfn9E=
+github.com/hashicorp/terraform-plugin-testing v1.2.0/go.mod h1:+8bp3O7xUb1UtBcdknrGdVRIuTw4b62TYSIgXHqlyew=
 github.com/hashicorp/terraform-registry-address v0.1.0 h1:W6JkV9wbum+m516rCl5/NjKxCyTVaaUBbzYcMzBDO3U=
 github.com/hashicorp/terraform-registry-address v0.1.0/go.mod h1:EnyO2jYO6j29DTHbJcm00E5nQTFeTtyZH3H5ycydQ5A=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
@@ -143,6 +156,7 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -164,6 +178,10 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
+github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
+github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
@@ -199,6 +217,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
+github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvCazn8G65U=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=


### PR DESCRIPTION
This PR introduces the first tests using the terraform acceptance testing framework.

The tests are in:

- `apstra/data_source_ipv4_pool_test.go`
- `apstra/resource_asn_pool_test.go`
- `apstra/resource_ipv4_pool_test.go`
- `apstra/resource_ipv6_pool_test.go`
- `apstra/resource_vni_pool_test.go`

Those tests have supporting code in `apstra/provider_test.go`

In addition to the tests, some functionality needed to be split into sub packages for re-use:

- `newKeyLogWriter()` has moved to the `utils` package
- `newClientConfig()` and supporting constants have moved to the `utils` package

Other new stuff:
- `test_utils` package with methods for setting up test conditions on Apstra