### PR TITLE
Add missing doc string to resource `apstra_datacenter_resource_pool_allocation`

### DIFF
--- a/apstra/blueprint/pool_allocation.go
+++ b/apstra/blueprint/pool_allocation.go
@@ -53,8 +53,10 @@ func (o PoolAllocation) ResourceAttributes() map[string]resourceSchema.Attribute
 			},
 		},
 		"routing_zone_id": resourceSchema.StringAttribute{
-			MarkdownDescription: "",
-			Optional:            true,
+			MarkdownDescription: "Used to allocate a resource pool to a role associated with specific Routing Zone " +
+				"within a Blueprint, rather than to the Blueprint at large. This feature is intended for binding IP" +
+				"address pools to the per-Routing-Zone Leaf Switch Loopback IP addressing role.",
+			Optional: true,
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
 				apstravalidator.AtMostNOf(1,

--- a/apstra/blueprint/pool_allocation.go
+++ b/apstra/blueprint/pool_allocation.go
@@ -54,7 +54,7 @@ func (o PoolAllocation) ResourceAttributes() map[string]resourceSchema.Attribute
 		},
 		"routing_zone_id": resourceSchema.StringAttribute{
 			MarkdownDescription: "Used to allocate a resource pool to a role associated with specific Routing Zone " +
-				"within a Blueprint, rather than to the Blueprint at large. This feature is intended for binding IP" +
+				"within a Blueprint, rather than to the Blueprint at large. This feature is intended for binding IP " +
 				"address pools to the per-Routing-Zone Leaf Switch Loopback IP addressing role.",
 			Optional: true,
 			Validators: []validator.String{

--- a/docs/resources/datacenter_resource_pool_allocation.md
+++ b/docs/resources/datacenter_resource_pool_allocation.md
@@ -68,4 +68,4 @@ resource "apstra_datacenter_resource_pool_allocation" "ipv4" {
 
 ### Optional
 
-- `routing_zone_id` (String)
+- `routing_zone_id` (String) Used to allocate a resource pool to a role associated with specific Routing Zone within a Blueprint, rather than to the Blueprint at large. This feature is intended for binding IP address pools to the per-Routing-Zone Leaf Switch Loopback IP addressing role.


### PR DESCRIPTION
The `apstra_datacenter_resource_pool_allocation` resource's `routing_zone_id` attribute was undocumented.

Fixes #131