### PR TITLE
Fix version selection logic for `fabric_addressing`

### DIFF
--- a/apstra/blueprint/blueprint.go
+++ b/apstra/blueprint/blueprint.go
@@ -274,10 +274,8 @@ func (o *Blueprint) SetName(ctx context.Context, client *apstra.Client, diags *d
 func (o *Blueprint) MinMaxApiVersions(_ context.Context, diags *diag.Diagnostics) (*version.Version, *version.Version) {
 	var min, max *version.Version
 	var err error
-	if o.FabricAddressing.IsNull() {
+	if !o.FabricAddressing.IsNull() {
 		min, err = version.NewVersion("4.1.1")
-	} else {
-		max, err = version.NewVersion("4.1.0")
 	}
 	if err != nil {
 		diags.AddError(errProviderBug,


### PR DESCRIPTION
- version only relevant when `fabric_addressing` is selected (logic is inverted)
- the `fabric_addressing` attribute sets a minimum version (it's new in 4.1.1)
- no need to set maximum version based on this parameter
- omitting this parameter is okay for all currently supported versions (4.1.0 - 4.1.2)

Fixes #189