### PR TITLE
Add `name` selector to `apstra_datacenter_system` data source

### DIFF
--- a/apstra/data_source_datacenter_system.go
+++ b/apstra/data_source_datacenter_system.go
@@ -25,8 +25,7 @@ func (o *dataSourceDatacenterSystemNode) Configure(ctx context.Context, req data
 func (o *dataSourceDatacenterSystemNode) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source returns details of a specific " +
-			"*system* Graph DB node (identified by ID) *system* nodes within " +
-			"a Blueprint.",
+			"*system* Graph DB node within a Blueprint.",
 		Attributes: blueprint.NodeTypeSystem{}.DataSourceAttributes(),
 	}
 }

--- a/docs/data-sources/datacenter_system.md
+++ b/docs/data-sources/datacenter_system.md
@@ -2,12 +2,12 @@
 page_title: "apstra_datacenter_system Data Source - terraform-provider-apstra"
 subcategory: ""
 description: |-
-  This data source returns details of a specific system Graph DB node (identified by ID) system nodes within a Blueprint.
+  This data source returns details of a specific system Graph DB node within a Blueprint.
 ---
 
 # apstra_datacenter_system (Data Source)
 
-This data source returns details of a specific *system* Graph DB node (identified by ID) *system* nodes within a Blueprint.
+This data source returns details of a specific *system* Graph DB node within a Blueprint.
 
 ## Example Usage
 
@@ -47,7 +47,11 @@ locals {
 ### Required
 
 - `blueprint_id` (String) Apstra Blueprint ID
-- `id` (String) Apstra Graph DB node `id`
+
+### Optional
+
+- `id` (String) Apstra Graph DB node `id` field
+- `name` (String) Apstra Web UI `name` field / Graph DB `label` field
 
 ### Read-Only
 


### PR DESCRIPTION
This PR introduces the `name` attribute to the `apstra_datacenter_system` data source:

```hcl
data "apstra_datacenter_system" "foo" {
  blueprint_id = "1c0c455f-6029-4696-9cda-5e7fde1d7ff6"
# id = "N_n5hK0BcEQc5KFfHoE"
  name = "apstra_esi_001_sys001"
}
```

Previously only `id` could be used to select a system node.