### PR TITLE
Add missing mutex lock call to Delete() methods

### DIFF
--- a/apstra/resource_datacenter_property_set.go
+++ b/apstra/resource_datacenter_property_set.go
@@ -203,7 +203,6 @@ func (o *resourceDatacenterPropertySet) Update(ctx context.Context, req resource
 
 	// ensure that keys configured to be imported actually exist in the Global
 	// Catalog's copy of the Property Set
-
 	missingRequiredKeys, _ := utils.DiffSliceSets(availableKeys, keysToImport)
 	if len(missingRequiredKeys) != 0 {
 		resp.Diagnostics.AddAttributeError(
@@ -273,12 +272,22 @@ func (o *resourceDatacenterPropertySet) Delete(ctx context.Context, req resource
 		return
 	}
 
+	// create a blueprint client
 	bpClient, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
 	if err != nil {
 		if utils.IsApstra404(err) {
 			return // 404 is okay
 		}
 		resp.Diagnostics.AddError("unable to get blueprint client", err.Error())
+		return
+	}
+
+	// Lock the blueprint mutex.
+	err = o.lockFunc(ctx, state.BlueprintId.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("error locking blueprint %q mutex", state.BlueprintId.ValueString()),
+			err.Error())
 		return
 	}
 

--- a/apstra/resource_datacenter_virtual_network.go
+++ b/apstra/resource_datacenter_virtual_network.go
@@ -342,6 +342,15 @@ func (o *resourceDatacenterVirtualNetwork) Delete(ctx context.Context, req resou
 		return
 	}
 
+	// Lock the blueprint mutex.
+	err = o.lockFunc(ctx, state.BlueprintId.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("error locking blueprint %q mutex", state.BlueprintId.ValueString()),
+			err.Error())
+		return
+	}
+
 	err = bp.DeleteVirtualNetwork(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
 		var ace apstra.ApstraClientErr


### PR DESCRIPTION
Delete method in `apstra/resource_datacenter_property_set.go` and `apstra/resource_datacenter_virtual_network.go` failed to invoke the blueprint lock function.

Closes #183