### PR TITLE
Fixed task # 239

### DIFF
--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -200,7 +200,7 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 			Optional: true,
 			Computed: true,
 			Validators: []validator.String{
-				apstravalidator.ParseCidr(true, false),
+				apstravalidator.ParseCidr(false, true),
 				apstravalidator.WhenValueSetString(
 					apstravalidator.ValueAtMustBeString(
 						path.MatchRelative().AtParent().AtName("ipv6_connectivity_enabled"),
@@ -261,7 +261,7 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 			Optional: true,
 			Computed: true,
 			Validators: []validator.String{
-				apstravalidator.ParseIp(true, false),
+				apstravalidator.ParseIp(false, true),
 				apstravalidator.FallsWithinCidr(
 					path.MatchRelative().AtParent().AtName("ipv6_subnet"),
 					true, true),


### PR DESCRIPTION
apstravalidator.ParseCidr for ipv6_virtual_gateway and ipv6_subnet were incorrectly set in the reverse order. now set to apstravalidator.ParseCidr(false, true),