### PR TITLE
Issue 48 - interface map sort order

### DIFF
--- a/apstra/resource_interface_map.go
+++ b/apstra/resource_interface_map.go
@@ -854,7 +854,7 @@ func iMapUnallocaedInterfaces(allocatedPorts []apstra.InterfaceMapInterface, dp 
 				LDPort:        -1,
 			},
 			ActiveState: true, // unclear what this is, UI sets "active"
-			Position:    allocatedPortCount + i + 1,
+			Position:    dpPort.PortId,
 			Speed:       transformation.Interfaces[0].Speed,
 			Setting:     apstra.InterfaceMapInterfaceSetting{Param: transformation.Interfaces[0].Setting},
 		}


### PR DESCRIPTION
This PR should resolve #48.

The issue was that we loop over a map of interfaces and use the iterator variable, rather than the port ID when assigning the interface `position` element.

This problem appeared in two places:
- processing allocated interfaces
- processing unallocated interfaces

The required fix is in both loops.