### PR TITLE
Add GitHub action to verify documentation generation

### DIFF
--- a/.github/workflows/go_tools.yml
+++ b/.github/workflows/go_tools.yml
@@ -19,3 +19,6 @@ jobs:
 
       - name: go vet
         run: make govet
+
+      - name: tfplugindocs
+        run: make docs

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-all: gofmt govet unit-tests integration-tests device-integration-tests
+all: docs gofmt govet unit-tests integration-tests device-integration-tests
+
+docs:
+	@sh -c "$(CURDIR)/scripts/tfplugindocs.sh"
 
 gofmt:
 	@sh -c "$(CURDIR)/scripts/gofmtcheck.sh"
@@ -15,4 +18,4 @@ integration-tests:
 device-integration-tests:
 	go test -tags device-integration -v ./...
 
-.PHONY: all gofmt govet unit-tests integration-tests device-integration-tests
+.PHONY: all docs gofmt govet unit-tests integration-tests device-integration-tests

--- a/scripts/tfplugindocs.sh
+++ b/scripts/tfplugindocs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs || exit 1
+
+git update-index --refresh || exit 1
+
+git diff-index --quiet HEAD -- || exit 1


### PR DESCRIPTION
This PR should cause workflow failures if:

- it's impossible to render documentation (forgotten `example.tf` scenario)
- `MarkdownDescription` in resource/datasource schema has been changed without re-running `tfplugindocs`