### PR TITLE
Bug 161: use `initial_interface_map_id` in example

### DIFF
--- a/docs/resources/datacenter_device_allocation.md
+++ b/docs/resources/datacenter_device_allocation.md
@@ -21,41 +21,43 @@ resource "apstra_datacenter_blueprint" "r" {
   template_id = "L2_Virtual_EVPN"
 }
 
-# Only one of "device_key" and "interface_map_id" is required in most cases.
+# Only one of "device_key" and "initial_interface_map_id" is required in
+# most cases.
 #
-# When only the interface_map_id is provided, we set the interface map (this
-# step eliminates build errors), but do not assign systems by ID.
+# When only the initial_interface_map_id is provided, we set the interface
+# map (this step eliminates build errors), but do not assign systems by ID.
 #
-# When only the device_key is provided, we try to infer the interface_map_id
-# by first determining the device type, and then looking for candidate
-# interface maps which can map the specific hardware to the logical device
-# specified by the fabric role. When multiple candidate interface maps exist
-# supplying interface_map_id becomes mandatory.
+# When only the device_key is provided, we try to infer the
+# initial_interface_map_id by first determining the device type, and then
+# looking for candidate interface maps which can map the specific hardware
+# to the logical device specified by the fabric role. When multiple
+# candidate interface maps exist supplying interface_map_id becomes
+# mandatory.
 locals {
   switches = {
     spine1 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Spine"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Spine"
     }
     spine2 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Spine"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Spine"
     }
     l2_virtual_001_leaf1 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
     }
     l2_virtual_002_leaf1 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
     }
     l2_virtual_003_leaf1 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
     }
     l2_virtual_004_leaf1 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
     }
   }
 }
@@ -64,7 +66,7 @@ locals {
 resource "apstra_datacenter_device_allocation" "r" {
   for_each                 = local.switches
   blueprint_id             = apstra_datacenter_blueprint.r.id
-  initial_interface_map_id = each.value["interface_map_id"]
+  initial_interface_map_id = each.value["initial_interface_map_id"]
   node_name                = each.key
   deploy_mode              = "deploy"
 }

--- a/examples/resources/apstra_datacenter_device_allocation/example.tf
+++ b/examples/resources/apstra_datacenter_device_allocation/example.tf
@@ -7,41 +7,43 @@ resource "apstra_datacenter_blueprint" "r" {
   template_id = "L2_Virtual_EVPN"
 }
 
-# Only one of "device_key" and "interface_map_id" is required in most cases.
+# Only one of "device_key" and "initial_interface_map_id" is required in
+# most cases.
 #
-# When only the interface_map_id is provided, we set the interface map (this
-# step eliminates build errors), but do not assign systems by ID.
+# When only the initial_interface_map_id is provided, we set the interface
+# map (this step eliminates build errors), but do not assign systems by ID.
 #
-# When only the device_key is provided, we try to infer the interface_map_id
-# by first determining the device type, and then looking for candidate
-# interface maps which can map the specific hardware to the logical device
-# specified by the fabric role. When multiple candidate interface maps exist
-# supplying interface_map_id becomes mandatory.
+# When only the device_key is provided, we try to infer the
+# initial_interface_map_id by first determining the device type, and then
+# looking for candidate interface maps which can map the specific hardware
+# to the logical device specified by the fabric role. When multiple
+# candidate interface maps exist supplying interface_map_id becomes
+# mandatory.
 locals {
   switches = {
     spine1 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Spine"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Spine"
     }
     spine2 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Spine"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Spine"
     }
     l2_virtual_001_leaf1 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
     }
     l2_virtual_002_leaf1 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
     }
     l2_virtual_003_leaf1 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
     }
     l2_virtual_004_leaf1 = {
       #     device_key       = "<serial-number-goes-here>"
-      interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
+      initial_interface_map_id = "Juniper_vQFX__AOS-7x10-Leaf"
     }
   }
 }
@@ -50,7 +52,7 @@ locals {
 resource "apstra_datacenter_device_allocation" "r" {
   for_each                 = local.switches
   blueprint_id             = apstra_datacenter_blueprint.r.id
-  initial_interface_map_id = each.value["interface_map_id"]
+  initial_interface_map_id = each.value["initial_interface_map_id"]
   node_name                = each.key
   deploy_mode              = "deploy"
 }


### PR DESCRIPTION
Feedback from Aninda: "hey, this example is confusing, especially since you changed the attribute name"