### PR TITLE
review of `data_source_datacenter_property_set.go` and `data_source_datacenter_property_sets.go`

### DIFF
--- a/apstra/resource_datacenter_property_set.go
+++ b/apstra/resource_datacenter_property_set.go
@@ -98,20 +98,20 @@ func (o *resourceDatacenterPropertySet) Read(ctx context.Context, req resource.R
 	bpClient, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
 	var api *apstra.TwoStageL3ClosPropertySet
 	switch {
-	case !plan.Label.IsNull():
-		api, err = bpClient.GetPropertySetByName(ctx, plan.Label.ValueString())
+	case !plan.Name.IsNull():
+		api, err = bpClient.GetPropertySetByName(ctx, plan.Name.ValueString())
 		if err != nil {
 			if utils.IsApstra404(err) {
 				resp.Diagnostics.AddAttributeError(
 					path.Root("name"),
 					"DatacenterPropertySet not found",
-					fmt.Sprintf("DatacenterPropertySet with label %q not found", plan.Label.ValueString()))
+					fmt.Sprintf("DatacenterPropertySet with label %q not found", plan.Name.ValueString()))
 				return
 			}
 			resp.Diagnostics.AddAttributeError(
 				path.Root("name"),
 				"Error Getting DatacenterPropertySet",
-				fmt.Sprintf("DatacenterPropertySet with label %q failed with error %q", plan.Label.ValueString(), err.Error()))
+				fmt.Sprintf("DatacenterPropertySet with label %q failed with error %q", plan.Name.ValueString(), err.Error()))
 			return
 		}
 	case !plan.Id.IsNull():

--- a/docs/data-sources/datacenter_property_set.md
+++ b/docs/data-sources/datacenter_property_set.md
@@ -50,7 +50,7 @@ output "o" {
 ### Optional
 
 - `id` (String) Populate this field to look up an imported Property Set by ID. Required when `name` is omitted.
-- `name` (String) Populate this field to look up an imported Property Set by name. Required when `id` is omitted.
+- `name` (String) Populate this field to look up an imported Property Set by `name`. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/datacenter_property_sets.md
+++ b/docs/data-sources/datacenter_property_sets.md
@@ -22,35 +22,16 @@ data "apstra_datacenter_blueprint" "b" {
 data "apstra_datacenter_property_sets" "ps" {
   blueprint_id = data.apstra_datacenter_blueprint.b.id
 }
+
 output "o" {
   value = data.apstra_datacenter_property_sets.ps
 }
 
 #Output looks something like this
 #o = {
-#  "blueprint_id" = "d6c74373-45ce-4d88-9547-ac23c2ebe61e"
-#  "property_sets" = toset([
-#    {
-#      "blueprint_id" = "d6c74373-45ce-4d88-9547-ac23c2ebe61e"
-#      "data" = "{\"junos_mgmt_vrf\": \"mgmt_junos\", \"mgmt_vrf\": \"management\"}"
-#      "id" = "3ae45f2e-c9ed-401b-8f00-367fb9a5e0e8"
-#      "keys" = toset([
-#        "junos_mgmt_vrf",
-#        "mgmt_vrf",
-#      ])
-#      "name" = "MGMT VRF"
-#      "stale" = false
-#    },
-#    {
-#      "blueprint_id" = "d6c74373-45ce-4d88-9547-ac23c2ebe61e"
-#      "data" = "{\"ntp_server\": \"172.20.12.4\"}"
-#      "id" = "8e1c1316-857d-4a49-a10d-5a61063bc38c"
-#      "keys" = toset([
-#        "ntp_server",
-#      ])
-#      "name" = "NTP Server"
-#      "stale" = false
-#    },
+#  "blueprint_id" = "621a5671-970f-402c-ae13-6b83834b5255"
+#  "ids" = toset([
+#    "a60a45fe-7466-48e1-8ca7-b6008de1c1e5",
 #  ])
 #}
 ```
@@ -64,4 +45,4 @@ output "o" {
 
 ### Read-Only
 
-- `property_sets` (Set of String) Set of Ids of Property Sets that have been imported.
+- `ids` (Set of String) Set of IDs of Property Sets imported into the Blueprint.

--- a/docs/resources/datacenter_property_set.md
+++ b/docs/resources/datacenter_property_set.md
@@ -47,14 +47,14 @@ output "p" {
 ### Required
 
 - `blueprint_id` (String) Apstra Blueprint ID. Used to identify the Blueprint that the Property Set is imported into.
+- `id` (String) ID of the Property Set ID to be imported.
 
 ### Optional
 
-- `id` (String) Populate this field to look up an imported Property Set by ID. Required when `name` is omitted.
 - `keys` (Set of String) Subset of Keys to import. Omit to import all keys.
-- `name` (String) Populate this field to look up an imported Property Set by name. Required when `id` is omitted.
 
 ### Read-Only
 
 - `data` (String) A map of values in the Property Set in JSON format.
+- `name` (String) Property Set name as shown in the Web UI.
 - `stale` (Boolean) Stale as reported in the Web UI.

--- a/examples/data-sources/apstra_datacenter_property_sets/example.tf
+++ b/examples/data-sources/apstra_datacenter_property_sets/example.tf
@@ -8,34 +8,15 @@ data "apstra_datacenter_blueprint" "b" {
 data "apstra_datacenter_property_sets" "ps" {
   blueprint_id = data.apstra_datacenter_blueprint.b.id
 }
+
 output "o" {
   value = data.apstra_datacenter_property_sets.ps
 }
 
 #Output looks something like this
 #o = {
-#  "blueprint_id" = "d6c74373-45ce-4d88-9547-ac23c2ebe61e"
-#  "property_sets" = toset([
-#    {
-#      "blueprint_id" = "d6c74373-45ce-4d88-9547-ac23c2ebe61e"
-#      "data" = "{\"junos_mgmt_vrf\": \"mgmt_junos\", \"mgmt_vrf\": \"management\"}"
-#      "id" = "3ae45f2e-c9ed-401b-8f00-367fb9a5e0e8"
-#      "keys" = toset([
-#        "junos_mgmt_vrf",
-#        "mgmt_vrf",
-#      ])
-#      "name" = "MGMT VRF"
-#      "stale" = false
-#    },
-#    {
-#      "blueprint_id" = "d6c74373-45ce-4d88-9547-ac23c2ebe61e"
-#      "data" = "{\"ntp_server\": \"172.20.12.4\"}"
-#      "id" = "8e1c1316-857d-4a49-a10d-5a61063bc38c"
-#      "keys" = toset([
-#        "ntp_server",
-#      ])
-#      "name" = "NTP Server"
-#      "stale" = false
-#    },
+#  "blueprint_id" = "621a5671-970f-402c-ae13-6b83834b5255"
+#  "ids" = toset([
+#    "a60a45fe-7466-48e1-8ca7-b6008de1c1e5",
 #  ])
 #}


### PR DESCRIPTION
I don't think I broke anything, but I'm most worried about schema stuff, so please pay special attention there.

We don't currently correct the situation where the property set has been re-imported via the web UI. We should explore detecting/correcting that condition.

We should also talk about the implications of the user specifying a key which doesn't exist.