### PR TITLE
bug #144: Suppress API error on 404

### DIFF
--- a/apstra/resource_interface_map.go
+++ b/apstra/resource_interface_map.go
@@ -307,8 +307,6 @@ type rInterfaceMap struct {
 }
 
 func (o *rInterfaceMap) fetchEmbeddedObjects(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) (*apstra.LogicalDevice, *apstra.DeviceProfile) {
-	var ace apstra.ApstraClientErr
-
 	// fetch the logical device
 	ld, err := client.GetLogicalDevice(ctx, apstra.ObjectId(o.LogicalDeviceId.ValueString()))
 	if err != nil {

--- a/apstra/resource_interface_map.go
+++ b/apstra/resource_interface_map.go
@@ -307,14 +307,16 @@ type rInterfaceMap struct {
 
 func (o *rInterfaceMap) fetchEmbeddedObjects(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) (*apstra.LogicalDevice, *apstra.DeviceProfile) {
 	var ace apstra.ApstraClientErr
+
 	// fetch the logical device
 	ld, err := client.GetLogicalDevice(ctx, apstra.ObjectId(o.LogicalDeviceId.ValueString()))
 	if err != nil {
 		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
 			diags.AddAttributeError(path.Root("logical_device_id"), errInvalidConfig,
-				fmt.Sprintf("logical device'%s' not found", o.DeviceProfileId.ValueString()))
+				fmt.Sprintf("logical device %q not found", o.DeviceProfileId))
+		} else {
+			diags.AddError("error while fetching logical device", err.Error())
 		}
-		diags.AddError("error while fetching logical device", err.Error())
 	}
 
 	// fetch the device profile specified by the user
@@ -322,9 +324,10 @@ func (o *rInterfaceMap) fetchEmbeddedObjects(ctx context.Context, client *apstra
 	if err != nil {
 		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
 			diags.AddAttributeError(path.Root("device_profile_id"), errInvalidConfig,
-				fmt.Sprintf("device profile '%s' not found", o.DeviceProfileId.ValueString()))
+				fmt.Sprintf("device profile %q not found", o.DeviceProfileId))
+		} else {
+			diags.AddError("error while fetching device profile", err.Error())
 		}
-		diags.AddError("error while fetching device profile", err.Error())
 	}
 
 	return ld, dp
@@ -346,6 +349,7 @@ func (o *rInterfaceMap) ldPortNames(ctx context.Context, diags *diag.Diagnostics
 	for i, planIntf := range interfaces {
 		result[i] = planIntf.LogicalDevicePort.ValueString()
 	}
+
 	return result
 }
 

--- a/apstra/resource_interface_map.go
+++ b/apstra/resource_interface_map.go
@@ -315,7 +315,7 @@ func (o *rInterfaceMap) fetchEmbeddedObjects(ctx context.Context, client *apstra
 			diags.AddAttributeError(path.Root("logical_device_id"), errInvalidConfig,
 				fmt.Sprintf("logical device %q not found", o.DeviceProfileId))
 		} else {
-			diags.AddError("error while fetching logical device", err.Error())
+			diags.AddError("failed to fetch logical device", err.Error())
 		}
 	}
 
@@ -326,7 +326,7 @@ func (o *rInterfaceMap) fetchEmbeddedObjects(ctx context.Context, client *apstra
 			diags.AddAttributeError(path.Root("device_profile_id"), errInvalidConfig,
 				fmt.Sprintf("device profile %q not found", o.DeviceProfileId))
 		} else {
-			diags.AddError("error while fetching device profile", err.Error())
+			diags.AddError("failed to fetch device profile", err.Error())
 		}
 	}
 

--- a/apstra/resource_interface_map.go
+++ b/apstra/resource_interface_map.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 const (
@@ -311,7 +312,7 @@ func (o *rInterfaceMap) fetchEmbeddedObjects(ctx context.Context, client *apstra
 	// fetch the logical device
 	ld, err := client.GetLogicalDevice(ctx, apstra.ObjectId(o.LogicalDeviceId.ValueString()))
 	if err != nil {
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			diags.AddAttributeError(path.Root("logical_device_id"), errInvalidConfig,
 				fmt.Sprintf("logical device %q not found", o.DeviceProfileId))
 		} else {
@@ -322,7 +323,7 @@ func (o *rInterfaceMap) fetchEmbeddedObjects(ctx context.Context, client *apstra
 	// fetch the device profile specified by the user
 	dp, err := client.GetDeviceProfile(ctx, apstra.ObjectId(o.DeviceProfileId.ValueString()))
 	if err != nil {
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			diags.AddAttributeError(path.Root("device_profile_id"), errInvalidConfig,
 				fmt.Sprintf("device profile %q not found", o.DeviceProfileId))
 		} else {


### PR DESCRIPTION
resource `apstra_interface_map` triggers multiple diagnostics when encountering a 404 while fetching device profile or logical device.

This PR ensures that only the "not found" or the API error is surfaced to the user and fixes #144.