### PR TITLE
Audit use of `RemoveResource()` #83

### DIFF
--- a/apstra/blueprint/blueprint.go
+++ b/apstra/blueprint/blueprint.go
@@ -233,7 +233,7 @@ func (o *Blueprint) SetName(ctx context.Context, client *apstra.Client, diags *d
 	// create a client specific to the reference design
 	bpClient, err := client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(o.Id.ValueString()))
 	if err != nil {
-		diags.AddError("error creating Blueprint client", err.Error())
+		diags.AddError(fmt.Sprintf(ErrDCBlueprintCreate, o.Id), err.Error())
 		return
 	}
 

--- a/apstra/blueprint/constants.go
+++ b/apstra/blueprint/constants.go
@@ -5,6 +5,8 @@ const (
 	errApiPatchWithTypeAndId = "API error patching %s %q"
 	errProviderBug           = "Provider Bug. Please report this issue to the provider maintainers."
 
+	ErrDCBlueprintCreate = "Failed to create client for Datacenter Blueprint %s"
+
 	vrfIdMin = 1
 	vrfIdMax = 4999
 )

--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -319,7 +319,8 @@ func (o *DeviceAllocation) SetInterfaceMap(ctx context.Context, client *apstra.C
 			o.BlueprintId = types.StringNull()
 			return
 		}
-		diags.AddError("error creating blueprint client", err.Error())
+		diags.AddError(fmt.Sprintf(ErrDCBlueprintCreate, o.BlueprintId), err.Error())
+
 		return
 	}
 
@@ -669,7 +670,7 @@ func (o *DeviceAllocation) SetNodeDeployMode(ctx context.Context, client *apstra
 func (o *DeviceAllocation) GetNodeDeployMode(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
 	bpClient, err := client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(o.BlueprintId.ValueString()))
 	if err != nil {
-		diags.AddError("error creating blueprint client", err.Error())
+		diags.AddError(fmt.Sprintf(ErrDCBlueprintCreate, o.BlueprintId), err.Error())
 		return
 	}
 

--- a/apstra/blueprint/vn_binding_constructor.go
+++ b/apstra/blueprint/vn_binding_constructor.go
@@ -60,7 +60,7 @@ func (o VnBindingConstructor) DataSourceAttributes() map[string]dataSourceSchema
 func (o *VnBindingConstructor) Compute(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
 	bpClient, err := client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(o.BlueprintId.ValueString()))
 	if err != nil {
-		diags.AddError("error creating blueprint client", err.Error())
+		diags.AddError(fmt.Sprintf(ErrDCBlueprintCreate, o.BlueprintId), err.Error())
 		return
 	}
 

--- a/apstra/data_source_datacenter_routing_zone.go
+++ b/apstra/data_source_datacenter_routing_zone.go
@@ -52,7 +52,7 @@ func (o *dataSourceDatacenterRoutingZone) Read(ctx context.Context, req datasour
 				config.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, config.BlueprintId), err.Error())
 		return
 	}
 

--- a/apstra/resource_datacenter_resource_pool_allocation.go
+++ b/apstra/resource_datacenter_resource_pool_allocation.go
@@ -58,27 +58,25 @@ func (o *resourcePoolAllocation) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	// Ensure the blueprint exists.
-	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(plan.BlueprintId.ValueString()), &resp.Diagnostics) {
-		resp.Diagnostics.AddError("blueprint not found", fmt.Sprintf("blueprint %q not found", plan.BlueprintId.ValueString()))
-	}
-	if resp.Diagnostics.HasError() {
+	// create a client for the datacenter reference design
+	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
+	if err != nil {
+		var ace apstra.ApstraClientErr
+		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
+			return
+		}
+		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
 		return
 	}
 
 	// Lock the blueprint mutex.
-	err := o.lockFunc(ctx, plan.BlueprintId.ValueString())
+	err = o.lockFunc(ctx, plan.BlueprintId.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("error locking blueprint %q mutex", plan.BlueprintId.ValueString()),
 			err.Error())
 		return
-	}
-
-	// Create a blueprint client
-	client, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
-	if err != nil {
-		resp.Diagnostics.AddError("error creating client for Apstra Blueprint", err.Error())
 	}
 
 	// Create a resource allocation request
@@ -90,12 +88,13 @@ func (o *resourcePoolAllocation) Create(ctx context.Context, req resource.Create
 	// Set the new allocation
 	switch {
 	case !plan.RoutingZoneId.IsNull():
-		err = client.SetResourceAllocation(ctx, request)
+		err = bp.SetResourceAllocation(ctx, request)
 	default:
-		err = client.SetResourceAllocation(ctx, request)
+		err = bp.SetResourceAllocation(ctx, request)
 	}
 	if err != nil {
 		resp.Diagnostics.AddError("error setting resource allocation", err.Error())
+		return
 	}
 
 	// Set state
@@ -115,20 +114,8 @@ func (o *resourcePoolAllocation) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	// Ensure the blueprint still exists.
-	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(state.BlueprintId.ValueString()), &resp.Diagnostics) {
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		resp.State.RemoveResource(ctx)
-		return
-	}
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	// Create a blueprint client
-	client, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
+	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
 	if err != nil {
 		var ace apstra.ApstraClientErr
 		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
@@ -145,7 +132,7 @@ func (o *resourcePoolAllocation) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	apiData, err := client.GetResourceAllocation(ctx, &allocationRequest.ResourceGroup)
+	apiData, err := bp.GetResourceAllocation(ctx, &allocationRequest.ResourceGroup)
 	if err != nil {
 		var ace apstra.ApstraClientErr
 		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
@@ -181,31 +168,20 @@ func (o *resourcePoolAllocation) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	// Ensure the blueprint still exists.
-	if !utils.BlueprintExists(ctx, o.client, apstra.ObjectId(plan.BlueprintId.ValueString()), &resp.Diagnostics) {
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		resp.State.RemoveResource(ctx)
-		return
-	}
-	if resp.Diagnostics.HasError() {
+	// Create a blueprint client
+	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
+	if err != nil {
+		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
 		return
 	}
 
 	// Lock the blueprint mutex.
-	err := o.lockFunc(ctx, plan.BlueprintId.ValueString())
+	err = o.lockFunc(ctx, plan.BlueprintId.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("error locking blueprint %q mutex", plan.BlueprintId.ValueString()),
 			err.Error())
 		return
-	}
-
-	// Create a blueprint client
-	client, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
-	if err != nil {
-		resp.Diagnostics.AddError("error creating client for Apstra Blueprint", err.Error())
 	}
 
 	// Create a resource allocation request
@@ -215,7 +191,7 @@ func (o *resourcePoolAllocation) Update(ctx context.Context, req resource.Update
 	}
 
 	// Set the new allocation
-	err = client.SetResourceAllocation(ctx, request)
+	err = bp.SetResourceAllocation(ctx, request)
 	if err != nil {
 		resp.Diagnostics.AddError("error setting resource allocation", err.Error())
 	}

--- a/apstra/resource_datacenter_resource_pool_allocation.go
+++ b/apstra/resource_datacenter_resource_pool_allocation.go
@@ -66,7 +66,7 @@ func (o *resourcePoolAllocation) Create(ctx context.Context, req resource.Create
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
 		return
 	}
 
@@ -122,7 +122,8 @@ func (o *resourcePoolAllocation) Read(ctx context.Context, req resource.ReadRequ
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("error creating client for Apstra Blueprint", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
+
 		return
 	}
 
@@ -171,7 +172,7 @@ func (o *resourcePoolAllocation) Update(ctx context.Context, req resource.Update
 	// Create a blueprint client
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
 		return
 	}
 
@@ -236,7 +237,7 @@ func (o *resourcePoolAllocation) Delete(ctx context.Context, req resource.Delete
 	// Create a blueprint client
 	client, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("error creating client for Apstra Blueprint", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
 	}
 
 	// Create a resource allocation request

--- a/apstra/resource_datacenter_routing_policy.go
+++ b/apstra/resource_datacenter_routing_policy.go
@@ -56,7 +56,7 @@ func (o *resourceDatacenterRoutingPolicy) Create(ctx context.Context, req resour
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
 		return
 	}
 
@@ -109,7 +109,7 @@ func (o *resourceDatacenterRoutingPolicy) Read(ctx context.Context, req resource
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("error creating client for Apstra Blueprint", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
 		return
 	}
 
@@ -148,7 +148,7 @@ func (o *resourceDatacenterRoutingPolicy) Update(ctx context.Context, req resour
 	// Create a blueprint client
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
 		return
 	}
 
@@ -207,7 +207,7 @@ func (o *resourceDatacenterRoutingPolicy) Delete(ctx context.Context, req resour
 
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
 		return
 	}
 

--- a/apstra/resource_datacenter_routing_zone.go
+++ b/apstra/resource_datacenter_routing_zone.go
@@ -129,7 +129,7 @@ func (o *resourceDatacenterRoutingZone) Create(ctx context.Context, req resource
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
 		return
 	}
 
@@ -202,7 +202,7 @@ func (o *resourceDatacenterRoutingZone) Read(ctx context.Context, req resource.R
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("error creating client for Apstra Blueprint", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
 		return
 	}
 
@@ -258,7 +258,7 @@ func (o *resourceDatacenterRoutingZone) Update(ctx context.Context, req resource
 	// Create a blueprint client
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
 		return
 	}
 
@@ -350,7 +350,7 @@ func (o *resourceDatacenterRoutingZone) Delete(ctx context.Context, req resource
 
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
 		return
 	}
 

--- a/apstra/resource_datacenter_virtual_network.go
+++ b/apstra/resource_datacenter_virtual_network.go
@@ -121,7 +121,7 @@ func (o *resourceDatacenterVirtualNetwork) Create(ctx context.Context, req resou
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
 		return
 	}
 
@@ -187,7 +187,7 @@ func (o *resourceDatacenterVirtualNetwork) Read(ctx context.Context, req resourc
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
 		return
 	}
 
@@ -222,7 +222,7 @@ func (o *resourceDatacenterVirtualNetwork) Update(ctx context.Context, req resou
 	// create a client for the datacenter reference design
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
 		return
 	}
 
@@ -287,7 +287,7 @@ func (o *resourceDatacenterVirtualNetwork) Delete(ctx context.Context, req resou
 		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
 			return
 		}
-		resp.Diagnostics.AddError("error creating blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
 		return
 	}
 


### PR DESCRIPTION
#83 was concerned with cases where we failed to invoke `resp.State.RemoveResource()`.

It turns out that `Read()` is the *only* method where that call makes sense:
- `Create()` makes the resource, so you wouldn't use it here.
- `Read()` might discover the resource missing. That's when it makes sense.
- `Update()` expects the plan to be possible to execute. Per [this comment](https://discuss.hashicorp.com/t/when-the-api-doesnt-recognize-the-object-id-during-update/53218/6) terraform will ignore attempts to remove state anyway.
- `Delete()` used to require invoking `RemoveResource()` but hasn't required it for several versions now.

After first writing up #83 I probably over-rotated on this issue, started calling `RemoveResource()` in places where it didn't make sense.

In addition to ensuring sensible use of `RemoveResource()`, some order of operations has been swapped around to ensure the blueprint exists prior to establishing the blueprint mutex.

This seems like it'll also fix #55