### PR TITLE
Add new resource allocation role strings

### DIFF
--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -21,8 +21,9 @@ const (
 
 	nodeDeployModeNotSet = "not_set"
 
-	resourceGroupNameVxlanVnIds      = "vni_virtual_network_ids"
-	resourceGroupNameLeafL3PeerLinks = "leaf_l3_peer_links"
+	resourceGroupNameVxlanVnIds          = "vni_virtual_network_ids"
+	resourceGroupNameLeafL3PeerLinksIpv4 = "leaf_l3_peer_links"
+	resourceGroupNameLeafL3PeerLinksIpv6 = "leaf_l3_peer_links_ipv6"
 )
 
 type StringerWithFromString interface {
@@ -155,8 +156,10 @@ func refDesignToFriendlyString(in apstra.RefDesign) string {
 
 func resourceGroupNameToFriendlyString(in apstra.ResourceGroupName) string {
 	switch in {
-	case apstra.ResourceGroupNameLeafL3PeerLinkLinkIps:
-		return resourceGroupNameLeafL3PeerLinks
+	case apstra.ResourceGroupNameLeafL3PeerLinkLinkIp4:
+		return resourceGroupNameLeafL3PeerLinksIpv4
+	case apstra.ResourceGroupNameLeafL3PeerLinkLinkIp6:
+		return resourceGroupNameLeafL3PeerLinksIpv6
 	case apstra.ResourceGroupNameVxlanVnIds:
 		return resourceGroupNameVxlanVnIds
 	}
@@ -263,8 +266,10 @@ func resourceGroupNameFromFriendlyString(target *apstra.ResourceGroupName, in ..
 	}
 
 	switch in[0] {
-	case resourceGroupNameLeafL3PeerLinks:
-		*target = apstra.ResourceGroupNameLeafL3PeerLinkLinkIps
+	case resourceGroupNameLeafL3PeerLinksIpv4:
+		*target = apstra.ResourceGroupNameLeafL3PeerLinkLinkIp4
+	case resourceGroupNameLeafL3PeerLinksIpv6:
+		*target = apstra.ResourceGroupNameLeafL3PeerLinkLinkIp6
 	case resourceGroupNameVxlanVnIds:
 		*target = apstra.ResourceGroupNameVxlanVnIds
 	default:

--- a/apstra/utils/rosetta_test.go
+++ b/apstra/utils/rosetta_test.go
@@ -33,7 +33,8 @@ func TestRosetta(t *testing.T) {
 		{string: "freeform", stringers: []fmt.Stringer{apstra.RefDesignFreeform}},
 
 		{string: "vni_virtual_network_ids", stringers: []fmt.Stringer{apstra.ResourceGroupNameVxlanVnIds}},
-		{string: "leaf_l3_peer_links", stringers: []fmt.Stringer{apstra.ResourceGroupNameLeafL3PeerLinkLinkIps}},
+		{string: "leaf_l3_peer_links", stringers: []fmt.Stringer{apstra.ResourceGroupNameLeafL3PeerLinkLinkIp4}},
+		{string: "leaf_l3_peer_links_ipv6", stringers: []fmt.Stringer{apstra.ResourceGroupNameLeafL3PeerLinkLinkIp6}},
 	}
 
 	for i, tc := range testCases {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20230720020021-2ba369439271
+	github.com/Juniper/apstra-go-sdk v0.0.0-20230720180724-83eca0367412
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
@@ -17,7 +17,7 @@ require (
 )
 
 //                                                                                          HHMMSS
-//replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230720020021-2ba369439271
+replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230720180724-83eca0367412
 
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 )
 
 //                                                                                          HHMMSS
-replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230720180724-83eca0367412
+//replace github.com/Juniper/apstra-go-sdk => github.com/Juniper/apstra-go-sdk v0.0.0-20230720180724-83eca0367412
 
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230720020021-2ba369439271 h1:lh1TZC8Ol7EGagofPblEmrY3c1KREkUW6+N3HiqOmuM=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230720020021-2ba369439271/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230720180724-83eca0367412 h1:V7TAkkR4TtOWR+3Te/iXbR6C8vyrsPPIPztPzdOHONc=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230720180724-83eca0367412/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=


### PR DESCRIPTION
New roles introduced by:

- bump upstream SDK dependency (the role strings live here)
- rosetta transform to make `leaf_l3_peer_links_ipv6` from the native API string

Closes #207