### PR TITLE
Bump upstream SDK version; absorb breaking changes

### DIFF
--- a/apstra/blueprint/blueprint.go
+++ b/apstra/blueprint/blueprint.go
@@ -246,7 +246,7 @@ func (o Blueprint) Request(_ context.Context, diags *diag.Diagnostics) *apstra.C
 	}
 
 	return &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:              apstra.RefDesignDatacenter,
+		RefDesign:              apstra.RefDesignTwoStageL3Clos,
 		Label:                  o.Name.ValueString(),
 		TemplateId:             apstra.ObjectId(o.TemplateId.ValueString()),
 		FabricAddressingPolicy: fap,

--- a/apstra/data_source_blueprints.go
+++ b/apstra/data_source_blueprints.go
@@ -46,7 +46,7 @@ func (o *dataSourceBlueprints) Schema(_ context.Context, _ datasource.SchemaRequ
 				MarkdownDescription: "Optional filter to select only Blueprints matching the specified Reference Design.",
 				Optional:            true,
 				Validators: []validator.String{stringvalidator.OneOf(
-					utils.StringersToFriendlyString(apstra.RefDesignDatacenter),
+					utils.StringersToFriendlyString(apstra.RefDesignTwoStageL3Clos),
 					apstra.RefDesignFreeform.String(),
 				)},
 			},

--- a/apstra/design/configlet.go
+++ b/apstra/design/configlet.go
@@ -80,7 +80,7 @@ func (o *Configlet) Request(ctx context.Context, diags *diag.Diagnostics) *apstr
 	var d diag.Diagnostics
 
 	// We only use the Datacenter Reference Design
-	refArchs := []apstra.RefDesign{apstra.RefDesignDatacenter}
+	refArchs := []apstra.RefDesign{apstra.RefDesignTwoStageL3Clos}
 
 	// Extract configlet generators
 	tfGenerators := make([]ConfigletGenerator, len(o.Generators.Elements()))

--- a/apstra/resource_managed_device.go
+++ b/apstra/resource_managed_device.go
@@ -65,7 +65,7 @@ func (o *resourceManagedDevice) Create(ctx context.Context, req resource.CreateR
 	}
 
 	// Create new Agent for this Managed Device
-	agentId, err := o.client.CreateAgent(ctx, request)
+	agentId, err := o.client.CreateSystemAgent(ctx, request)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"error creating new Agent",

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -17,7 +17,7 @@ func BlueprintA(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context
 
 	name := acctest.RandString(10)
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignDatacenter,
+		RefDesign:  apstra.RefDesignTwoStageL3Clos,
 		Label:      name,
 		TemplateId: "L2_Virtual_EVPN",
 		FabricAddressingPolicy: &apstra.FabricAddressingPolicy{
@@ -62,7 +62,7 @@ func BlueprintB(ctx context.Context) (*apstra.TwoStageL3ClosClient, apstra.Objec
 
 	name := acctest.RandString(10)
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignDatacenter,
+		RefDesign:  apstra.RefDesignTwoStageL3Clos,
 		Label:      name,
 		TemplateId: template.Id,
 		FabricAddressingPolicy: &apstra.FabricAddressingPolicy{
@@ -103,7 +103,7 @@ func BlueprintC(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context
 
 	name := acctest.RandString(10)
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignDatacenter,
+		RefDesign:  apstra.RefDesignTwoStageL3Clos,
 		Label:      name,
 		TemplateId: template.Id,
 		FabricAddressingPolicy: &apstra.FabricAddressingPolicy{
@@ -144,7 +144,7 @@ func BlueprintD(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context
 
 	name := acctest.RandString(10)
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignDatacenter,
+		RefDesign:  apstra.RefDesignTwoStageL3Clos,
 		Label:      name,
 		TemplateId: template.Id,
 		FabricAddressingPolicy: &apstra.FabricAddressingPolicy{
@@ -245,7 +245,7 @@ func BlueprintE(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context
 
 	name := acctest.RandString(10)
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignDatacenter,
+		RefDesign:  apstra.RefDesignTwoStageL3Clos,
 		Label:      name,
 		TemplateId: template.Id,
 		FabricAddressingPolicy: &apstra.FabricAddressingPolicy{
@@ -285,7 +285,7 @@ func BlueprintF(ctx context.Context) (*apstra.TwoStageL3ClosClient, func(context
 
 	name := acctest.RandString(10)
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignDatacenter,
+		RefDesign:  apstra.RefDesignTwoStageL3Clos,
 		Label:      name,
 		TemplateId: template.Id,
 		FabricAddressingPolicy: &apstra.FabricAddressingPolicy{

--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -147,7 +147,7 @@ func overlayControlProtocolToFriendlyString(in apstra.OverlayControlProtocol) st
 
 func refDesignToFriendlyString(in apstra.RefDesign) string {
 	switch in {
-	case apstra.RefDesignDatacenter:
+	case apstra.RefDesignTwoStageL3Clos:
 		return refDesignDataCenter
 	}
 
@@ -252,7 +252,7 @@ func refDesignFromFriendlyString(target *apstra.RefDesign, in ...string) error {
 
 	switch in[0] {
 	case refDesignDataCenter:
-		*target = apstra.RefDesignDatacenter
+		*target = apstra.RefDesignTwoStageL3Clos
 	default:
 		return target.FromString(in[0])
 	}

--- a/apstra/utils/rosetta_test.go
+++ b/apstra/utils/rosetta_test.go
@@ -29,7 +29,7 @@ func TestRosetta(t *testing.T) {
 		{string: "static", stringers: []fmt.Stringer{apstra.OverlayControlProtocolNone}},
 		{string: "evpn", stringers: []fmt.Stringer{apstra.OverlayControlProtocolEvpn}},
 
-		{string: "datacenter", stringers: []fmt.Stringer{apstra.RefDesignDatacenter}},
+		{string: "datacenter", stringers: []fmt.Stringer{apstra.RefDesignTwoStageL3Clos}},
 		{string: "freeform", stringers: []fmt.Stringer{apstra.RefDesignFreeform}},
 
 		{string: "vni_virtual_network_ids", stringers: []fmt.Stringer{apstra.ResourceGroupNameVxlanVnIds}},

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20230801124116-78482286e91a
+	github.com/Juniper/apstra-go-sdk v0.0.0-20230802183107-9ab5c1f1cc78
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230801124116-78482286e91a h1:2MQASu0+FglJB8HwJ4lmmMNWaBfztdwimXf8xDG20dU=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230801124116-78482286e91a/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230802183107-9ab5c1f1cc78 h1:peEAGiVd9iVGWTvz3lWx5HrBpWy+CCMDGGzJ13N/29Q=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230802183107-9ab5c1f1cc78/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=


### PR DESCRIPTION
- https://github.com/Juniper/apstra-go-sdk/pull/66
- https://github.com/Juniper/apstra-go-sdk/pull/70