### PR TITLE
s/EmptyDeleteFunc/deleteFunc/

### DIFF
--- a/apstra/test_utils/ipv4_pool.go
+++ b/apstra/test_utils/ipv4_pool.go
@@ -11,12 +11,12 @@ import (
 )
 
 func Ipv4PoolA(ctx context.Context) (*apstra.IpPool, func(context.Context) error, error) {
-	EmptyDeleteFunc := func(_ context.Context) error { return nil }
+	deleteFunc := func(_ context.Context) error { return nil }
 
 	client, err := GetTestClient()
 
 	if err != nil {
-		return nil, EmptyDeleteFunc, err
+		return nil, deleteFunc, err
 	}
 
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -28,7 +28,10 @@ func Ipv4PoolA(ctx context.Context) (*apstra.IpPool, func(context.Context) error
 	}
 	id, err := client.CreateIp4Pool(ctx, &request)
 	if err != nil {
-		return nil, EmptyDeleteFunc, err
+		return nil, deleteFunc, err
+	}
+	deleteFunc = func(ctx context.Context) error {
+		return client.DeleteIp4Pool(ctx, id)
 	}
 
 	var z *big.Int
@@ -37,7 +40,7 @@ func Ipv4PoolA(ctx context.Context) (*apstra.IpPool, func(context.Context) error
 	bigZero := new(big.Int)
 	z, ok = bigZero.SetString("0", 10)
 	if z == nil || !ok {
-		return nil, EmptyDeleteFunc, errors.New("error setting 'bigZero' value")
+		return nil, deleteFunc, errors.New("error setting 'bigZero' value")
 	}
 
 	subnets := make([]apstra.IpSubnet, len(request.Subnets))
@@ -45,7 +48,7 @@ func Ipv4PoolA(ctx context.Context) (*apstra.IpPool, func(context.Context) error
 	for i := range request.Subnets {
 		_, net, err := net.ParseCIDR(request.Subnets[i].Network)
 		if err != nil {
-			return nil, EmptyDeleteFunc, err
+			return nil, deleteFunc, err
 		}
 		subnets[i] = apstra.IpSubnet{
 			Network:        net,
@@ -68,22 +71,14 @@ func Ipv4PoolA(ctx context.Context) (*apstra.IpPool, func(context.Context) error
 		Subnets:        subnets,
 	}
 
-	deleteFunc := func(ctx context.Context) error {
-		err := client.DeleteIp4Pool(ctx, id)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
 	return &pool, deleteFunc, nil
 }
 
 func Ipv4PoolB(ctx context.Context) (*apstra.IpPool, func(context.Context) error, error) {
-	EmptyDeleteFunc := func(_ context.Context) error { return nil }
+	deleteFunc := func(_ context.Context) error { return nil }
 	client, err := GetTestClient()
 	if err != nil {
-		return nil, nil, err
+		return nil, deleteFunc, err
 	}
 
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -97,7 +92,10 @@ func Ipv4PoolB(ctx context.Context) (*apstra.IpPool, func(context.Context) error
 	}
 	id, err := client.CreateIp4Pool(ctx, &request)
 	if err != nil {
-		return nil, EmptyDeleteFunc, err
+		return nil, deleteFunc, err
+	}
+	deleteFunc = func(ctx context.Context) error {
+		return client.DeleteIp4Pool(ctx, id)
 	}
 
 	var z *big.Int
@@ -106,7 +104,7 @@ func Ipv4PoolB(ctx context.Context) (*apstra.IpPool, func(context.Context) error
 	bigZero := new(big.Int)
 	z, ok = bigZero.SetString("0", 10)
 	if z == nil || !ok {
-		return nil, EmptyDeleteFunc, errors.New("error setting 'bigZero' value")
+		return nil, deleteFunc, errors.New("error setting 'bigZero' value")
 	}
 
 	subnets := make([]apstra.IpSubnet, len(request.Subnets))
@@ -114,7 +112,7 @@ func Ipv4PoolB(ctx context.Context) (*apstra.IpPool, func(context.Context) error
 	for i := range request.Subnets {
 		_, net, err := net.ParseCIDR(request.Subnets[i].Network)
 		if err != nil {
-			return nil, EmptyDeleteFunc, err
+			return nil, deleteFunc, err
 		}
 		subnets[i] = apstra.IpSubnet{
 			Network:        net,
@@ -135,14 +133,6 @@ func Ipv4PoolB(ctx context.Context) (*apstra.IpPool, func(context.Context) error
 		Total:          *total,
 		UsedPercentage: 0,
 		Subnets:        subnets,
-	}
-
-	deleteFunc := func(ctx context.Context) error {
-		err := client.DeleteIp4Pool(ctx, id)
-		if err != nil {
-			return err
-		}
-		return nil
 	}
 
 	return &pool, deleteFunc, nil

--- a/apstra/test_utils/property_set.go
+++ b/apstra/test_utils/property_set.go
@@ -8,9 +8,9 @@ import (
 
 func PropertySetA(ctx context.Context) (*apstra.PropertySet, func(context.Context) error, error) {
 	client, err := GetTestClient()
-	EmptyDeleteFunc := func(_ context.Context) error { return nil }
+	deleteFunc := func(_ context.Context) error { return nil }
 	if err != nil {
-		return nil, EmptyDeleteFunc, err
+		return nil, deleteFunc, err
 	}
 
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -21,19 +21,16 @@ func PropertySetA(ctx context.Context) (*apstra.PropertySet, func(context.Contex
 
 	id, err := client.CreatePropertySet(ctx, &request)
 	if err != nil {
-		return nil, EmptyDeleteFunc, err
+		return nil, deleteFunc, err
 	}
-	ps, err := client.GetPropertySet(ctx, id)
-	if err != nil {
-		return nil, EmptyDeleteFunc, err
+	deleteFunc = func(ctx context.Context) error {
+		return client.DeletePropertySet(ctx, id)
 	}
 
-	deleteFunc := func(ctx context.Context) error {
-		err := client.DeletePropertySet(ctx, id)
-		if err != nil {
-			return err
-		}
-		return nil
+	ps, err := client.GetPropertySet(ctx, id)
+	if err != nil {
+		return nil, deleteFunc, err
 	}
+
 	return ps, deleteFunc, nil
 }


### PR DESCRIPTION
Here's what I had in mind for the empty `deleteFunc`.

Some `Test<object>A` functions will wind up creating multiple objects in Apstra. At least one of the `TestBlueprintX` methods does this now.

Their `deleteFunc` needs to be ready/able to delete any objects created whenever an error occurs, even if it occurs between creation of sub-object 1 and sub-object 2, so `deleteFunc` will need to evolve as the function progresses.

This was the point that I realized `deleteFunc` should start out as a no-op, and gradually accumulate destructive functionality as its parent function does the work of creating test objects.