### PR TITLE
Add support for resource role `leaf_l3_peer_links`

### DIFF
--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -21,7 +21,8 @@ const (
 
 	nodeDeployModeNotSet = "not_set"
 
-	resourceGroupNameVxlanVnIds = "vni_virtual_network_ids"
+	resourceGroupNameVxlanVnIds      = "vni_virtual_network_ids"
+	resourceGroupNameLeafL3PeerLinks = "leaf_l3_peer_links"
 )
 
 type StringerWithFromString interface {
@@ -155,6 +156,8 @@ func refDesignToFriendlyString(in apstra.RefDesign) string {
 
 func resourceGroupNameToFriendlyString(in apstra.ResourceGroupName) string {
 	switch in {
+	case apstra.ResourceGroupNameLeafL3PeerLinkLinkIps:
+		return resourceGroupNameLeafL3PeerLinks
 	case apstra.ResourceGroupNameVxlanVnIds:
 		return resourceGroupNameVxlanVnIds
 	}
@@ -261,6 +264,8 @@ func resourceGroupNameFromFriendlyString(target *apstra.ResourceGroupName, in ..
 	}
 
 	switch in[0] {
+	case resourceGroupNameLeafL3PeerLinks:
+		*target = apstra.ResourceGroupNameLeafL3PeerLinkLinkIps
 	case resourceGroupNameVxlanVnIds:
 		*target = apstra.ResourceGroupNameVxlanVnIds
 	default:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20230624211927-4a68f2d73a57
+	github.com/Juniper/apstra-go-sdk v0.0.0-20230715001022-adc5b8c7fa16
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
@@ -17,7 +17,7 @@ require (
 )
 
 //                                                                                          HHMMSS
-replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230714223928-51e65ef0e9d2
+//replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230714223928-51e65ef0e9d2
 
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 )
 
 //                                                                                          HHMMSS
-//replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230624020917-8ade103b3366
+replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230714223928-51e65ef0e9d2
 
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230714223928-51e65ef0e9d2 h1:Lq5ts65nM5fQBVQ0CIHCjYBVjFvptTPHgxKk4Uye07s=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230714223928-51e65ef0e9d2/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230715001022-adc5b8c7fa16 h1:XJK+TSAWg1QQdaESEGI4tW6Qnt2S1c3FSqBEva16+wQ=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230715001022-adc5b8c7fa16/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230624211927-4a68f2d73a57 h1:hc/eNpyZBFBmarAM+kgqKSOLyXck8zHZR17aAuHAumg=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230624211927-4a68f2d73a57/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230714223928-51e65ef0e9d2 h1:Lq5ts65nM5fQBVQ0CIHCjYBVjFvptTPHgxKk4Uye07s=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230714223928-51e65ef0e9d2/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=


### PR DESCRIPTION
Before this PR can merge:

- [SDK #55](https://github.com/Juniper/apstra-go-sdk/pull/55) needs to be merged.
- the `replace` directive in this project's `go.mod` must be removed.