### PR TITLE
Remove extraneous quotes from `apstra_datacenter_routing_zones` example configuration

### DIFF
--- a/docs/data-sources/datacenter_routing_zones.md
+++ b/docs/data-sources/datacenter_routing_zones.md
@@ -15,17 +15,17 @@ This data source returns the IDs of Routing Zones within the specified Blueprint
 # By specifying no filters, a wide search is performed. All routing
 # zones in the blueprint will match.
 data "apstra_datacenter_routing_zones" "all" {
-    blueprint_id = "05f9d3fc-671a-4efc-8e91-5ef87b2937d3"
+  blueprint_id = "05f9d3fc-671a-4efc-8e91-5ef87b2937d3"
 }
 
 # This example performs a very narrow search. Only one (or zero!)
 # routing zones can match the resulting query.
 data "apstra_datacenter_routing_zones" "rzs" {
   blueprint_id = "05f9d3fc-671a-4efc-8e91-5ef87b2937d3"
-  filters = {                             # all filters are optional
-    "name"            = "customer_1"
-    "vlan_id"         = 55
-    "vni"             = 10055
+  filters = { # all filters are optional
+    name              = "customer_1"
+    vlan_id           = 55
+    vni               = 10055
     dhcp_servers      = ["192.168.5.100", "192.168.10.100"]
     routing_policy_id = "vqsv3F93MBHUgg5e8ws"
   }

--- a/examples/data-sources/apstra_datacenter_routing_zones/example.tf
+++ b/examples/data-sources/apstra_datacenter_routing_zones/example.tf
@@ -1,17 +1,17 @@
 # By specifying no filters, a wide search is performed. All routing
 # zones in the blueprint will match.
 data "apstra_datacenter_routing_zones" "all" {
-    blueprint_id = "05f9d3fc-671a-4efc-8e91-5ef87b2937d3"
+  blueprint_id = "05f9d3fc-671a-4efc-8e91-5ef87b2937d3"
 }
 
 # This example performs a very narrow search. Only one (or zero!)
 # routing zones can match the resulting query.
 data "apstra_datacenter_routing_zones" "rzs" {
   blueprint_id = "05f9d3fc-671a-4efc-8e91-5ef87b2937d3"
-  filters = {                             # all filters are optional
-    "name"            = "customer_1"
-    "vlan_id"         = 55
-    "vni"             = 10055
+  filters = { # all filters are optional
+    name              = "customer_1"
+    vlan_id           = 55
+    vni               = 10055
     dhcp_servers      = ["192.168.5.100", "192.168.10.100"]
     routing_policy_id = "vqsv3F93MBHUgg5e8ws"
   }


### PR DESCRIPTION
closes #217