### PR TITLE
introduce `OneOfStringers()`

### DIFF
--- a/apstra/apstra_validator/one_of_stringers.go
+++ b/apstra/apstra_validator/one_of_stringers.go
@@ -1,0 +1,15 @@
+package apstravalidator
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+func OneOfStringers(s ...fmt.Stringer) validator.String {
+	strings := make([]string, len(s))
+	for i := range s {
+		strings[i] = s[i].String()
+	}
+	return stringvalidator.OneOf(strings...)
+}

--- a/apstra/apstra_validator/one_of_stringers.go
+++ b/apstra/apstra_validator/one_of_stringers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-func OneOfStringers(s ...fmt.Stringer) validator.String {
+func OneOfStringers[S fmt.Stringer](s []S) validator.String {
 	strings := make([]string, len(s))
 	for i := range s {
 		strings[i] = s[i].String()


### PR DESCRIPTION
`OneOfStringers()` is a helper function which returns a (standard terraform) `oneOf` string validator based on a `[]fmt.Stringer`.

It's a step toward eliminating reliance on helper functions which turn slices of our iota types into slices of strings, because now we can base input validation on the SDK's `All<whatever>()` methods directly without type-specific helpers to turn 'em into strings.