### PR TITLE
add `context.Context` to `GetTestClient()` signature

### DIFF
--- a/apstra/data_source_datacenter_system_test.go
+++ b/apstra/data_source_datacenter_system_test.go
@@ -22,7 +22,7 @@ data "apstra_datacenter_system" "test" {
 
 func TestDatacenterSystem_A(t *testing.T) {
 	ctx := context.Background()
-	client, err := testutils.GetTestClient()
+	client, err := testutils.GetTestClient(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -10,7 +10,7 @@ import (
 
 func BlueprintA(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -47,7 +47,7 @@ func BlueprintA(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context
 
 func BlueprintB(ctx context.Context) (*apstra.TwoStageL3ClosClient, apstra.ObjectId, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, "", deleteFunc, err
 	}
@@ -88,7 +88,7 @@ func BlueprintB(ctx context.Context) (*apstra.TwoStageL3ClosClient, apstra.Objec
 
 func BlueprintC(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -128,7 +128,7 @@ func BlueprintC(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context
 }
 
 func BlueprintD(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context.Context) error, error) {
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -230,7 +230,7 @@ func BlueprintD(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context
 
 func BlueprintE(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -269,7 +269,7 @@ func BlueprintE(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context
 }
 
 func BlueprintF(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context.Context) error, error) {
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/apstra/test_utils/ipv4_pool.go
+++ b/apstra/test_utils/ipv4_pool.go
@@ -13,7 +13,7 @@ import (
 func Ipv4PoolA(ctx context.Context) (*apstra.IpPool, func(context.Context) error, error) {
 	deleteFunc := func(_ context.Context) error { return nil }
 
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 
 	if err != nil {
 		return nil, deleteFunc, err
@@ -76,7 +76,7 @@ func Ipv4PoolA(ctx context.Context) (*apstra.IpPool, func(context.Context) error
 
 func Ipv4PoolB(ctx context.Context) (*apstra.IpPool, func(context.Context) error, error) {
 	deleteFunc := func(_ context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}

--- a/apstra/test_utils/ipv4_pool.go
+++ b/apstra/test_utils/ipv4_pool.go
@@ -12,7 +12,7 @@ import (
 
 func Ipv4PoolA(ctx context.Context) (*apstra.IpPool, func(context.Context) error, error) {
 	deleteFunc := func(_ context.Context) error { return nil }
-  
+
 	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err

--- a/apstra/test_utils/property_set.go
+++ b/apstra/test_utils/property_set.go
@@ -9,7 +9,7 @@ import (
 func PropertySetA(ctx context.Context) (*apstra.PropertySet, func(context.Context) error, error) {
 	deleteFunc := func(_ context.Context) error { return nil }
 
-  client, err := GetTestClient(ctx)
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}

--- a/apstra/test_utils/property_set.go
+++ b/apstra/test_utils/property_set.go
@@ -7,7 +7,7 @@ import (
 )
 
 func PropertySetA(ctx context.Context) (*apstra.PropertySet, func(context.Context) error, error) {
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	deleteFunc := func(_ context.Context) error { return nil }
 	if err != nil {
 		return nil, deleteFunc, err

--- a/apstra/test_utils/rack_type.go
+++ b/apstra/test_utils/rack_type.go
@@ -368,7 +368,7 @@ func RackTypeE(ctx context.Context) (*apstra.RackType, func(context.Context) err
 func RackTypeF(ctx context.Context) (*apstra.RackType, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
 
-  client, err := GetTestClient(ctx)
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}

--- a/apstra/test_utils/rack_type.go
+++ b/apstra/test_utils/rack_type.go
@@ -12,7 +12,7 @@ import (
 // - 1 access switch
 func RackTypeA(ctx context.Context) (*apstra.RackType, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -64,7 +64,7 @@ func RackTypeA(ctx context.Context) (*apstra.RackType, func(context.Context) err
 // - 1 pair (count = 2) access switches single-homed to ESI leaf "B"
 func RackTypeB(ctx context.Context) (*apstra.RackType, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -132,7 +132,7 @@ func RackTypeB(ctx context.Context) (*apstra.RackType, func(context.Context) err
 // - 1 access switch dual-homed to both ESI leaf switches
 func RackTypeC(ctx context.Context) (*apstra.RackType, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -187,7 +187,7 @@ func RackTypeC(ctx context.Context) (*apstra.RackType, func(context.Context) err
 // - 1 access switch single homed to ESI leaf "B"
 func RackTypeD(ctx context.Context) (*apstra.RackType, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -279,7 +279,7 @@ func RackTypeD(ctx context.Context) (*apstra.RackType, func(context.Context) err
 // - 1 access switch homed to both MLAG peers
 func RackTypeE(ctx context.Context) (*apstra.RackType, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -366,7 +366,7 @@ func RackTypeE(ctx context.Context) (*apstra.RackType, func(context.Context) err
 }
 
 func RackTypeF(ctx context.Context) (*apstra.RackType, func(context.Context) error, error) {
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/apstra/test_utils/tag.go
+++ b/apstra/test_utils/tag.go
@@ -8,7 +8,7 @@ import (
 
 func TagA(ctx context.Context) (*apstra.DesignTag, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}

--- a/apstra/test_utils/template.go
+++ b/apstra/test_utils/template.go
@@ -267,7 +267,7 @@ func TemplateD(ctx context.Context) (*apstra.TemplateRackBased, func(context.Con
 func TemplateE(ctx context.Context) (*apstra.TemplateRackBased, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
 
-  client, err := GetTestClient(ctx)
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}

--- a/apstra/test_utils/template.go
+++ b/apstra/test_utils/template.go
@@ -9,7 +9,7 @@ import (
 
 func TemplateA(ctx context.Context) (*apstra.TemplateRackBased, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -75,7 +75,7 @@ func TemplateA(ctx context.Context) (*apstra.TemplateRackBased, func(context.Con
 
 func TemplateB(ctx context.Context) (*apstra.TemplateRackBased, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -120,7 +120,7 @@ func TemplateB(ctx context.Context) (*apstra.TemplateRackBased, func(context.Con
 
 func TemplateC(ctx context.Context) (*apstra.TemplateRackBased, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -164,7 +164,7 @@ func TemplateC(ctx context.Context) (*apstra.TemplateRackBased, func(context.Con
 
 func TemplateD(ctx context.Context) (*apstra.TemplateRackBased, func(context.Context) error, error) {
 	deleteFunc := func(ctx context.Context) error { return nil }
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, deleteFunc, err
 	}
@@ -265,7 +265,7 @@ func TemplateD(ctx context.Context) (*apstra.TemplateRackBased, func(context.Con
 }
 
 func TemplateE(ctx context.Context) (*apstra.TemplateRackBased, func(context.Context) error, error) {
-	client, err := GetTestClient()
+	client, err := GetTestClient(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/apstra/test_utils/test_utils.go
+++ b/apstra/test_utils/test_utils.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"context"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"net/http"
 	"sync"
@@ -10,7 +11,7 @@ import (
 var sharedClient *apstra.Client
 var testClientMutex sync.Mutex
 
-func GetTestClient() (*apstra.Client, error) {
+func GetTestClient(ctx context.Context) (*apstra.Client, error) {
 	testClientMutex.Lock()
 	defer testClientMutex.Unlock()
 
@@ -21,6 +22,9 @@ func GetTestClient() (*apstra.Client, error) {
 		}
 		clientCfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
 
+		// https://github.com/Juniper/apstra-go-sdk/issues/53
+		// sharedClient, err = clientCfg.NewClient(ctx)
+		_ = ctx
 		sharedClient, err = clientCfg.NewClient()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR changes the function signature from `GetTestClient()` to ``GetTestClient(ctx context.Context)`.

Somewhere down the rabbit hole of client creation is a call which inspects the Apstra API version. Via HTTP request.

That call should be using a caller-supplied `context.Context`. This PR is a step in that direction.

first phase of #61