### PR TITLE
Fix crash in data source `apstra_datacenter_routing_zones`

### DIFF
--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -275,24 +275,19 @@ func (o *DatacenterRoutingZone) LoadApiDhcpServers(ctx context.Context, IPs []ne
 func (o *DatacenterRoutingZone) Query(szResultName, policyResultName string) *apstra.PathQuery {
 	query := new(apstra.PathQuery)
 
-	var rz DatacenterRoutingZone // o may be nil, so we work with rz instead
-	if o != nil {
-		rz = *o // rz is a copy of o when o is not nil
-	}
-
-	if utils.Known(rz.RoutingPolicyId) {
+	if utils.Known(o.RoutingPolicyId) {
 		query.Node([]apstra.QEEAttribute{
 			{Key: "type", Value: apstra.QEStringVal(apstra.NodeTypeRoutingPolicy.String())},
-			{Key: "id", Value: apstra.QEStringVal(rz.RoutingPolicyId.ValueString())},
+			{Key: "id", Value: apstra.QEStringVal(o.RoutingPolicyId.ValueString())},
 		})
 		query.In([]apstra.QEEAttribute{
 			{Key: "type", Value: apstra.QEStringVal("policy")},
 		})
 	}
 
-	query.Node(rz.szNodeQueryAttributes(szResultName))
+	query.Node(o.szNodeQueryAttributes(szResultName))
 
-	if utils.Known(rz.DhcpServers) {
+	if utils.Known(o.DhcpServers) {
 		query.Out([]apstra.QEEAttribute{
 			{Key: "type", Value: apstra.QEStringVal("policy")},
 		})
@@ -303,7 +298,7 @@ func (o *DatacenterRoutingZone) Query(szResultName, policyResultName string) *ap
 		})
 	}
 
-	for _, dhcpServerVal := range rz.DhcpServers.Elements() {
+	for _, dhcpServerVal := range o.DhcpServers.Elements() {
 		query.Where("lambda " +
 			policyResultName +
 			": '" +

--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -275,19 +275,24 @@ func (o *DatacenterRoutingZone) LoadApiDhcpServers(ctx context.Context, IPs []ne
 func (o *DatacenterRoutingZone) Query(szResultName, policyResultName string) *apstra.PathQuery {
 	query := new(apstra.PathQuery)
 
-	if utils.Known(o.RoutingPolicyId) {
+	var rz DatacenterRoutingZone // o may be nil, so we work with rz instead
+	if o != nil {
+		rz = *o // rz is a copy of o when o is not nil
+	}
+
+	if utils.Known(rz.RoutingPolicyId) {
 		query.Node([]apstra.QEEAttribute{
 			{Key: "type", Value: apstra.QEStringVal(apstra.NodeTypeRoutingPolicy.String())},
-			{Key: "id", Value: apstra.QEStringVal(o.RoutingPolicyId.ValueString())},
+			{Key: "id", Value: apstra.QEStringVal(rz.RoutingPolicyId.ValueString())},
 		})
 		query.In([]apstra.QEEAttribute{
 			{Key: "type", Value: apstra.QEStringVal("policy")},
 		})
 	}
 
-	query.Node(o.szNodeQueryAttributes(szResultName))
+	query.Node(rz.szNodeQueryAttributes(szResultName))
 
-	if utils.Known(o.DhcpServers) {
+	if utils.Known(rz.DhcpServers) {
 		query.Out([]apstra.QEEAttribute{
 			{Key: "type", Value: apstra.QEStringVal("policy")},
 		})
@@ -298,7 +303,7 @@ func (o *DatacenterRoutingZone) Query(szResultName, policyResultName string) *ap
 		})
 	}
 
-	for _, dhcpServerVal := range o.DhcpServers.Elements() {
+	for _, dhcpServerVal := range rz.DhcpServers.Elements() {
 		query.Where("lambda " +
 			policyResultName +
 			": '" +

--- a/apstra/data_source_datacenter_routing_zones.go
+++ b/apstra/data_source_datacenter_routing_zones.go
@@ -69,11 +69,12 @@ func (o *dataSourceDatacenterRoutingZones) Read(ctx context.Context, req datasou
 		return
 	}
 
-	filters := &blueprint.DatacenterRoutingZone{}
-	d := config.Filters.As(ctx, &filters, basetypes.ObjectAsOptions{})
-	resp.Diagnostics.Append(d...)
-	if resp.Diagnostics.HasError() {
-		return
+	filters := blueprint.DatacenterRoutingZone{}
+	if !config.Filters.IsNull() {
+		resp.Diagnostics.Append(config.Filters.As(ctx, &filters, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	query := filters.Query("n_security_zone", "n_policy")


### PR DESCRIPTION
When the configuration includes filter attributes there is no problem:

```hcl
data "apstra_datacenter_routing_zones" "rzs" {
  blueprint_id = "b726704d-f80e-4733-9103-abd6ccd8752c"
  filters = {
    "name" = "ROUTING_ZONE_A"
  }
}
```

Without a filter...
```hcl
data "apstra_datacenter_routing_zones" "all" {
  blueprint_id = "b726704d-f80e-4733-9103-abd6ccd8752c"
}
```
...`filter` became a nil pointer and crashed when its `Query()` method was invoked.

This PR ensures that `filter` always exists (with `Null` zero values) regardless of the user input so that `filter.Query()` can be invoked safely.