### PR TITLE
introduce data source `apstra_anomalies`

### DIFF
--- a/apstra/blueprint/anomalies.go
+++ b/apstra/blueprint/anomalies.go
@@ -1,0 +1,117 @@
+package blueprint
+
+import (
+	"context"
+	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-apstra/apstra/utils"
+)
+
+type Anomalies struct {
+	BlueprintId      types.String `tfsdk:"blueprint_id"`
+	Details          types.Set    `tfsdk:"details"`
+	SummaryByNode    types.Set    `tfsdk:"summary_by_node"`
+	SummaryByService types.Set    `tfsdk:"summary_by_service"`
+}
+
+func (o Anomalies) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
+	return map[string]dataSourceSchema.Attribute{
+		"blueprint_id": dataSourceSchema.StringAttribute{
+			Required:            true,
+			MarkdownDescription: "Apstra Blueprint ID.",
+			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
+		},
+		"details": dataSourceSchema.SetNestedAttribute{
+			NestedObject:        dataSourceSchema.NestedAttributeObject{Attributes: anomalyDetail{}.dataSourceAttributes()},
+			Computed:            true,
+			MarkdownDescription: "Each current Anomaly is represented by an object in this set.",
+		},
+		"summary_by_node": dataSourceSchema.SetNestedAttribute{
+			NestedObject:        dataSourceSchema.NestedAttributeObject{Attributes: anomalyNodeSummary{}.dataSourceAttributes()},
+			Computed:            true,
+			MarkdownDescription: "Set of Anomaly summaries organized by Node.",
+		},
+		"summary_by_service": dataSourceSchema.SetNestedAttribute{
+			NestedObject:        dataSourceSchema.NestedAttributeObject{Attributes: anomalyServiceSummary{}.dataSourceAttributes()},
+			Computed:            true,
+			MarkdownDescription: "Set of Anomaly summaries organized by Fabric Service.",
+		},
+	}
+}
+
+func (o *Anomalies) ReadFromApi(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
+	o.ReadAnomalyDetailsFromApi(ctx, client, diags)
+	if diags.HasError() {
+		return
+	}
+
+	o.ReadAnomalyNodeSummariesFromApi(ctx, client, diags)
+	if diags.HasError() {
+		return
+	}
+
+	o.ReadAnomalyServiceSummariesFromApi(ctx, client, diags)
+	if diags.HasError() {
+		return
+	}
+}
+
+func (o *Anomalies) ReadAnomalyDetailsFromApi(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
+	anomalies, err := client.GetBlueprintAnomalies(ctx, apstra.ObjectId(o.BlueprintId.ValueString()))
+	if err != nil {
+		if utils.IsApstra404(err) {
+			diags.AddAttributeError(
+				path.Root("blueprint_id"),
+				"not found",
+				fmt.Sprintf("Blueprint %s not found", o.BlueprintId),
+			)
+			return
+		}
+		diags.AddError(fmt.Sprintf("unable to fetch Blueprint %s Anomalies from API", o.BlueprintId), err.Error())
+		return
+	}
+
+	o.Details = newAnomalyDetailSet(ctx, anomalies, diags)
+}
+
+func (o *Anomalies) ReadAnomalyNodeSummariesFromApi(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
+	nodeSummaries, err := client.GetBlueprintNodeAnomalyCounts(ctx, apstra.ObjectId(o.BlueprintId.ValueString()))
+	if err != nil {
+		if utils.IsApstra404(err) {
+			diags.AddAttributeError(
+				path.Root("blueprint_id"),
+				"not found",
+				fmt.Sprintf("Blueprint %s not found", o.BlueprintId),
+			)
+			return
+		}
+		diags.AddError(fmt.Sprintf("unable to fetch Blueprint %s per-Node Anomaly Summaries from API", o.BlueprintId), err.Error())
+		return
+	}
+
+	o.SummaryByNode = newAnomalyNodeSummarySet(ctx, nodeSummaries, diags)
+}
+
+func (o *Anomalies) ReadAnomalyServiceSummariesFromApi(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
+	serviceSummaries, err := client.GetBlueprintServiceAnomalyCounts(ctx, apstra.ObjectId(o.BlueprintId.ValueString()))
+	if err != nil {
+		if utils.IsApstra404(err) {
+			diags.AddAttributeError(
+				path.Root("blueprint_id"),
+				"not found",
+				fmt.Sprintf("Blueprint %s not found", o.BlueprintId),
+			)
+			return
+		}
+		diags.AddError(fmt.Sprintf("unable to fetch Blueprint %s per-Service Anomaly Summaries from API", o.BlueprintId), err.Error())
+		return
+	}
+
+	o.SummaryByService = newAnomalyServiceSummarySet(ctx, serviceSummaries, diags)
+}

--- a/apstra/blueprint/anomalies_by_node.go
+++ b/apstra/blueprint/anomalies_by_node.go
@@ -1,0 +1,179 @@
+package blueprint
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-apstra/apstra/utils"
+)
+
+type anomalyNodeSummary struct {
+	NodeName           types.String `tfsdk:"node_name"`
+	SystemId           types.String `tfsdk:"system_id"`
+	Total              types.Int64  `tfsdk:"total"`
+	Arp                types.Int64  `tfsdk:"arp"`
+	Bgp                types.Int64  `tfsdk:"bgp"`
+	BlueprintRendering types.Int64  `tfsdk:"blueprint_rendering"`
+	Cabling            types.Int64  `tfsdk:"cabling"`
+	Config             types.Int64  `tfsdk:"config"`
+	Counter            types.Int64  `tfsdk:"counter"`
+	Deployment         types.Int64  `tfsdk:"deployment"`
+	Hostname           types.Int64  `tfsdk:"hostname"`
+	Interface          types.Int64  `tfsdk:"interface"`
+	Lag                types.Int64  `tfsdk:"lag"`
+	Liveness           types.Int64  `tfsdk:"liveness"`
+	Mac                types.Int64  `tfsdk:"mac"`
+	Mlag               types.Int64  `tfsdk:"mlag"`
+	Probe              types.Int64  `tfsdk:"probe"`
+	Route              types.Int64  `tfsdk:"route"`
+	Series             types.Int64  `tfsdk:"series"`
+	Streaming          types.Int64  `tfsdk:"streaming"`
+}
+
+func (o anomalyNodeSummary) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"node_name":           types.StringType,
+		"system_id":           types.StringType,
+		"total":               types.Int64Type,
+		"arp":                 types.Int64Type,
+		"bgp":                 types.Int64Type,
+		"blueprint_rendering": types.Int64Type,
+		"cabling":             types.Int64Type,
+		"config":              types.Int64Type,
+		"counter":             types.Int64Type,
+		"deployment":          types.Int64Type,
+		"hostname":            types.Int64Type,
+		"interface":           types.Int64Type,
+		"lag":                 types.Int64Type,
+		"liveness":            types.Int64Type,
+		"mac":                 types.Int64Type,
+		"mlag":                types.Int64Type,
+		"probe":               types.Int64Type,
+		"route":               types.Int64Type,
+		"series":              types.Int64Type,
+		"streaming":           types.Int64Type,
+	}
+}
+
+func (o anomalyNodeSummary) dataSourceAttributes() map[string]dataSourceSchema.Attribute {
+	return map[string]dataSourceSchema.Attribute{
+		"node_name": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "Name of the Node experiencing Anomalies.",
+			Computed:            true,
+		},
+		"system_id": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "System ID of the Node experiencing Anomalies.",
+			Computed:            true,
+		},
+		"total": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Total number of Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"arp": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of ARP Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"bgp": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of BGP Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"blueprint_rendering": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Blueprint Rendering Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"cabling": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Cabling Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"config": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Config Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"counter": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Counter Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"deployment": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Deployment Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"hostname": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Hostname Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"interface": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Interface Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"lag": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of LAG Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"liveness": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Liveness Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"mac": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of MAC Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"mlag": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of MLAG Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"probe": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Probe Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"route": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Route Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"series": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Series Anomalies related to the Node.",
+			Computed:            true,
+		},
+		"streaming": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Number of Streaming Anomalies related to the Node.",
+			Computed:            true,
+		},
+	}
+}
+
+func (o *anomalyNodeSummary) loadApiData(_ context.Context, in *apstra.BlueprintNodeAnomalyCounts, _ *diag.Diagnostics) {
+	o.NodeName = types.StringValue(in.Node)
+	o.SystemId = types.StringValue(in.SystemId.String())
+	o.Total = types.Int64Value(int64(in.All))
+	o.Arp = types.Int64Value(int64(in.Arp))
+	o.Bgp = types.Int64Value(int64(in.Bgp))
+	o.BlueprintRendering = types.Int64Value(int64(in.BlueprintRendering))
+	o.Cabling = types.Int64Value(int64(in.Cabling))
+	o.Config = types.Int64Value(int64(in.Config))
+	o.Counter = types.Int64Value(int64(in.Counter))
+	o.Deployment = types.Int64Value(int64(in.Deployment))
+	o.Hostname = types.Int64Value(int64(in.Hostname))
+	o.Interface = types.Int64Value(int64(in.Interface))
+	o.Lag = types.Int64Value(int64(in.Lag))
+	o.Liveness = types.Int64Value(int64(in.Liveness))
+	o.Mac = types.Int64Value(int64(in.Mac))
+	o.Mlag = types.Int64Value(int64(in.Mlag))
+	o.Probe = types.Int64Value(int64(in.Probe))
+	o.Route = types.Int64Value(int64(in.Route))
+	o.Series = types.Int64Value(int64(in.Series))
+	o.Streaming = types.Int64Value(int64(in.Streaming))
+}
+
+func newAnomalyNodeSummarySet(ctx context.Context, in []apstra.BlueprintNodeAnomalyCounts, diags *diag.Diagnostics) types.Set {
+	nodeSummaries := make([]anomalyNodeSummary, len(in))
+	for i, nodeSummary := range in {
+		nodeSummaries[i].loadApiData(ctx, &nodeSummary, diags)
+	}
+	if diags.HasError() {
+		return types.SetNull(types.ObjectType{AttrTypes: anomalyNodeSummary{}.attrTypes()})
+	}
+
+	return utils.SetValueOrNull(ctx, types.ObjectType{AttrTypes: anomalyNodeSummary{}.attrTypes()}, nodeSummaries, diags)
+}

--- a/apstra/blueprint/anomalies_by_service.go
+++ b/apstra/blueprint/anomalies_by_service.go
@@ -1,0 +1,60 @@
+package blueprint
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-apstra/apstra/utils"
+)
+
+type anomalyServiceSummary struct {
+	AnomalyType types.String `tfsdk:"type"`
+	Role        types.String `tfsdk:"role"`
+	Count       types.Int64  `tfsdk:"count"`
+}
+
+func (o anomalyServiceSummary) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"type":  types.StringType,
+		"role":  types.StringType,
+		"count": types.Int64Type,
+	}
+}
+
+func (o anomalyServiceSummary) dataSourceAttributes() map[string]dataSourceSchema.Attribute {
+	return map[string]dataSourceSchema.Attribute{
+		"type": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "Fabric Service experiencing Anomalies.",
+			Computed:            true,
+		},
+		"role": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "Further context about the Fabric Service Anomalies.",
+			Computed:            true,
+		},
+		"count": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "Count of Anomalies related to the Fabric Service and Role.",
+			Computed:            true,
+		},
+	}
+}
+
+func (o *anomalyServiceSummary) loadApiData(_ context.Context, in *apstra.BlueprintServiceAnomalyCount, _ *diag.Diagnostics) {
+	o.AnomalyType = types.StringValue(in.AnomalyType)
+	o.Role = types.StringValue(in.Role)
+	o.Count = types.Int64Value(int64(in.Count))
+}
+
+func newAnomalyServiceSummarySet(ctx context.Context, in []apstra.BlueprintServiceAnomalyCount, diags *diag.Diagnostics) types.Set {
+	serviceSummaries := make([]anomalyServiceSummary, len(in))
+	for i, serviceSummary := range in {
+		serviceSummaries[i].loadApiData(ctx, &serviceSummary, diags)
+	}
+	if diags.HasError() {
+		return types.SetNull(types.ObjectType{AttrTypes: anomalyServiceSummary{}.attrTypes()})
+	}
+
+	return utils.SetValueOrNull(ctx, types.ObjectType{AttrTypes: anomalyServiceSummary{}.attrTypes()}, serviceSummaries, diags)
+}

--- a/apstra/blueprint/anomalies_detail.go
+++ b/apstra/blueprint/anomalies_detail.go
@@ -1,0 +1,100 @@
+package blueprint
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-apstra/apstra/utils"
+)
+
+type anomalyDetail struct {
+	AnomalyId   types.String `tfsdk:"anomaly_id"`
+	Severity    types.String `tfsdk:"severity"`
+	AnomalyType types.String `tfsdk:"type"`
+	Expected    types.String `tfsdk:"expected"`
+	Actual      types.String `tfsdk:"actual"`
+	Identity    types.String `tfsdk:"identity"`
+	Role        types.String `tfsdk:"role"`
+	Anomalous   types.String `tfsdk:"anomalous"`
+}
+
+func (o anomalyDetail) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"anomaly_id": types.StringType,
+		"severity":   types.StringType,
+		"type":       types.StringType,
+		"expected":   types.StringType,
+		"actual":     types.StringType,
+		"identity":   types.StringType,
+		"role":       types.StringType,
+		"anomalous":  types.StringType,
+	}
+}
+
+func (o anomalyDetail) dataSourceAttributes() map[string]dataSourceSchema.Attribute {
+	return map[string]dataSourceSchema.Attribute{
+		"anomaly_id": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "Apstra Anomaly ID.",
+			Computed:            true,
+		},
+		"severity": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "Severity of Anomaly.",
+			Computed:            true,
+		},
+		"type": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "Anomaly Type.",
+			Computed:            true,
+		},
+		"expected": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "Extended Anomaly attribute describing the expected value/state/condition in JSON format.",
+			Computed:            true,
+		},
+		"actual": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "Extended Anomaly attribute describing the actual value/state/condition in JSON format.",
+			Computed:            true,
+		},
+		"identity": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "Extended Anomaly attribute which identifies the anomalous value/state/condition in JSON format.",
+			Computed:            true,
+		},
+		"role": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "Anomaly role further contextualizes `type`.",
+			Computed:            true,
+		},
+		"anomalous": dataSourceSchema.StringAttribute{
+			MarkdownDescription: "Extended Anomaly attribute which further contextualizes the Anomaly.",
+			Computed:            true,
+		},
+	}
+}
+
+func (o *anomalyDetail) loadApiData(ctx context.Context, in *apstra.BlueprintAnomaly, diags *diag.Diagnostics) {
+	var role string
+	if in.Role != nil {
+		role = *in.Role
+	}
+
+	o.AnomalyId = types.StringValue(in.Id.String())
+	o.Severity = types.StringValue(in.Severity)
+	o.AnomalyType = types.StringValue(in.AnomalyType)
+	o.Expected = utils.StringValueOrNull(ctx, string(in.Expected), diags)
+	o.Actual = utils.StringValueOrNull(ctx, string(in.Actual), diags)
+	o.Identity = utils.StringValueOrNull(ctx, string(in.Identity), diags)
+	o.Role = utils.StringValueOrNull(ctx, role, diags)
+	o.Anomalous = utils.StringValueOrNull(ctx, string(in.Anomalous), diags)
+}
+
+func newAnomalyDetailSet(ctx context.Context, in []apstra.BlueprintAnomaly, diags *diag.Diagnostics) types.Set {
+	anomalyDetails := make([]anomalyDetail, len(in))
+	for i, anomalyDetail := range in {
+		anomalyDetails[i].loadApiData(ctx, &anomalyDetail, diags)
+	}
+	if diags.HasError() {
+		return types.SetNull(types.ObjectType{AttrTypes: anomalyDetail{}.attrTypes()})
+	}
+
+	return utils.SetValueOrNull(ctx, types.ObjectType{AttrTypes: anomalyDetail{}.attrTypes()}, anomalyDetails, diags)
+}

--- a/apstra/data_source_anomalies.go
+++ b/apstra/data_source_anomalies.go
@@ -1,0 +1,50 @@
+package tfapstra
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	_ "github.com/hashicorp/terraform-plugin-framework/provider"
+	"terraform-provider-apstra/apstra/blueprint"
+)
+
+var _ datasource.DataSourceWithConfigure = &dataSourceAnomalies{}
+
+type dataSourceAnomalies struct {
+	client *apstra.Client
+}
+
+func (o *dataSourceAnomalies) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_anomalies"
+}
+
+func (o *dataSourceAnomalies) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	o.client = DataSourceGetClient(ctx, req, resp)
+}
+
+func (o *dataSourceAnomalies) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "This data source provides per-node summary, " +
+			"per-service summary and full details of anomalies in the specified Blueprint.",
+		Attributes: blueprint.Anomalies{}.DataSourceAttributes(),
+	}
+}
+
+func (o *dataSourceAnomalies) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	if o.client == nil {
+		resp.Diagnostics.AddError(errDataSourceUnconfiguredSummary, errDatasourceUnconfiguredDetail)
+		return
+	}
+
+	var config blueprint.Anomalies
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	config.ReadFromApi(ctx, o.client, &resp.Diagnostics)
+
+	// set state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}

--- a/apstra/provider.go
+++ b/apstra/provider.go
@@ -294,6 +294,7 @@ func (p *Provider) DataSources(_ context.Context) []func() datasource.DataSource
 		func() datasource.DataSource { return &dataSourceAgents{} },
 		func() datasource.DataSource { return &dataSourceAgentProfile{} },
 		func() datasource.DataSource { return &dataSourceAgentProfiles{} },
+		func() datasource.DataSource { return &dataSourceAnomalies{} },
 		func() datasource.DataSource { return &dataSourceAsnPool{} },
 		func() datasource.DataSource { return &dataSourceAsnPools{} },
 		func() datasource.DataSource { return &dataSourceBlueprintDeploy{} },

--- a/docs/data-sources/anomalies.md
+++ b/docs/data-sources/anomalies.md
@@ -1,0 +1,453 @@
+---
+page_title: "apstra_anomalies Data Source - terraform-provider-apstra"
+subcategory: ""
+description: |-
+  This data source provides per-node summary, per-service summary and full details of anomalies in the specified Blueprint.
+---
+
+# apstra_anomalies (Data Source)
+
+This data source provides per-node summary, per-service summary and full details of anomalies in the specified Blueprint.
+
+## Example Usage
+
+```terraform
+# This example pulls all of the anomaly details from a blueprint with several
+# cabling mistakes which produce a total of 21 anomalies.
+data "apstra_anomalies" "anomalies" {
+  blueprint_id = "c8fe07d6-f631-46e6-ae2a-9c6f3929e6a3"
+}
+
+output anomalies { value = data.apstra_anomalies.anomalies }
+
+# The output looks like this:
+
+#anomalies = {
+#  "blueprint_id" = "c8fe07d6-f631-46e6-ae2a-9c6f3929e6a3"
+#  "details" = toset([
+#    {
+#      "actual" = "{\"interfaces_up\":[],\"intf_up_count\":0}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "40403043-dba1-4546-9a7e-00d92858d590"
+#      "expected" = "{\"interfaces_up\":[\"ge-0/0/0\"],\"intf_up_count\":1}"
+#      "identity" = "{\"anomaly_type\":\"lag\",\"lag\":\"ae1\",\"system_id\":\"525400240557\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "lag"
+#    },
+#    {
+#      "actual" = "{\"interfaces_up\":[],\"intf_up_count\":0}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "4bdd2de3-2022-4151-82f2-e734e57a5619"
+#      "expected" = "{\"interfaces_up\":[\"ge-0/0/1\"],\"intf_up_count\":1}"
+#      "identity" = "{\"anomaly_type\":\"lag\",\"lag\":\"ae1\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "lag"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/0\",\"neighbor_name\":\"test-001-access1\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "76692c7a-2067-4372-8906-02a015825557"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/0\",\"neighbor_name\":\"test-001-leaf2\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/1\",\"system_id\":\"5254008A8F34\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/0\",\"neighbor_name\":\"test-001-access2\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "cde14dba-daf0-4bf3-9b49-a718cfc3694d"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/0\",\"neighbor_name\":\"test-001-access1\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/1\",\"system_id\":\"525400523E0A\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/1\",\"neighbor_name\":\"spine1\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "e9e29a10-386d-4d87-bf5c-91c0db7eb878"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/1\",\"neighbor_name\":\"test-001-leaf1\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/0\",\"system_id\":\"525400240557\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/1\",\"neighbor_name\":\"test-001-leaf1\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "294822e8-7d8f-4978-9ccb-749ea373c6e8"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/1\",\"neighbor_name\":\"test-001-leaf2\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/0\",\"system_id\":\"525400101F55\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/2\",\"neighbor_name\":\"spine1\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "9e7b289e-f106-4856-add7-e4566ee57314"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/1\",\"neighbor_name\":\"spine1\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/0\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/2\",\"neighbor_name\":\"test-001-access2\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "31d7aa87-efb3-4695-9312-0580d9c4ea27"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/0\",\"neighbor_name\":\"test-001-access2\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/1\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "0cf491f3-031a-4fa2-8daa-61aa23bbe045"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"addr_family\":\"evpn\",\"anomaly_type\":\"bgp\",\"destination_asn\":\"4200000002\",\"destination_ip\":\"10.60.60.2\",\"destination_name\":\"test-001-leaf2\",\"source_asn\":\"4200000000\",\"source_ip\":\"10.60.60.0\",\"system_id\":\"5254008A8F34\",\"vrf_name\":\"default\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "bgp"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "1fd5a3c3-07cf-4b97-81f2-b6e1153b48ee"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"interface\",\"interface\":\"ae1.0\",\"system_id\":\"525400240557\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "interface"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "2058be80-5be3-4787-b09b-a46935c52974"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"addr_family\":\"ipv4\",\"anomaly_type\":\"bgp\",\"destination_asn\":\"4200000000\",\"destination_ip\":\"10.60.60.8\",\"destination_name\":\"spine1\",\"source_asn\":\"4200000002\",\"source_ip\":\"10.60.60.9\",\"system_id\":\"525400E19D40\",\"vrf_name\":\"default\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "bgp"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "3dca6d8b-23ab-4636-b446-48b3979967f4"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"interface\",\"interface\":\"ae1.0\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "interface"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "3fdd09db-832d-4186-8e8a-81ec69cf9837"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"interface\",\"interface\":\"ae1\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "interface"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "8a8b0438-b751-46c4-a3ea-992a58fe1d0d"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"addr_family\":\"ipv4\",\"anomaly_type\":\"bgp\",\"destination_asn\":\"4200000002\",\"destination_ip\":\"10.60.60.9\",\"destination_name\":\"test-001-leaf2\",\"source_asn\":\"4200000000\",\"source_ip\":\"10.60.60.8\",\"system_id\":\"5254008A8F34\",\"vrf_name\":\"default\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "bgp"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "bba106ea-ed79-4268-81f4-dad5ce3f45b9"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"addr_family\":\"evpn\",\"anomaly_type\":\"bgp\",\"destination_asn\":\"4200000000\",\"destination_ip\":\"10.60.60.0\",\"destination_name\":\"spine1\",\"source_asn\":\"4200000002\",\"source_ip\":\"10.60.60.2\",\"system_id\":\"525400E19D40\",\"vrf_name\":\"default\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "bgp"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "e73513eb-9393-4893-8306-7e0f23e4a4a2"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"interface\",\"interface\":\"ae1\",\"system_id\":\"525400240557\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "interface"
+#    },
+#    {
+#      "actual" = "{\"value\":\"missing\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "7a800b7c-605c-4efa-8d7a-852b651aa3c3"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"route\",\"destination_ip\":\"10.60.60.0/32\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "unknown"
+#      "severity" = "critical"
+#      "type" = "route"
+#    },
+#    {
+#      "actual" = "{\"value\":\"missing\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "8fc0ad40-a4d3-4932-99c9-bca252666373"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"route\",\"destination_ip\":\"10.60.60.1/32\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "unknown"
+#      "severity" = "critical"
+#      "type" = "route"
+#    },
+#    {
+#      "actual" = "{\"value\":\"missing\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "978c04e4-c029-4d28-8502-924d0b78a920"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"route\",\"destination_ip\":\"10.60.60.2/32\",\"system_id\":\"5254008A8F34\"}"
+#      "role" = "unknown"
+#      "severity" = "critical"
+#      "type" = "route"
+#    },
+#    {
+#      "actual" = "{\"value\":\"missing\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "a7141677-b4a4-470b-8027-6c84fef7fd51"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"route\",\"destination_ip\":\"10.60.60.6/31\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "unknown"
+#      "severity" = "critical"
+#      "type" = "route"
+#    },
+#    {
+#      "actual" = "{\"value\":\"missing\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "b0136228-a626-4ed2-8df2-552ab32cb7d0"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"route\",\"destination_ip\":\"10.60.60.2/32\",\"system_id\":\"525400523E0A\"}"
+#      "role" = "unknown"
+#      "severity" = "critical"
+#      "type" = "route"
+#    },
+#  ])
+#  "summary_by_node" = toset([
+#    {
+#      "arp" = 0
+#      "bgp" = 0
+#      "blueprint_rendering" = 0
+#      "cabling" = 1
+#      "config" = 0
+#      "counter" = 0
+#      "deployment" = 0
+#      "hostname" = 0
+#      "interface" = 0
+#      "lag" = 0
+#      "liveness" = 0
+#      "mac" = 0
+#      "mlag" = 0
+#      "node_name" = "test_001_access2"
+#      "probe" = 0
+#      "route" = 0
+#      "series" = 0
+#      "streaming" = 0
+#      "system_id" = "525400101F55"
+#      "total" = 1
+#    },
+#    {
+#      "arp" = 0
+#      "bgp" = 0
+#      "blueprint_rendering" = 0
+#      "cabling" = 1
+#      "config" = 0
+#      "counter" = 0
+#      "deployment" = 0
+#      "hostname" = 0
+#      "interface" = 0
+#      "lag" = 0
+#      "liveness" = 0
+#      "mac" = 0
+#      "mlag" = 0
+#      "node_name" = "test_001_leaf1"
+#      "probe" = 0
+#      "route" = 1
+#      "series" = 0
+#      "streaming" = 0
+#      "system_id" = "525400523E0A"
+#      "total" = 2
+#    },
+#    {
+#      "arp" = 0
+#      "bgp" = 0
+#      "blueprint_rendering" = 0
+#      "cabling" = 1
+#      "config" = 0
+#      "counter" = 0
+#      "deployment" = 0
+#      "hostname" = 0
+#      "interface" = 2
+#      "lag" = 1
+#      "liveness" = 0
+#      "mac" = 0
+#      "mlag" = 0
+#      "node_name" = "test_001_access1"
+#      "probe" = 0
+#      "route" = 0
+#      "series" = 0
+#      "streaming" = 0
+#      "system_id" = "525400240557"
+#      "total" = 4
+#    },
+#    {
+#      "arp" = 0
+#      "bgp" = 2
+#      "blueprint_rendering" = 0
+#      "cabling" = 1
+#      "config" = 0
+#      "counter" = 0
+#      "deployment" = 0
+#      "hostname" = 0
+#      "interface" = 0
+#      "lag" = 0
+#      "liveness" = 0
+#      "mac" = 0
+#      "mlag" = 0
+#      "node_name" = "spine1"
+#      "probe" = 0
+#      "route" = 1
+#      "series" = 0
+#      "streaming" = 0
+#      "system_id" = "5254008A8F34"
+#      "total" = 4
+#    },
+#    {
+#      "arp" = 0
+#      "bgp" = 2
+#      "blueprint_rendering" = 0
+#      "cabling" = 2
+#      "config" = 0
+#      "counter" = 0
+#      "deployment" = 0
+#      "hostname" = 0
+#      "interface" = 2
+#      "lag" = 1
+#      "liveness" = 0
+#      "mac" = 0
+#      "mlag" = 0
+#      "node_name" = "test_001_leaf2"
+#      "probe" = 0
+#      "route" = 3
+#      "series" = 0
+#      "streaming" = 0
+#      "system_id" = "525400E19D40"
+#      "total" = 10
+#    },
+#  ])
+#  "summary_by_service" = toset([
+#    {
+#      "count" = 21
+#      "role" = "all"
+#      "type" = "all"
+#    },
+#    {
+#      "count" = 2
+#      "role" = "leaf_access"
+#      "type" = "lag"
+#    },
+#    {
+#      "count" = 2
+#      "role" = "spine_leaf"
+#      "type" = "cabling"
+#    },
+#    {
+#      "count" = 4
+#      "role" = "leaf_access"
+#      "type" = "cabling"
+#    },
+#    {
+#      "count" = 4
+#      "role" = "leaf_access"
+#      "type" = "interface"
+#    },
+#    {
+#      "count" = 4
+#      "role" = "spine_leaf"
+#      "type" = "bgp"
+#    },
+#    {
+#      "count" = 5
+#      "role" = "unknown"
+#      "type" = "route"
+#    },
+#  ])
+#}
+```
+
+<!-- schema generated by tfplugindocs -->
+## Schema
+
+### Required
+
+- `blueprint_id` (String) Apstra Blueprint ID.
+
+### Read-Only
+
+- `details` (Attributes Set) Each current Anomaly is represented by an object in this set. (see [below for nested schema](#nestedatt--details))
+- `summary_by_node` (Attributes Set) Set of Anomaly summaries organized by Node. (see [below for nested schema](#nestedatt--summary_by_node))
+- `summary_by_service` (Attributes Set) Set of Anomaly summaries organized by Fabric Service. (see [below for nested schema](#nestedatt--summary_by_service))
+
+<a id="nestedatt--details"></a>
+### Nested Schema for `details`
+
+Read-Only:
+
+- `actual` (String) Extended Anomaly attribute describing the actual value/state/condition in JSON format.
+- `anomalous` (String) Extended Anomaly attribute which further contextualizes the Anomaly.
+- `anomaly_id` (String) Apstra Anomaly ID.
+- `expected` (String) Extended Anomaly attribute describing the expected value/state/condition in JSON format.
+- `identity` (String) Extended Anomaly attribute which identifies the anomalous value/state/condition in JSON format.
+- `role` (String) Anomaly role further contextualizes `type`.
+- `severity` (String) Severity of Anomaly.
+- `type` (String) Anomaly Type.
+
+
+<a id="nestedatt--summary_by_node"></a>
+### Nested Schema for `summary_by_node`
+
+Read-Only:
+
+- `arp` (Number) Number of ARP Anomalies related to the Node.
+- `bgp` (Number) Number of BGP Anomalies related to the Node.
+- `blueprint_rendering` (Number) Number of Blueprint Rendering Anomalies related to the Node.
+- `cabling` (Number) Number of Cabling Anomalies related to the Node.
+- `config` (Number) Number of Config Anomalies related to the Node.
+- `counter` (Number) Number of Counter Anomalies related to the Node.
+- `deployment` (Number) Number of Deployment Anomalies related to the Node.
+- `hostname` (Number) Number of Hostname Anomalies related to the Node.
+- `interface` (Number) Number of Interface Anomalies related to the Node.
+- `lag` (Number) Number of LAG Anomalies related to the Node.
+- `liveness` (Number) Number of Liveness Anomalies related to the Node.
+- `mac` (Number) Number of MAC Anomalies related to the Node.
+- `mlag` (Number) Number of MLAG Anomalies related to the Node.
+- `node_name` (String) Name of the Node experiencing Anomalies.
+- `probe` (Number) Number of Probe Anomalies related to the Node.
+- `route` (Number) Number of Route Anomalies related to the Node.
+- `series` (Number) Number of Series Anomalies related to the Node.
+- `streaming` (Number) Number of Streaming Anomalies related to the Node.
+- `system_id` (String) System ID of the Node experiencing Anomalies.
+- `total` (Number) Total number of Anomalies related to the Node.
+
+
+<a id="nestedatt--summary_by_service"></a>
+### Nested Schema for `summary_by_service`
+
+Read-Only:
+
+- `count` (Number) Count of Anomalies related to the Fabric Service and Role.
+- `role` (String) Further context about the Fabric Service Anomalies.
+- `type` (String) Fabric Service experiencing Anomalies.

--- a/examples/data-sources/apstra_anomalies/example.tf
+++ b/examples/data-sources/apstra_anomalies/example.tf
@@ -1,0 +1,374 @@
+# This example pulls all of the anomaly details from a blueprint with several
+# cabling mistakes which produce a total of 21 anomalies.
+data "apstra_anomalies" "anomalies" {
+  blueprint_id = "c8fe07d6-f631-46e6-ae2a-9c6f3929e6a3"
+}
+
+output anomalies { value = data.apstra_anomalies.anomalies }
+
+# The output looks like this:
+
+#anomalies = {
+#  "blueprint_id" = "c8fe07d6-f631-46e6-ae2a-9c6f3929e6a3"
+#  "details" = toset([
+#    {
+#      "actual" = "{\"interfaces_up\":[],\"intf_up_count\":0}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "40403043-dba1-4546-9a7e-00d92858d590"
+#      "expected" = "{\"interfaces_up\":[\"ge-0/0/0\"],\"intf_up_count\":1}"
+#      "identity" = "{\"anomaly_type\":\"lag\",\"lag\":\"ae1\",\"system_id\":\"525400240557\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "lag"
+#    },
+#    {
+#      "actual" = "{\"interfaces_up\":[],\"intf_up_count\":0}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "4bdd2de3-2022-4151-82f2-e734e57a5619"
+#      "expected" = "{\"interfaces_up\":[\"ge-0/0/1\"],\"intf_up_count\":1}"
+#      "identity" = "{\"anomaly_type\":\"lag\",\"lag\":\"ae1\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "lag"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/0\",\"neighbor_name\":\"test-001-access1\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "76692c7a-2067-4372-8906-02a015825557"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/0\",\"neighbor_name\":\"test-001-leaf2\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/1\",\"system_id\":\"5254008A8F34\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/0\",\"neighbor_name\":\"test-001-access2\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "cde14dba-daf0-4bf3-9b49-a718cfc3694d"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/0\",\"neighbor_name\":\"test-001-access1\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/1\",\"system_id\":\"525400523E0A\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/1\",\"neighbor_name\":\"spine1\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "e9e29a10-386d-4d87-bf5c-91c0db7eb878"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/1\",\"neighbor_name\":\"test-001-leaf1\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/0\",\"system_id\":\"525400240557\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/1\",\"neighbor_name\":\"test-001-leaf1\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "294822e8-7d8f-4978-9ccb-749ea373c6e8"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/1\",\"neighbor_name\":\"test-001-leaf2\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/0\",\"system_id\":\"525400101F55\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/2\",\"neighbor_name\":\"spine1\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "9e7b289e-f106-4856-add7-e4566ee57314"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/1\",\"neighbor_name\":\"spine1\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/0\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"neighbor_interface\":\"ge-0/0/2\",\"neighbor_name\":\"test-001-access2\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "31d7aa87-efb3-4695-9312-0580d9c4ea27"
+#      "expected" = "{\"neighbor_interface\":\"ge-0/0/0\",\"neighbor_name\":\"test-001-access2\"}"
+#      "identity" = "{\"anomaly_type\":\"cabling\",\"interface\":\"ge-0/0/1\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "cabling"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "0cf491f3-031a-4fa2-8daa-61aa23bbe045"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"addr_family\":\"evpn\",\"anomaly_type\":\"bgp\",\"destination_asn\":\"4200000002\",\"destination_ip\":\"10.60.60.2\",\"destination_name\":\"test-001-leaf2\",\"source_asn\":\"4200000000\",\"source_ip\":\"10.60.60.0\",\"system_id\":\"5254008A8F34\",\"vrf_name\":\"default\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "bgp"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "1fd5a3c3-07cf-4b97-81f2-b6e1153b48ee"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"interface\",\"interface\":\"ae1.0\",\"system_id\":\"525400240557\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "interface"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "2058be80-5be3-4787-b09b-a46935c52974"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"addr_family\":\"ipv4\",\"anomaly_type\":\"bgp\",\"destination_asn\":\"4200000000\",\"destination_ip\":\"10.60.60.8\",\"destination_name\":\"spine1\",\"source_asn\":\"4200000002\",\"source_ip\":\"10.60.60.9\",\"system_id\":\"525400E19D40\",\"vrf_name\":\"default\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "bgp"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "3dca6d8b-23ab-4636-b446-48b3979967f4"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"interface\",\"interface\":\"ae1.0\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "interface"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "3fdd09db-832d-4186-8e8a-81ec69cf9837"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"interface\",\"interface\":\"ae1\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "interface"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "8a8b0438-b751-46c4-a3ea-992a58fe1d0d"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"addr_family\":\"ipv4\",\"anomaly_type\":\"bgp\",\"destination_asn\":\"4200000002\",\"destination_ip\":\"10.60.60.9\",\"destination_name\":\"test-001-leaf2\",\"source_asn\":\"4200000000\",\"source_ip\":\"10.60.60.8\",\"system_id\":\"5254008A8F34\",\"vrf_name\":\"default\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "bgp"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "bba106ea-ed79-4268-81f4-dad5ce3f45b9"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"addr_family\":\"evpn\",\"anomaly_type\":\"bgp\",\"destination_asn\":\"4200000000\",\"destination_ip\":\"10.60.60.0\",\"destination_name\":\"spine1\",\"source_asn\":\"4200000002\",\"source_ip\":\"10.60.60.2\",\"system_id\":\"525400E19D40\",\"vrf_name\":\"default\"}"
+#      "role" = "spine_leaf"
+#      "severity" = "critical"
+#      "type" = "bgp"
+#    },
+#    {
+#      "actual" = "{\"value\":\"down\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "e73513eb-9393-4893-8306-7e0f23e4a4a2"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"interface\",\"interface\":\"ae1\",\"system_id\":\"525400240557\"}"
+#      "role" = "leaf_access"
+#      "severity" = "critical"
+#      "type" = "interface"
+#    },
+#    {
+#      "actual" = "{\"value\":\"missing\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "7a800b7c-605c-4efa-8d7a-852b651aa3c3"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"route\",\"destination_ip\":\"10.60.60.0/32\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "unknown"
+#      "severity" = "critical"
+#      "type" = "route"
+#    },
+#    {
+#      "actual" = "{\"value\":\"missing\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "8fc0ad40-a4d3-4932-99c9-bca252666373"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"route\",\"destination_ip\":\"10.60.60.1/32\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "unknown"
+#      "severity" = "critical"
+#      "type" = "route"
+#    },
+#    {
+#      "actual" = "{\"value\":\"missing\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "978c04e4-c029-4d28-8502-924d0b78a920"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"route\",\"destination_ip\":\"10.60.60.2/32\",\"system_id\":\"5254008A8F34\"}"
+#      "role" = "unknown"
+#      "severity" = "critical"
+#      "type" = "route"
+#    },
+#    {
+#      "actual" = "{\"value\":\"missing\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "a7141677-b4a4-470b-8027-6c84fef7fd51"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"route\",\"destination_ip\":\"10.60.60.6/31\",\"system_id\":\"525400E19D40\"}"
+#      "role" = "unknown"
+#      "severity" = "critical"
+#      "type" = "route"
+#    },
+#    {
+#      "actual" = "{\"value\":\"missing\"}"
+#      "anomalous" = tostring(null)
+#      "anomaly_id" = "b0136228-a626-4ed2-8df2-552ab32cb7d0"
+#      "expected" = "{\"value\":\"up\"}"
+#      "identity" = "{\"anomaly_type\":\"route\",\"destination_ip\":\"10.60.60.2/32\",\"system_id\":\"525400523E0A\"}"
+#      "role" = "unknown"
+#      "severity" = "critical"
+#      "type" = "route"
+#    },
+#  ])
+#  "summary_by_node" = toset([
+#    {
+#      "arp" = 0
+#      "bgp" = 0
+#      "blueprint_rendering" = 0
+#      "cabling" = 1
+#      "config" = 0
+#      "counter" = 0
+#      "deployment" = 0
+#      "hostname" = 0
+#      "interface" = 0
+#      "lag" = 0
+#      "liveness" = 0
+#      "mac" = 0
+#      "mlag" = 0
+#      "node_name" = "test_001_access2"
+#      "probe" = 0
+#      "route" = 0
+#      "series" = 0
+#      "streaming" = 0
+#      "system_id" = "525400101F55"
+#      "total" = 1
+#    },
+#    {
+#      "arp" = 0
+#      "bgp" = 0
+#      "blueprint_rendering" = 0
+#      "cabling" = 1
+#      "config" = 0
+#      "counter" = 0
+#      "deployment" = 0
+#      "hostname" = 0
+#      "interface" = 0
+#      "lag" = 0
+#      "liveness" = 0
+#      "mac" = 0
+#      "mlag" = 0
+#      "node_name" = "test_001_leaf1"
+#      "probe" = 0
+#      "route" = 1
+#      "series" = 0
+#      "streaming" = 0
+#      "system_id" = "525400523E0A"
+#      "total" = 2
+#    },
+#    {
+#      "arp" = 0
+#      "bgp" = 0
+#      "blueprint_rendering" = 0
+#      "cabling" = 1
+#      "config" = 0
+#      "counter" = 0
+#      "deployment" = 0
+#      "hostname" = 0
+#      "interface" = 2
+#      "lag" = 1
+#      "liveness" = 0
+#      "mac" = 0
+#      "mlag" = 0
+#      "node_name" = "test_001_access1"
+#      "probe" = 0
+#      "route" = 0
+#      "series" = 0
+#      "streaming" = 0
+#      "system_id" = "525400240557"
+#      "total" = 4
+#    },
+#    {
+#      "arp" = 0
+#      "bgp" = 2
+#      "blueprint_rendering" = 0
+#      "cabling" = 1
+#      "config" = 0
+#      "counter" = 0
+#      "deployment" = 0
+#      "hostname" = 0
+#      "interface" = 0
+#      "lag" = 0
+#      "liveness" = 0
+#      "mac" = 0
+#      "mlag" = 0
+#      "node_name" = "spine1"
+#      "probe" = 0
+#      "route" = 1
+#      "series" = 0
+#      "streaming" = 0
+#      "system_id" = "5254008A8F34"
+#      "total" = 4
+#    },
+#    {
+#      "arp" = 0
+#      "bgp" = 2
+#      "blueprint_rendering" = 0
+#      "cabling" = 2
+#      "config" = 0
+#      "counter" = 0
+#      "deployment" = 0
+#      "hostname" = 0
+#      "interface" = 2
+#      "lag" = 1
+#      "liveness" = 0
+#      "mac" = 0
+#      "mlag" = 0
+#      "node_name" = "test_001_leaf2"
+#      "probe" = 0
+#      "route" = 3
+#      "series" = 0
+#      "streaming" = 0
+#      "system_id" = "525400E19D40"
+#      "total" = 10
+#    },
+#  ])
+#  "summary_by_service" = toset([
+#    {
+#      "count" = 21
+#      "role" = "all"
+#      "type" = "all"
+#    },
+#    {
+#      "count" = 2
+#      "role" = "leaf_access"
+#      "type" = "lag"
+#    },
+#    {
+#      "count" = 2
+#      "role" = "spine_leaf"
+#      "type" = "cabling"
+#    },
+#    {
+#      "count" = 4
+#      "role" = "leaf_access"
+#      "type" = "cabling"
+#    },
+#    {
+#      "count" = 4
+#      "role" = "leaf_access"
+#      "type" = "interface"
+#    },
+#    {
+#      "count" = 4
+#      "role" = "spine_leaf"
+#      "type" = "bgp"
+#    },
+#    {
+#      "count" = 5
+#      "role" = "unknown"
+#      "type" = "route"
+#    },
+#  ])
+#}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20230620202423-07263c23e752
+	github.com/Juniper/apstra-go-sdk v0.0.0-20230624211927-4a68f2d73a57
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
@@ -17,7 +17,7 @@ require (
 )
 
 //                                                                                          HHMMSS
-//replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230611205558-aab0899dddbb
+//replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230624020917-8ade103b3366
 
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230620202423-07263c23e752 h1:ZlDtEa3v8k3Y1joXzjqDoLOek0+xZ31gf01+J0sDnZU=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230620202423-07263c23e752/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230624211927-4a68f2d73a57 h1:hc/eNpyZBFBmarAM+kgqKSOLyXck8zHZR17aAuHAumg=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230624211927-4a68f2d73a57/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=


### PR DESCRIPTION
This PR introduces data source `apstra_anomalies`:

```hcl
data "apstra_anomalies" "a" {
  blueprint_id = "blueprint-id"
}
```

This data source has 3 `Computed` attributes:
- `details`
- `summary_by_node`
- `summary_by_service`

Each attribute is a set representing current blueprint anomalies.