### PR TITLE
Change device allocation behavior on removal of `device_key`

### DIFF
--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -95,12 +95,9 @@ func (o DeviceAllocation) ResourceAttributes() map[string]resourceSchema.Attribu
 		"deploy_mode": resourceSchema.StringAttribute{
 			MarkdownDescription: "Set the [deploy mode](https://www.juniper.net/documentation/us/en/software/apstra4.1/apstra-user-guide/topics/topic-map/datacenter-deploy-mode-set.html) " +
 				"of the associated fabric node.",
-			Optional: true,
-			Computed: true,
-			Validators: []validator.String{
-				stringvalidator.OneOf(utils.AllNodeDeployModes()...),
-				stringvalidator.AlsoRequires(path.MatchRoot("device_key")),
-			},
+			Optional:   true,
+			Computed:   true,
+			Validators: []validator.String{stringvalidator.OneOf(utils.AllNodeDeployModes()...)},
 		},
 	}
 }
@@ -358,20 +355,15 @@ func (o *DeviceAllocation) SetInterfaceMap(ctx context.Context, client *apstra.C
 // SetNodeSystemId assigns a managed device 'device_key' (serial number) to
 // the `system_id` field of a switch 'system' node in the blueprint graph based
 // on the value of o.DeviceKey. When Sets o.DeviceKey is <null>, as would be the
-// case when it's not provided in the Terraform config, SetNodeSystemId returns
-// immediately without making any changes. When o.DeviceKey is <unknown>,
-// SetNodeSystemId clears the graph node's `system_id` field.
+// case when it's not provided in the Terraform config, SetNodeSystemId clears
+// the graph node's `system_id` field.
 //
 // If Apstra returns 404 to any blueprint operation, indicating the blueprint
 // doesn't exist, SetNodeSystemId sets o.BlueprintId to <null> to indicate that
 // resources which depend on the blueprint's existence should be removed.
 func (o *DeviceAllocation) SetNodeSystemId(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
-	if o.DeviceKey.IsNull() {
-		return
-	}
-
 	var deviceKeyPtr *string
-	if !o.DeviceKey.IsUnknown() {
+	if !o.DeviceKey.IsNull() {
 		dk := o.DeviceKey.ValueString()
 		deviceKeyPtr = &dk
 	}


### PR DESCRIPTION
All changes are in the `apstra_datacenter_device_allocation` resource.

- Simplify `blueprint.GetNodeDeplooyMode()` using new-ish `client.GetNode()` method.
- Revert recently added validator which says that `deploy_mode` requires `device_key` be set. These features have no interdependency.
- Change logic for handling removal of `device_key` attribute from configuration (explained below)

Removing `deploy_mode` from the configuration does nothing. The deploy mode knob/selector stays in the last position it was set. We just don't manage that knob anymore. This seems fine.

The same logic had been applied to removing `device_key`, but it makes less sense here. How do you de-allocate a switch, if not by removing it from the config?

Under the old behavior, `SetNodeSystemId()` did nothing when `device_key` was `null` (not present in the config), and only removed the switch when it was found to be `unknown` (a condition which could not happen naturally, but was forced in the resource `Delete()` method.

Now, `SetNodeSystemId()` is only invoked when `device_key` is not null (in `Create()`) or when `device_key` is found to have changed since the prior state (in `Update()`), and a `null` value causes the system to be de-allocated from the topology when the serial number is removed.

Closes #138