### PR TITLE
Clean up redundant language in embedded doc string

### DIFF
--- a/docs/data-sources/datacenter_routing_zones.md
+++ b/docs/data-sources/datacenter_routing_zones.md
@@ -53,7 +53,7 @@ data "apstra_datacenter_routing_zones" "rzs" {
 
 Optional:
 
-- `dhcp_servers` (Set of String) Set of DHCP server IPv4 or IPv6 addresses of DHCP servers which must be configured in the Routing Zone. This is a list of *required* servers, not an exact-match list.
+- `dhcp_servers` (Set of String) Set of addresses of DHCP servers (IPv4 or IPv6) which must be configured in the Routing Zone. This is a list of *required* servers, not an exact-match list.
 - `name` (String) VRF name displayed in thw Apstra web UI.
 - `routing_policy_id` (String) Non-EVPN blueprints must use the default policy, so this field must be null. Set this attribute in an EVPN blueprint to use a non-default policy.
 - `vlan_id` (Number) Used for VLAN tagged Layer 3 links on external connections.


### PR DESCRIPTION
Grammar caught by @rajagopalans in #101 and fixed (in the code) in 7ee2477...

But the docs weren't re-generated at that time.

This sort of oversight shouldn't be an issue since #102 got merged. Missed it by *that much* 🤏