### PR TITLE
remove unused structs

### DIFF
--- a/apstra/apstra_validator/parse_cidr.go
+++ b/apstra/apstra_validator/parse_cidr.go
@@ -4,11 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"net"
 )
 
@@ -17,17 +13,6 @@ var _ validator.String = ParseCidrValidator{}
 type ParseCidrValidator struct {
 	requireIpv4 bool
 	requireIpv6 bool
-}
-
-type ParseCidrValidatorRequest struct {
-	Config         tfsdk.Config
-	ConfigValue    attr.Value
-	Path           path.Path
-	PathExpression path.Expression
-}
-
-type ParseCidrValidatorResponse struct {
-	Diagnostics diag.Diagnostics
 }
 
 func (o ParseCidrValidator) Description(_ context.Context) string {

--- a/apstra/apstra_validator/parse_ip.go
+++ b/apstra/apstra_validator/parse_ip.go
@@ -3,11 +3,7 @@ package apstravalidator
 import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"net"
 )
 
@@ -16,17 +12,6 @@ var _ validator.String = ParseIpValidator{}
 type ParseIpValidator struct {
 	requireIpv4 bool
 	requireIpv6 bool
-}
-
-type ParseIpValidatorRequest struct {
-	Config         tfsdk.Config
-	ConfigValue    attr.Value
-	Path           path.Path
-	PathExpression path.Expression
-}
-
-type ParseIpValidatorResponse struct {
-	Diagnostics diag.Diagnostics
 }
 
 func (o ParseIpValidator) Description(_ context.Context) string {


### PR DESCRIPTION
while working with @bwJuniper the other day we noticed some unused structs in the `parse_ip.go` and `parse_cidr.go` files.

This will close #77