### PR TITLE
Use result of type assertion in switch

### DIFF
--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -40,19 +40,19 @@ func StringersToFriendlyString(in ...fmt.Stringer) string {
 		return ""
 	}
 
-	switch in[0].(type) {
+	switch in0 := in[0].(type) {
 	case apstra.AsnAllocationScheme:
-		return asnAllocationSchemeToFriendlyString(in[0].(apstra.AsnAllocationScheme))
+		return asnAllocationSchemeToFriendlyString(in0)
 	case apstra.ConfigletSection:
-		return configletSectionToFriendlyString(in[0].(apstra.ConfigletSection), in[1:]...)
+		return configletSectionToFriendlyString(in0, in[1:]...)
 	case apstra.NodeDeployMode:
-		return nodeDeployModeToFriendlyString(in[0].(apstra.NodeDeployMode))
+		return nodeDeployModeToFriendlyString(in0)
 	case apstra.OverlayControlProtocol:
-		return overlayControlProtocolToFriendlyString(in[0].(apstra.OverlayControlProtocol))
+		return overlayControlProtocolToFriendlyString(in0)
 	case apstra.RefDesign:
-		return refDesignToFriendlyString(in[0].(apstra.RefDesign))
+		return refDesignToFriendlyString(in0)
 	case apstra.ResourceGroupName:
-		return resourceGroupNameToFriendlyString(in[0].(apstra.ResourceGroupName))
+		return resourceGroupNameToFriendlyString(in0)
 	}
 
 	return in[0].String()
@@ -70,20 +70,19 @@ func ApiStringerFromFriendlyString(target StringerWithFromString, in ...string) 
 		return errors.New("ApiStringerFromFriendlyString called with no string input")
 	}
 
-	//lint:ignore S1034 see issue #127
-	switch target.(type) {
+	switch target := target.(type) {
 	case *apstra.AsnAllocationScheme:
-		return asnAllocationSchemeFromFriendlyString(target.(*apstra.AsnAllocationScheme), in...)
+		return asnAllocationSchemeFromFriendlyString(target, in...)
 	case *apstra.ConfigletSection:
-		return configletSectionFromFriendlyString(target.(*apstra.ConfigletSection), in...)
+		return configletSectionFromFriendlyString(target, in...)
 	case *apstra.NodeDeployMode:
-		return nodeDeployModeFromFriendlyString(target.(*apstra.NodeDeployMode), in...)
+		return nodeDeployModeFromFriendlyString(target, in...)
 	case *apstra.OverlayControlProtocol:
-		return overlayControlProtocolFromFriendlyString(target.(*apstra.OverlayControlProtocol), in...)
+		return overlayControlProtocolFromFriendlyString(target, in...)
 	case *apstra.RefDesign:
-		return refDesignFromFriendlyString(target.(*apstra.RefDesign), in...)
+		return refDesignFromFriendlyString(target, in...)
 	case *apstra.ResourceGroupName:
-		return resourceGroupNameFromFriendlyString(target.(*apstra.ResourceGroupName), in...)
+		return resourceGroupNameFromFriendlyString(target, in...)
 	}
 
 	return target.FromString(in[0])

--- a/apstra/utils/terraform_plugin_framework_value_creation.go
+++ b/apstra/utils/terraform_plugin_framework_value_creation.go
@@ -89,56 +89,55 @@ func Int64ValueOrNull(_ context.Context, in any, diags *diag.Diagnostics) types.
 		return types.Int64Null()
 	}
 
-	//lint:ignore S1034 see issue #127
-	switch in.(type) {
+	switch in := in.(type) {
 	case *apstra.VNI:
-		return types.Int64Value(int64(*in.(*apstra.VNI)))
+		return types.Int64Value(int64(*in))
 	case *apstra.Vlan:
-		return types.Int64Value(int64(*in.(*apstra.Vlan)))
+		return types.Int64Value(int64(*in))
 	case *int:
-		return types.Int64Value(int64(*in.(*int)))
+		return types.Int64Value(int64(*in))
 	case *int8:
-		return types.Int64Value(int64(*in.(*int8)))
+		return types.Int64Value(int64(*in))
 	case *int16:
-		return types.Int64Value(int64(*in.(*int16)))
+		return types.Int64Value(int64(*in))
 	case *int32:
-		return types.Int64Value(int64(*in.(*int32)))
+		return types.Int64Value(int64(*in))
 	case *int64:
-		return types.Int64Value(*in.(*int64))
+		return types.Int64Value(*in)
 	case *uint:
-		return types.Int64Value(int64(*in.(*uint)))
+		return types.Int64Value(int64(*in))
 	case *uint8:
-		return types.Int64Value(int64(*in.(*uint8)))
+		return types.Int64Value(int64(*in))
 	case *uint16:
-		return types.Int64Value(int64(*in.(*uint16)))
+		return types.Int64Value(int64(*in))
 	case *uint32:
-		return types.Int64Value(int64(*in.(*uint32)))
+		return types.Int64Value(int64(*in))
 	case *uint64:
-		return types.Int64Value(int64(*in.(*uint64)))
+		return types.Int64Value(int64(*in))
 	case apstra.VNI:
-		return types.Int64Value(int64(in.(apstra.VNI)))
+		return types.Int64Value(int64(in))
 	case apstra.Vlan:
-		return types.Int64Value(int64(in.(apstra.Vlan)))
+		return types.Int64Value(int64(in))
 	case int:
-		return types.Int64Value(int64(in.(int)))
+		return types.Int64Value(int64(in))
 	case int8:
-		return types.Int64Value(int64(in.(int8)))
+		return types.Int64Value(int64(in))
 	case int16:
-		return types.Int64Value(int64(in.(int16)))
+		return types.Int64Value(int64(in))
 	case int32:
-		return types.Int64Value(int64(in.(int32)))
+		return types.Int64Value(int64(in))
 	case int64:
-		return types.Int64Value(in.(int64))
+		return types.Int64Value(in)
 	case uint:
-		return types.Int64Value(int64(in.(uint)))
+		return types.Int64Value(int64(in))
 	case uint8:
-		return types.Int64Value(int64(in.(uint8)))
+		return types.Int64Value(int64(in))
 	case uint16:
-		return types.Int64Value(int64(in.(uint16)))
+		return types.Int64Value(int64(in))
 	case uint32:
-		return types.Int64Value(int64(in.(uint32)))
+		return types.Int64Value(int64(in))
 	case uint64:
-		return types.Int64Value(int64(in.(uint64)))
+		return types.Int64Value(int64(in))
 
 	default:
 		diags.AddError("cannot convert interface to int64",


### PR DESCRIPTION
S1034 [documentation](https://staticcheck.dev/docs/checks#S1034) says:

> Use result of type assertion to simplify cases

Rather than doing a type assertion to select a code path, and then doing the type assertion *again* within the code path, we now save the result of the type assertion in the `switch` statement.

Closes #127