### PR TITLE
Copy missing `id` field from API response into `apstra_datacenter_routing_zone`

### DIFF
--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -76,7 +76,7 @@ func (o DatacenterRoutingZone) DataSourceAttributes() map[string]dataSourceSchem
 		},
 		"had_prior_vlan_id_config": dataSourceSchema.BoolAttribute{
 			MarkdownDescription: "Used to trigger plan modification when `vlan_id` has been removed from the " +
-				"configuration in managed resource context, this attribute will always be `false` and should be " +
+				"configuration in managed resource context, this attribute will always be `null` and should be " +
 				"ignored in data source context.",
 			Computed: true,
 		},
@@ -87,7 +87,7 @@ func (o DatacenterRoutingZone) DataSourceAttributes() map[string]dataSourceSchem
 		},
 		"had_prior_vni_config": dataSourceSchema.BoolAttribute{
 			MarkdownDescription: "Used to trigger plan modification when `vni` has been removed from the " +
-				"configuration in managed resource context, this attribute will always be `false` and should be " +
+				"configuration in managed resource context, this attribute will always be `null` and should be " +
 				"ignored in data source context.",
 			Computed: true,
 		},

--- a/apstra/data_source_datacenter_routing_zone.go
+++ b/apstra/data_source_datacenter_routing_zone.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-apstra/apstra/blueprint"
 	"terraform-provider-apstra/apstra/utils"
 )
@@ -86,6 +87,7 @@ func (o *dataSourceDatacenterRoutingZone) Read(ctx context.Context, req datasour
 			return
 		}
 	}
+	config.Id = types.StringValue(api.Id.String())
 	config.LoadApiData(ctx, api.Data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return

--- a/apstra/data_source_datacenter_routing_zone.go
+++ b/apstra/data_source_datacenter_routing_zone.go
@@ -87,6 +87,7 @@ func (o *dataSourceDatacenterRoutingZone) Read(ctx context.Context, req datasour
 			return
 		}
 	}
+
 	config.Id = types.StringValue(api.Id.String())
 	config.LoadApiData(ctx, api.Data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {

--- a/docs/data-sources/datacenter_routing_zone.md
+++ b/docs/data-sources/datacenter_routing_zone.md
@@ -60,8 +60,8 @@ output "routing_zone" {
 ### Read-Only
 
 - `dhcp_servers` (Set of String) Set of DHCP server IPv4 or IPv6 addresses of DHCP servers.
-- `had_prior_vlan_id_config` (Boolean) Used to trigger plan modification when `vlan_id` has been removed from the configuration in managed resource context, this attribute will always be `false` and should be ignored in data source context.
-- `had_prior_vni_config` (Boolean) Used to trigger plan modification when `vni` has been removed from the configuration in managed resource context, this attribute will always be `false` and should be ignored in data source context.
+- `had_prior_vlan_id_config` (Boolean) Used to trigger plan modification when `vlan_id` has been removed from the configuration in managed resource context, this attribute will always be `null` and should be ignored in data source context.
+- `had_prior_vni_config` (Boolean) Used to trigger plan modification when `vni` has been removed from the configuration in managed resource context, this attribute will always be `null` and should be ignored in data source context.
 - `routing_policy_id` (String) Non-EVPN blueprints must use the default policy, so this field must be null. Set this attribute in an EVPN blueprint to use a non-default policy.
 - `vlan_id` (Number) Used for VLAN tagged Layer 3 links on external connections. Leave this field blank to have it automatically assigned from a static pool in the range of 2-4094), or enter a specific value.
 - `vni` (Number) VxLAN VNI associated with the routing zone. Leave this field blank to have it automatically assigned from an allocated resource pool, or enter a specific value.


### PR DESCRIPTION
closes #244