### PR TITLE
Add missing `Computed` flag to data source `id` and `name` attributes

### DIFF
--- a/apstra/blueprint/datacenter_routing_policy.go
+++ b/apstra/blueprint/datacenter_routing_policy.go
@@ -150,7 +150,7 @@ func (o DatacenterRoutingPolicy) DataSourceAttributes() map[string]dataSourceSch
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Web UI 'name' field.",
+			MarkdownDescription: "Web UI `name` field.",
 			Computed:            true,
 			Optional:            true,
 			Validators: []validator.String{

--- a/apstra/blueprint/datacenter_routing_policy.go
+++ b/apstra/blueprint/datacenter_routing_policy.go
@@ -139,6 +139,7 @@ func (o DatacenterRoutingPolicy) DataSourceAttributes() map[string]dataSourceSch
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
 			MarkdownDescription: "Apstra graph node ID.",
+			Computed:            true,
 			Optional:            true,
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
@@ -150,6 +151,7 @@ func (o DatacenterRoutingPolicy) DataSourceAttributes() map[string]dataSourceSch
 		},
 		"name": dataSourceSchema.StringAttribute{
 			MarkdownDescription: "Web UI 'name' field.",
+			Computed:            true,
 			Optional:            true,
 			Validators: []validator.String{
 				stringvalidator.LengthBetween(1, 18),

--- a/docs/data-sources/datacenter_routing_policy.md
+++ b/docs/data-sources/datacenter_routing_policy.md
@@ -133,7 +133,7 @@ output "test_policy" { value = data.apstra_datacenter_routing_policy.test }
 ### Optional
 
 - `id` (String) Apstra graph node ID.
-- `name` (String) Web UI 'name' field.
+- `name` (String) Web UI `name` field.
 
 ### Read-Only
 


### PR DESCRIPTION
The `apstra_datacenter_routing_policy` data source seemed to be working okay without the `Computed` flag (relaxed rules in data sources?) but this is more correct.

Minor fix to markdown formatting.

Closes #211