### PR TITLE
Bug/46: Detect embedded passwords which look like fragment links because of `#`

### DIFF
--- a/apstra/utils/client.go
+++ b/apstra/utils/client.go
@@ -42,10 +42,12 @@ func NewClientConfig(apstraUrl string) (*apstra.ClientCfg, error) {
 	// Parse the URL.
 	parsedUrl, err := url.Parse(apstraUrl)
 	if err != nil {
-		if urlErr, ok := err.(*url.Error); ok && strings.Contains(urlErr.Error(), "invalid userinfo") {
+		if urlErr, ok := err.(*url.Error); ok &&
+			(strings.Contains(urlErr.Error(), "invalid userinfo") ||
+				strings.Contains(urlErr.Error(), "invalid port")) {
 			// don't print the actual error here because it likely contains a password
 			return nil, errors.New(
-				"error parsing userinfo from URL - " + fmt.Sprintf(urlEncodeMsg, UrlEscapeTable()))
+				"error parsing URL\n" + fmt.Sprintf(urlEncodeMsg, UrlEscapeTable()))
 		}
 
 		var urlEE url.EscapeError


### PR DESCRIPTION
It's not so much that we detect/handle these passwords directly, but the URL parsing error they produce is different.

With this PR, passwords containing `#` are no longer printed to the terminal.

## Before:

```text
╷
│ Error: Error creating Apstra client configuration
│ 
│   with provider["registry.terraform.io/juniper/apstra"],
│   on 0_provider.tf line 10, in provider "apstra":
│   10: provider "apstra" {
│ 
│ error parsing URL "https://admin:SlickRhinoceros7#@1.2.3.4:5" - parse "https://admin:SlickRhinoceros7": invalid port ":SlickRhinoceros7" after
│ host
╵
```

## After:

```text
╷
│ Error: Error creating Apstra client configuration
│ 
│   with provider["registry.terraform.io/juniper/apstra"],
│   on 0_provider.tf line 10, in provider "apstra":
│   10: provider "apstra" {
│ 
│ error parsing URL - 
│ Note that when the Username or Password fields contain special characters and are
│ embedded in the URL, they must be URL-encoded by substituting '%<hex-value>' in
│ place of each special character. The following table demonstrates some common
│ substitutions:
│ 
│       " => %22        # => %23        % => %25        / => %2F
│       < => %3C        > => %3E        ? => %3F        [ => %5B
│       \ => %5C        ] => %5D        ^ => %5E
╵
```

fixes #46