### PR TITLE
Bug 133: Support for `ResourceGroupNameVxlanVnIds`

### DIFF
--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -96,7 +96,8 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 		"vni": resourceSchema.Int64Attribute{
 			MarkdownDescription: fmt.Sprintf("EVPN Virtual Network ID to be associatd with this Virtual "+
 				"Network.  When omitted, Apstra chooses a VNI from the Resource Pool [allocated]"+
-				"(../apstra_datacenter_resource_pool_allocation) to role `%s`.", apstra.ResourceGroupNameEvpnL3Vni),
+				"(../apstra_datacenter_resource_pool_allocation) to role `%s`.",
+				utils.StringersToFriendlyString(apstra.ResourceGroupNameVxlanVnIds)),
 			Optional: true,
 			Computed: true,
 			Validators: []validator.Int64{

--- a/apstra/blueprint/pool_allocation.go
+++ b/apstra/blueprint/pool_allocation.go
@@ -84,7 +84,7 @@ func (o *PoolAllocation) LoadApiData(ctx context.Context, in *apstra.ResourceGro
 func (o *PoolAllocation) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.ResourceGroupAllocation {
 	// Parse 'role' into a ResourceGroupName
 	var rgName apstra.ResourceGroupName
-	err := rgName.FromString(o.Role.ValueString())
+	err := utils.ApiStringerFromFriendlyString(&rgName, o.Role.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("error parsing role %q", o.Role.ValueString()), err.Error())
 		return nil

--- a/apstra/utils/resource_group.go
+++ b/apstra/utils/resource_group.go
@@ -9,7 +9,7 @@ func AllResourceGroupNameStrings() []string {
 		if rgn == apstra.ResourceGroupNameNone {
 			continue
 		}
-		result = append(result, rgn.String())
+		result = append(result, StringersToFriendlyString(rgn))
 	}
 	return result
 }

--- a/apstra/utils/resource_group_test.go
+++ b/apstra/utils/resource_group_test.go
@@ -12,5 +12,9 @@ func TestAllResourceGroupNameStrings(t *testing.T) {
 			t.Fatal("AllResourceGroupNameStrings() returned an empty string")
 		}
 	}
+	expectedRgnCount := 20
+	if len(argns) != expectedRgnCount {
+		t.Fatalf("expected %d resource group names, got %d", expectedRgnCount, len(argns))
+	}
 	log.Println(argns)
 }

--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -20,6 +20,8 @@ const (
 	refDesignDataCenter = "datacenter"
 
 	nodeDeployModeNotSet = "not_set"
+
+	resourceGroupNameVxlanVniIds = "vni_virtual_network_ids"
 )
 
 type StringerWithFromString interface {
@@ -48,6 +50,8 @@ func StringersToFriendlyString(in ...fmt.Stringer) string {
 		return overlayControlProtocolToFriendlyString(in[0].(apstra.OverlayControlProtocol))
 	case apstra.RefDesign:
 		return refDesignToFriendlyString(in[0].(apstra.RefDesign))
+	case apstra.ResourceGroupName:
+		return resourceGroupNameToFriendlyString(in[0].(apstra.ResourceGroupName))
 	}
 
 	return in[0].String()
@@ -77,6 +81,8 @@ func ApiStringerFromFriendlyString(target StringerWithFromString, in ...string) 
 		return overlayControlProtocolFromFriendlyString(target.(*apstra.OverlayControlProtocol), in...)
 	case *apstra.RefDesign:
 		return refDesignFromFriendlyString(target.(*apstra.RefDesign), in...)
+	case *apstra.ResourceGroupName:
+		return resourceGroupNameFromFriendlyString(target.(*apstra.ResourceGroupName), in...)
 	}
 
 	return target.FromString(in[0])
@@ -142,6 +148,15 @@ func refDesignToFriendlyString(in apstra.RefDesign) string {
 	switch in {
 	case apstra.RefDesignDatacenter:
 		return refDesignDataCenter
+	}
+
+	return in.String()
+}
+
+func resourceGroupNameToFriendlyString(in apstra.ResourceGroupName) string {
+	switch in {
+	case apstra.ResourceGroupNameVxlanVnIds:
+		return resourceGroupNameVxlanVniIds
 	}
 
 	return in.String()
@@ -233,6 +248,21 @@ func refDesignFromFriendlyString(target *apstra.RefDesign, in ...string) error {
 	switch in[0] {
 	case refDesignDataCenter:
 		*target = apstra.RefDesignDatacenter
+	default:
+		return target.FromString(in[0])
+	}
+
+	return nil
+}
+
+func resourceGroupNameFromFriendlyString(target *apstra.ResourceGroupName, in ...string) error {
+	if len(in) == 0 {
+		return target.FromString("")
+	}
+
+	switch in[0] {
+	case resourceGroupNameVxlanVniIds:
+		*target = apstra.ResourceGroupNameVxlanVnIds
 	default:
 		return target.FromString(in[0])
 	}

--- a/docs/resources/datacenter_virtual_network.md
+++ b/docs/resources/datacenter_virtual_network.md
@@ -66,7 +66,7 @@ resource "apstra_datacenter_virtual_network" "test" {
 - `reserve_vlan` (Boolean) For use only with `%s` type Virtual networks when all `bindings` use the same VLAN ID. This option reserves the VLAN fabric-wide, even on switches to which the Virtual Network has not yet been deployed. The only accepted values is `true`.
 - `routing_zone_id` (String) Routing Zone ID (required when `type == vxlan`
 - `type` (String) Virtual Network Type
-- `vni` (Number) EVPN Virtual Network ID to be associatd with this Virtual Network.  When omitted, Apstra chooses a VNI from the Resource Pool [allocated](../apstra_datacenter_resource_pool_allocation) to role `evpn_l3_vnis`.
+- `vni` (Number) EVPN Virtual Network ID to be associatd with this Virtual Network.  When omitted, Apstra chooses a VNI from the Resource Pool [allocated](../apstra_datacenter_resource_pool_allocation) to role `vni_virtual_network_ids`.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20230525181310-bbaf3065d735
+	github.com/Juniper/apstra-go-sdk v0.0.0-20230601231402-112e92564e56
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
@@ -17,7 +17,7 @@ require (
 )
 
 //                                                                                          HHMMSS
-replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230526032236-a96567c7a1fb
+replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230602000120-6ef49a082779
 
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20230601231402-112e92564e56
+	github.com/Juniper/apstra-go-sdk v0.0.0-20230602113116-07b5ef34fcf7
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
@@ -17,7 +17,7 @@ require (
 )
 
 //                                                                                          HHMMSS
-replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230602000120-6ef49a082779
+//replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230602000120-6ef49a082779
 
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230602000120-6ef49a082779 h1:FQFTtdU0alPZvT26qXxL3EXuE+CHM46tYk60dSTUeBg=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230602000120-6ef49a082779/go.mod h1:PKQO0TF/UB7vSaD3KtIlNT6VlYSuJRfPVE2loT9C/lM=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230602113116-07b5ef34fcf7 h1:btALDE+ja9w/sVOn6QBYOefNYqwPPlB4FvauHBHcves=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230602113116-07b5ef34fcf7/go.mod h1:PKQO0TF/UB7vSaD3KtIlNT6VlYSuJRfPVE2loT9C/lM=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230526032236-a96567c7a1fb h1:zMDGqq+jeLWWh7yt0FXVRRjva6XlAemFRQLVSQJHx5k=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230526032236-a96567c7a1fb/go.mod h1:PKQO0TF/UB7vSaD3KtIlNT6VlYSuJRfPVE2loT9C/lM=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230602000120-6ef49a082779 h1:FQFTtdU0alPZvT26qXxL3EXuE+CHM46tYk60dSTUeBg=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230602000120-6ef49a082779/go.mod h1:PKQO0TF/UB7vSaD3KtIlNT6VlYSuJRfPVE2loT9C/lM=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=


### PR DESCRIPTION
Pulls in: https://github.com/Juniper/apstra-go-sdk/pull/39 which introduces `ResourceGroupNameVxlanVnIds`

Additionally this PR introduces a rosetta handler for the `ResourceGroupName` iota/stringer type and use of that handler in the `apstra_datacenter_resource_pool_allocation` logic.