### PR TITLE
Fix state churn due to "description" string value `""` vs. `null` #119

### DIFF
--- a/apstra/blueprint/datacenter_routing_policy.go
+++ b/apstra/blueprint/datacenter_routing_policy.go
@@ -249,7 +249,7 @@ func (o *DatacenterRoutingPolicy) LoadApiData(ctx context.Context, policyData *a
 	}
 
 	o.Name = types.StringValue(policyData.Label)
-	o.Description = types.StringValue(policyData.Description)
+	o.Description = utils.StringValueOrNull(ctx, policyData.Description, diags)
 	o.ImportPolicy = types.StringValue(policyData.ImportPolicy.String())
 	o.ExportPolicy = exportPolicyObj
 	o.ExpectV4Default = types.BoolValue(policyData.ExpectDefaultIpv4Route)


### PR DESCRIPTION
The "description" field in resource `apstra_datacenter_routing_policy` is optional for the operator's convenience.

When omitted, that field is `null` according to the configuration.

Apstra returns an empty string in this case.

The `DatacenterRoutingPolicy.LoadApiData()` method was storing an empty string: `""`, leading to state churn between when the field was omitted by the user.

This change causes it to store a `null` string when Apstra returns `""` to prevent state churn, fixing #119.