### PR TITLE
remove unnecessary struct element containing unlock function

### DIFF
--- a/apstra/resource_datacenter_device_allocation.go
+++ b/apstra/resource_datacenter_device_allocation.go
@@ -15,9 +15,8 @@ import (
 var _ resource.ResourceWithConfigure = &resourceDeviceAllocation{}
 
 type resourceDeviceAllocation struct {
-	client     *apstra.Client
-	lockFunc   func(context.Context, string) error
-	unlockFunc func(context.Context, string) error
+	client   *apstra.Client
+	lockFunc func(context.Context, string) error
 }
 
 func (o *resourceDeviceAllocation) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -27,7 +26,6 @@ func (o *resourceDeviceAllocation) Metadata(_ context.Context, req resource.Meta
 func (o *resourceDeviceAllocation) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	o.client = ResourceGetClient(ctx, req, resp)
 	o.lockFunc = ResourceGetBlueprintLockFunc(ctx, req, resp)
-	o.unlockFunc = ResourceGetBlueprintUnlockFunc(ctx, req, resp)
 }
 
 func (o *resourceDeviceAllocation) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/apstra/resource_datacenter_resource_pool_allocation.go
+++ b/apstra/resource_datacenter_resource_pool_allocation.go
@@ -15,9 +15,8 @@ import (
 var _ resource.ResourceWithConfigure = &resourcePoolAllocation{}
 
 type resourcePoolAllocation struct {
-	client     *apstra.Client
-	lockFunc   func(context.Context, string) error
-	unlockFunc func(context.Context, string) error
+	client   *apstra.Client
+	lockFunc func(context.Context, string) error
 }
 
 func (o *resourcePoolAllocation) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -27,7 +26,6 @@ func (o *resourcePoolAllocation) Metadata(_ context.Context, req resource.Metada
 func (o *resourcePoolAllocation) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	o.client = ResourceGetClient(ctx, req, resp)
 	o.lockFunc = ResourceGetBlueprintLockFunc(ctx, req, resp)
-	o.unlockFunc = ResourceGetBlueprintUnlockFunc(ctx, req, resp)
 }
 
 func (o *resourcePoolAllocation) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {


### PR DESCRIPTION
Remove unused `unlockFunc` from resource structs in both of these files:
- `apstra/resource_datacenter_device_allocation.go`
- `apstra/resource_datacenter_resource_pool_allocation.go`

The only resources which should be unlocking blueprint mutexes are:
- `apstra_blueprint_deployment` (on delete)
- `apstra_datacenter_blueprint` (on create)

Closes #185