### PR TITLE
Update docs to clarify when either `id` or `name` is required input

### DIFF
--- a/apstra/blueprint/blueprint.go
+++ b/apstra/blueprint/blueprint.go
@@ -44,7 +44,7 @@ type Blueprint struct {
 func (o Blueprint) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "ID of the Blueprint: Either as a result of a lookup, or user-specified.",
+			MarkdownDescription: "ID of the Blueprint. Required when `name` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators: []validator.String{
@@ -56,7 +56,7 @@ func (o Blueprint) DataSourceAttributes() map[string]dataSourceSchema.Attribute 
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Name of the Blueprint: Either as a result of a lookup, or user-specified.",
+			MarkdownDescription: "Name of the Blueprint. Required when `id` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},

--- a/apstra/blueprint/datacenter_routing_policy.go
+++ b/apstra/blueprint/datacenter_routing_policy.go
@@ -137,7 +137,7 @@ func (o DatacenterRoutingPolicy) ResourceAttributes() map[string]resourceSchema.
 func (o DatacenterRoutingPolicy) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Apstra graph node ID.",
+			MarkdownDescription: "Apstra graph node ID. Required when `name` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators: []validator.String{
@@ -149,7 +149,7 @@ func (o DatacenterRoutingPolicy) DataSourceAttributes() map[string]dataSourceSch
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Web UI `name` field.",
+			MarkdownDescription: "Web UI `name` field. Required when `id` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators:          []validator.String{stringvalidator.LengthBetween(1, 18)},

--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -43,7 +43,7 @@ func (o DatacenterRoutingZone) DataSourceAttributes() map[string]dataSourceSchem
 	nameRE := regexp.MustCompile("^[A-Za-z0-9_-]+$")
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Apstra graph node ID.",
+			MarkdownDescription: "Apstra graph node ID. Required when `name` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators: []validator.String{
@@ -55,7 +55,7 @@ func (o DatacenterRoutingZone) DataSourceAttributes() map[string]dataSourceSchem
 			},
 		},
 		"blueprint_id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Apstra Blueprint ID.",
+			MarkdownDescription: "Apstra Blueprint ID. Required when `id` is omitted.",
 			Required:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},

--- a/apstra/blueprint/node_system.go
+++ b/apstra/blueprint/node_system.go
@@ -28,7 +28,7 @@ func (o NodeTypeSystem) DataSourceAttributes() map[string]dataSourceSchema.Attri
 			Required:            true,
 		},
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Apstra Graph DB node `id` field",
+			MarkdownDescription: "Apstra Graph DB node `id` field. Required when `name` is omitted.",
 			Optional:            true,
 			Validators: []validator.String{stringvalidator.ExactlyOneOf(path.Expressions{
 				path.MatchRelative(),
@@ -36,7 +36,7 @@ func (o NodeTypeSystem) DataSourceAttributes() map[string]dataSourceSchema.Attri
 			}...)},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Apstra Web UI `name` field / Graph DB `label` field",
+			MarkdownDescription: "Apstra Web UI name (araph DB `label` field). Required when `id` is omitted.",
 			Optional:            true,
 		},
 		"attributes": dataSourceSchema.SingleNestedAttribute{

--- a/apstra/data_source_asn_pool.go
+++ b/apstra/data_source_asn_pool.go
@@ -29,9 +29,7 @@ func (o *dataSourceAsnPool) Configure(ctx context.Context, req datasource.Config
 func (o *dataSourceAsnPool) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source provides details of a specific ASN Pool.\n\n" +
-			"At least one optional attribute is required. " +
-			"It is incumbent upon the user to ensure the lookup criteria matches exactly one ASN Pool. " +
-			"Matching zero or more ASN Pools will produce an error.",
+			"At least one optional attribute is required.",
 		Attributes: resources.AsnPool{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_configlet.go
+++ b/apstra/data_source_configlet.go
@@ -29,7 +29,7 @@ func (o *dataSourceConfiglet) Configure(ctx context.Context, req datasource.Conf
 func (o *dataSourceConfiglet) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source provides details of a specific Configlet.\n\n" +
-			"At least one optional attribute is required. ",
+			"At least one optional attribute is required.",
 		Attributes: design.Configlet{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_datacenter_blueprint.go
+++ b/apstra/data_source_datacenter_blueprint.go
@@ -28,9 +28,7 @@ func (o *dataSourceDatacenterBlueprint) Configure(ctx context.Context, req datas
 func (o *dataSourceDatacenterBlueprint) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source looks up summary details of a Datacenter Blueprint.\n\n" +
-			"At least one optional attribute is required. " +
-			"It is incumbent upon the user to ensure the lookup criteria matches exactly one Datacenter Blueprint. " +
-			"Matching zero or more Datacenter Blueprints will produce an error.",
+			"At least one optional attribute is required.",
 		Attributes: blueprint.Blueprint{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_datacenter_property_set.go
+++ b/apstra/data_source_datacenter_property_set.go
@@ -28,7 +28,7 @@ func (o *dataSourceDatacenterPropertySet) Configure(ctx context.Context, req dat
 func (o *dataSourceDatacenterPropertySet) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source provides details of a specific Property Set imported into a Blueprint.\n\n" +
-			"At least one optional attribute is required. ",
+			"At least one optional attribute is required.",
 		Attributes: blueprint.DatacenterPropertySet{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_datacenter_routing_policy.go
+++ b/apstra/data_source_datacenter_routing_policy.go
@@ -30,7 +30,7 @@ func (o *dataSourceDatacenterRoutingPolicy) Schema(_ context.Context, _ datasour
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This resource returns details of a Datacenter Routing Policy.\n\n" +
 			"At least one optional attribute is required.",
-		Attributes:          blueprint.DatacenterRoutingPolicy{}.DataSourceAttributes(),
+		Attributes: blueprint.DatacenterRoutingPolicy{}.DataSourceAttributes(),
 	}
 }
 

--- a/apstra/data_source_datacenter_routing_policy.go
+++ b/apstra/data_source_datacenter_routing_policy.go
@@ -28,7 +28,8 @@ func (o *dataSourceDatacenterRoutingPolicy) Configure(ctx context.Context, req d
 
 func (o *dataSourceDatacenterRoutingPolicy) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "This resource returns details of a Datacenter Routing Policy.",
+		MarkdownDescription: "This resource returns details of a Datacenter Routing Policy.\n\n" +
+			"At least one optional attribute is required.",
 		Attributes:          blueprint.DatacenterRoutingPolicy{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_datacenter_routing_zone.go
+++ b/apstra/data_source_datacenter_routing_zone.go
@@ -29,7 +29,8 @@ func (o *dataSourceDatacenterRoutingZone) Configure(ctx context.Context, req dat
 
 func (o *dataSourceDatacenterRoutingZone) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "This resource returns details of a Routing Zone within a Datacenter Blueprint.",
+		MarkdownDescription: "This resource returns details of a Routing Zone within a Datacenter Blueprint.\n\n" +
+			"At least one optional attribute is required.",
 		Attributes:          blueprint.DatacenterRoutingZone{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_datacenter_routing_zone.go
+++ b/apstra/data_source_datacenter_routing_zone.go
@@ -31,7 +31,7 @@ func (o *dataSourceDatacenterRoutingZone) Schema(_ context.Context, _ datasource
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This resource returns details of a Routing Zone within a Datacenter Blueprint.\n\n" +
 			"At least one optional attribute is required.",
-		Attributes:          blueprint.DatacenterRoutingZone{}.DataSourceAttributes(),
+		Attributes: blueprint.DatacenterRoutingZone{}.DataSourceAttributes(),
 	}
 }
 

--- a/apstra/data_source_datacenter_system.go
+++ b/apstra/data_source_datacenter_system.go
@@ -24,8 +24,8 @@ func (o *dataSourceDatacenterSystemNode) Configure(ctx context.Context, req data
 
 func (o *dataSourceDatacenterSystemNode) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "This data source returns details of a specific " +
-			"*system* Graph DB node within a Blueprint.",
+		MarkdownDescription: "This data source returns details of a specific *system* Graph DB node within a Blueprint.\n\n" +
+			"At least one optional attribute is required.",
 		Attributes: blueprint.NodeTypeSystem{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_interface_map.go
+++ b/apstra/data_source_interface_map.go
@@ -29,9 +29,7 @@ func (o *dataSourceInterfaceMap) Configure(ctx context.Context, req datasource.C
 func (o *dataSourceInterfaceMap) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source provides details of a specific Interface Map.\n\n" +
-			"At least one optional attribute is required. " +
-			"It is incumbent upon the user to ensure the lookup criteria matches exactly one Interface Map. " +
-			"Matching zero or more Interface Maps will produce an error.",
+			"At least one optional attribute is required. ",
 		Attributes: design.InterfaceMap{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_ipv4_pool.go
+++ b/apstra/data_source_ipv4_pool.go
@@ -28,9 +28,7 @@ func (o *dataSourceIpv4Pool) Configure(ctx context.Context, req datasource.Confi
 func (o *dataSourceIpv4Pool) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source provides details of a specific IPv4 Pool.\n\n" +
-			"At least one optional attribute is required. " +
-			"It is incumbent upon the user to ensure the lookup criteria matches exactly one IPv4 Pool. " +
-			"Matching zero or more IPv4 Pools will produce an error.",
+			"At least one optional attribute is required. ",
 		Attributes: resources.Ipv4Pool{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_ipv6_pool.go
+++ b/apstra/data_source_ipv6_pool.go
@@ -28,9 +28,7 @@ func (o *dataSourceIpv6Pool) Configure(ctx context.Context, req datasource.Confi
 func (o *dataSourceIpv6Pool) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source provides details of a specific IPv6 Pool.\n\n" +
-			"At least one optional attribute is required. " +
-			"It is incumbent upon the user to ensure the lookup criteria matches exactly one IPv6 Pool. " +
-			"Matching zero or more IPv6 Pools will produce an error.",
+			"At least one optional attribute is required. ",
 		Attributes: resources.Ipv6Pool{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_logical_device.go
+++ b/apstra/data_source_logical_device.go
@@ -29,9 +29,7 @@ func (o *dataSourceLogicalDevice) Configure(ctx context.Context, req datasource.
 func (o *dataSourceLogicalDevice) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source provides details of a specific Logical Device.\n\n" +
-			"At least one optional attribute is required. " +
-			"It is incumbent upon the user to ensure the lookup criteria matches exactly one Logical Device. " +
-			"Matching zero or more Logical Devices will produce an error.",
+			"At least one optional attribute is required.",
 		Attributes: design.LogicalDevice{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_property_set.go
+++ b/apstra/data_source_property_set.go
@@ -29,7 +29,7 @@ func (o *dataSourcePropertySet) Configure(ctx context.Context, req datasource.Co
 func (o *dataSourcePropertySet) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source provides details of a specific PropertySet.\n\n" +
-			"At least one optional attribute is required. ",
+			"At least one optional attribute is required.",
 		Attributes: design.PropertySet{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_rack_type.go
+++ b/apstra/data_source_rack_type.go
@@ -29,9 +29,7 @@ func (o *dataSourceRackType) Configure(ctx context.Context, req datasource.Confi
 func (o *dataSourceRackType) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source provides details of a specific Rack Type.\n\n" +
-			"At least one optional attribute is required. " +
-			"It is incumbent on the user to ensure the criteria matches exactly one Rack Type. " +
-			"Matching zero Rack Types or more than one Rack Type will produce an error.",
+			"At least one optional attribute is required.",
 		Attributes: design.RackType{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_template_rack_based.go
+++ b/apstra/data_source_template_rack_based.go
@@ -28,9 +28,7 @@ func (o *dataSourceTemplateRackBased) Configure(ctx context.Context, req datasou
 func (o *dataSourceTemplateRackBased) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source provides details of a specific Rack Based (3 stage) Template.\n\n" +
-			"At least one optional attribute is required. " +
-			"It is incumbent on the user to ensure the criteria matches exactly one Rack Based Template. " +
-			"Matching zero Rack Based Templates or more than one Rack Based Template will produce an error.",
+			"At least one optional attribute is required.",
 		Attributes: design.TemplateRackBased{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_vni_pool.go
+++ b/apstra/data_source_vni_pool.go
@@ -29,9 +29,7 @@ func (o *dataSourceVniPool) Configure(ctx context.Context, req datasource.Config
 func (o *dataSourceVniPool) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source provides details of a specific VNI Pool.\n\n" +
-			"At least one optional attribute is required. " +
-			"It is incumbent upon the user to ensure the lookup criteria matches exactly one VNI Pool. " +
-			"Matching zero or more VNI Pools will produce an error.",
+			"At least one optional attribute is required.",
 		Attributes: resources.VniPool{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/design/interface_map.go
+++ b/apstra/design/interface_map.go
@@ -22,7 +22,7 @@ type InterfaceMap struct {
 func (o InterfaceMap) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Interface Map ID.  Required when the Interface Map name is omitted.",
+			MarkdownDescription: "Apstra Interface Map ID. Required when `name` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators: []validator.String{
@@ -34,7 +34,7 @@ func (o InterfaceMap) DataSourceAttributes() map[string]dataSourceSchema.Attribu
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Interface Map name displayed in the Apstra web UI.  Required when Interface Map ID is omitted.",
+			MarkdownDescription: "Interface Map name displayed in the Apstra web UI. Required when `id` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},

--- a/apstra/design/logical_device.go
+++ b/apstra/design/logical_device.go
@@ -26,7 +26,7 @@ type LogicalDevice struct {
 func (o LogicalDevice) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Populate this field to look up a Logical Device by ID. Required when `name`is omitted.",
+			MarkdownDescription: "Apstra ID of the Logical Device. Required when `name` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators: []validator.String{
@@ -38,7 +38,7 @@ func (o LogicalDevice) DataSourceAttributes() map[string]dataSourceSchema.Attrib
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Populate this field to look up a Logical Device by name. Required when `id`is omitted.",
+			MarkdownDescription: "Web UI name of the Logical Device. Required when `id` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},

--- a/apstra/design/property_set.go
+++ b/apstra/design/property_set.go
@@ -27,7 +27,7 @@ type PropertySet struct {
 func (o PropertySet) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Populate this field to look up a Property Set by ID. Required when `name` is omitted.",
+			MarkdownDescription: "Apstra ID of the Property Set. Required when `name` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators: []validator.String{
@@ -39,7 +39,7 @@ func (o PropertySet) DataSourceAttributes() map[string]dataSourceSchema.Attribut
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Populate this field to look up a Property Set by name. Required when `id` is omitted.",
+			MarkdownDescription: "Web UID name of the Property Set. Required when `id` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},

--- a/apstra/design/rack_type.go
+++ b/apstra/design/rack_type.go
@@ -32,7 +32,7 @@ type RackType struct {
 func (o RackType) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Rack Type ID.  Required when the Rack Type name is omitted.",
+			MarkdownDescription: "Apstra ID of the Rack Type. Required when `name` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators: []validator.String{
@@ -44,7 +44,7 @@ func (o RackType) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Rack Type name displayed in the Apstra web UI.  Required when Rack Type ID is omitted.",
+			MarkdownDescription: "Web UI name of the Type. Required when `id` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},

--- a/apstra/design/tag.go
+++ b/apstra/design/tag.go
@@ -25,7 +25,7 @@ type Tag struct {
 func (o Tag) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Populate this field to look up a Tag by ID. Required when `name`is omitted.",
+			MarkdownDescription: "Apstra ID of the Tag. Required when `name` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators: []validator.String{
@@ -37,7 +37,7 @@ func (o Tag) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Populate this field to look up a Tag by name. Required when `id` is omitted.",
+			MarkdownDescription: "Web UI name of the Tag. Required when `id` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators: []validator.String{

--- a/apstra/design/template_rack_based.go
+++ b/apstra/design/template_rack_based.go
@@ -33,7 +33,7 @@ type TemplateRackBased struct {
 func (o TemplateRackBased) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Template ID.  Required when the Template name is omitted.",
+			MarkdownDescription: "Apstra Template ID. Required when `id` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators: []validator.String{
@@ -45,7 +45,7 @@ func (o TemplateRackBased) DataSourceAttributes() map[string]dataSourceSchema.At
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Template name displayed in the Apstra web UI.  Required when Template ID is omitted.",
+			MarkdownDescription: "Web UI name of the Template. Required when `id` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators: []validator.String{

--- a/apstra/devices_agent_profile.go
+++ b/apstra/devices_agent_profile.go
@@ -30,7 +30,7 @@ type agentProfile struct {
 func (o agentProfile) dataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Populate this field to look up an Agent Profile by ID. Required when `name`is omitted.",
+			MarkdownDescription: "Apstra ID of the Agent Profile. Required when `name` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators: []validator.String{
@@ -42,7 +42,7 @@ func (o agentProfile) dataSourceAttributes() map[string]dataSourceSchema.Attribu
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Populate this field to look up an Agent Profile by name. Required when `id`is omitted.",
+			MarkdownDescription: "Web UID name of the Agent Profile. Required when `id` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},

--- a/apstra/resources/asn_pool.go
+++ b/apstra/resources/asn_pool.go
@@ -29,7 +29,7 @@ type AsnPool struct {
 func (o AsnPool) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "ID of the desired ASN Pool.",
+			MarkdownDescription: "ID of the desired ASN Pool. Required when `name` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators: []validator.String{
@@ -41,7 +41,7 @@ func (o AsnPool) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Display name of the ASN Pool.",
+			MarkdownDescription: "Display name of the ASN Pool. Required when `id` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},

--- a/apstra/resources/ipv4_pool.go
+++ b/apstra/resources/ipv4_pool.go
@@ -29,7 +29,7 @@ type Ipv4Pool struct {
 func (o Ipv4Pool) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "ID of the desired IPv4 Pool.",
+			MarkdownDescription: "Apstra ID of the desired IPv4 Pool. Required when `name` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators: []validator.String{
@@ -41,7 +41,7 @@ func (o Ipv4Pool) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Name of the IPv4 pool.",
+			MarkdownDescription: "Web UI Name of the IPv4 pool. Required when `id` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},

--- a/apstra/resources/ipv6_pool.go
+++ b/apstra/resources/ipv6_pool.go
@@ -29,7 +29,7 @@ type Ipv6Pool struct {
 func (o Ipv6Pool) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "ID of the desired IPv6 Pool.",
+			MarkdownDescription: "Apstra ID of the desired IPv6 Pool. Required when `name` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators: []validator.String{
@@ -41,7 +41,7 @@ func (o Ipv6Pool) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Name of the IPv6 pool.",
+			MarkdownDescription: "Web UI Name of the IPv6 pool. Required when `id` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},

--- a/apstra/resources/vni_pool.go
+++ b/apstra/resources/vni_pool.go
@@ -29,7 +29,7 @@ type VniPool struct {
 func (o VniPool) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "ID of the desired VNI Pool.",
+			MarkdownDescription: "Apstra ID of the VNI Pool. Required when `name` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators: []validator.String{
@@ -41,7 +41,7 @@ func (o VniPool) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Display name of the VNI Pool.",
+			MarkdownDescription: "Web UI name of the VNI Pool. Required when `id` is omitted.",
 			Computed:            true,
 			Optional:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},

--- a/docs/data-sources/agent_profile.md
+++ b/docs/data-sources/agent_profile.md
@@ -37,8 +37,8 @@ output "agent_profiles_missing_credentials" {
 
 ### Optional
 
-- `id` (String) Populate this field to look up an Agent Profile by ID. Required when `name`is omitted.
-- `name` (String) Populate this field to look up an Agent Profile by name. Required when `id`is omitted.
+- `id` (String) Apstra ID of the Agent Profile. Required when `name` is omitted.
+- `name` (String) Web UID name of the Agent Profile. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/asn_pool.md
+++ b/docs/data-sources/asn_pool.md
@@ -3,14 +3,14 @@ page_title: "apstra_asn_pool Data Source - terraform-provider-apstra"
 subcategory: ""
 description: |-
   This data source provides details of a specific ASN Pool.
-  At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one ASN Pool. Matching zero or more ASN Pools will produce an error.
+  At least one optional attribute is required.
 ---
 
 # apstra_asn_pool (Data Source)
 
 This data source provides details of a specific ASN Pool.
 
-At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one ASN Pool. Matching zero or more ASN Pools will produce an error.
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -61,8 +61,8 @@ output "asn_report" {
 
 ### Optional
 
-- `id` (String) ID of the desired ASN Pool.
-- `name` (String) Display name of the ASN Pool.
+- `id` (String) ID of the desired ASN Pool. Required when `name` is omitted.
+- `name` (String) Display name of the ASN Pool. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/datacenter_blueprint.md
+++ b/docs/data-sources/datacenter_blueprint.md
@@ -3,14 +3,14 @@ page_title: "apstra_datacenter_blueprint Data Source - terraform-provider-apstra
 subcategory: ""
 description: |-
   This data source looks up summary details of a Datacenter Blueprint.
-  At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one Datacenter Blueprint. Matching zero or more Datacenter Blueprints will produce an error.
+  At least one optional attribute is required.
 ---
 
 # apstra_datacenter_blueprint (Data Source)
 
 This data source looks up summary details of a Datacenter Blueprint.
 
-At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one Datacenter Blueprint. Matching zero or more Datacenter Blueprints will produce an error.
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -45,8 +45,8 @@ resource "apstra_blueprint_deployment" "as_needed" {
 
 ### Optional
 
-- `id` (String) ID of the Blueprint: Either as a result of a lookup, or user-specified.
-- `name` (String) Name of the Blueprint: Either as a result of a lookup, or user-specified.
+- `id` (String) ID of the Blueprint. Required when `name` is omitted.
+- `name` (String) Name of the Blueprint. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/datacenter_routing_policy.md
+++ b/docs/data-sources/datacenter_routing_policy.md
@@ -3,11 +3,14 @@ page_title: "apstra_datacenter_routing_policy Data Source - terraform-provider-a
 subcategory: ""
 description: |-
   This resource returns details of a Datacenter Routing Policy.
+  At least one optional attribute is required.
 ---
 
 # apstra_datacenter_routing_policy (Data Source)
 
 This resource returns details of a Datacenter Routing Policy.
+
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -132,8 +135,8 @@ output "test_policy" { value = data.apstra_datacenter_routing_policy.test }
 
 ### Optional
 
-- `id` (String) Apstra graph node ID.
-- `name` (String) Web UI `name` field.
+- `id` (String) Apstra graph node ID. Required when `name` is omitted.
+- `name` (String) Web UI `name` field. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/datacenter_routing_zone.md
+++ b/docs/data-sources/datacenter_routing_zone.md
@@ -3,11 +3,14 @@ page_title: "apstra_datacenter_routing_zone Data Source - terraform-provider-aps
 subcategory: ""
 description: |-
   This resource returns details of a Routing Zone within a Datacenter Blueprint.
+  At least one optional attribute is required.
 ---
 
 # apstra_datacenter_routing_zone (Data Source)
 
 This resource returns details of a Routing Zone within a Datacenter Blueprint.
+
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -50,11 +53,11 @@ output "routing_zone" {
 
 ### Required
 
-- `blueprint_id` (String) Apstra Blueprint ID.
+- `blueprint_id` (String) Apstra Blueprint ID. Required when `id` is omitted.
 
 ### Optional
 
-- `id` (String) Apstra graph node ID.
+- `id` (String) Apstra graph node ID. Required when `name` is omitted.
 - `name` (String) VRF name displayed in thw Apstra web UI.
 
 ### Read-Only

--- a/docs/data-sources/datacenter_system.md
+++ b/docs/data-sources/datacenter_system.md
@@ -3,11 +3,14 @@ page_title: "apstra_datacenter_system Data Source - terraform-provider-apstra"
 subcategory: ""
 description: |-
   This data source returns details of a specific system Graph DB node within a Blueprint.
+  At least one optional attribute is required.
 ---
 
 # apstra_datacenter_system (Data Source)
 
 This data source returns details of a specific *system* Graph DB node within a Blueprint.
+
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -50,8 +53,8 @@ locals {
 
 ### Optional
 
-- `id` (String) Apstra Graph DB node `id` field
-- `name` (String) Apstra Web UI `name` field / Graph DB `label` field
+- `id` (String) Apstra Graph DB node `id` field. Required when `name` is omitted.
+- `name` (String) Apstra Web UI name (araph DB `label` field). Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/interface_map.md
+++ b/docs/data-sources/interface_map.md
@@ -3,14 +3,14 @@ page_title: "apstra_interface_map Data Source - terraform-provider-apstra"
 subcategory: ""
 description: |-
   This data source provides details of a specific Interface Map.
-  At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one Interface Map. Matching zero or more Interface Maps will produce an error.
+  At least one optional attribute is required.
 ---
 
 # apstra_interface_map (Data Source)
 
 This data source provides details of a specific Interface Map.
 
-At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one Interface Map. Matching zero or more Interface Maps will produce an error.
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -67,8 +67,8 @@ output "unmapped_interface_count" {
 
 ### Optional
 
-- `id` (String) Interface Map ID.  Required when the Interface Map name is omitted.
-- `name` (String) Interface Map name displayed in the Apstra web UI.  Required when Interface Map ID is omitted.
+- `id` (String) Apstra Interface Map ID. Required when `name` is omitted.
+- `name` (String) Interface Map name displayed in the Apstra web UI. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/ipv4_pool.md
+++ b/docs/data-sources/ipv4_pool.md
@@ -3,14 +3,14 @@ page_title: "apstra_ipv4_pool Data Source - terraform-provider-apstra"
 subcategory: ""
 description: |-
   This data source provides details of a specific IPv4 Pool.
-  At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one IPv4 Pool. Matching zero or more IPv4 Pools will produce an error.
+  At least one optional attribute is required.
 ---
 
 # apstra_ipv4_pool (Data Source)
 
 This data source provides details of a specific IPv4 Pool.
 
-At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one IPv4 Pool. Matching zero or more IPv4 Pools will produce an error.
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -74,8 +74,8 @@ output "ipv4_pool_report" {
 
 ### Optional
 
-- `id` (String) ID of the desired IPv4 Pool.
-- `name` (String) Name of the IPv4 pool.
+- `id` (String) Apstra ID of the desired IPv4 Pool. Required when `name` is omitted.
+- `name` (String) Web UI Name of the IPv4 pool. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/ipv6_pool.md
+++ b/docs/data-sources/ipv6_pool.md
@@ -3,14 +3,14 @@ page_title: "apstra_ipv6_pool Data Source - terraform-provider-apstra"
 subcategory: ""
 description: |-
   This data source provides details of a specific IPv6 Pool.
-  At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one IPv6 Pool. Matching zero or more IPv6 Pools will produce an error.
+  At least one optional attribute is required.
 ---
 
 # apstra_ipv6_pool (Data Source)
 
 This data source provides details of a specific IPv6 Pool.
 
-At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one IPv6 Pool. Matching zero or more IPv6 Pools will produce an error.
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -54,8 +54,8 @@ output "ipv6_pool_report" {
 
 ### Optional
 
-- `id` (String) ID of the desired IPv6 Pool.
-- `name` (String) Name of the IPv6 pool.
+- `id` (String) Apstra ID of the desired IPv6 Pool. Required when `name` is omitted.
+- `name` (String) Web UI Name of the IPv6 pool. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/logical_device.md
+++ b/docs/data-sources/logical_device.md
@@ -3,14 +3,14 @@ page_title: "apstra_logical_device Data Source - terraform-provider-apstra"
 subcategory: ""
 description: |-
   This data source provides details of a specific Logical Device.
-  At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one Logical Device. Matching zero or more Logical Devices will produce an error.
+  At least one optional attribute is required.
 ---
 
 # apstra_logical_device (Data Source)
 
 This data source provides details of a specific Logical Device.
 
-At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one Logical Device. Matching zero or more Logical Devices will produce an error.
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -70,8 +70,8 @@ resource "apstra_rack_type" "my_rack" {
 
 ### Optional
 
-- `id` (String) Populate this field to look up a Logical Device by ID. Required when `name`is omitted.
-- `name` (String) Populate this field to look up a Logical Device by name. Required when `id`is omitted.
+- `id` (String) Apstra ID of the Logical Device. Required when `name` is omitted.
+- `name` (String) Web UI name of the Logical Device. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/property_set.md
+++ b/docs/data-sources/property_set.md
@@ -78,8 +78,8 @@ output "apstra_property_set_report" {
 
 ### Optional
 
-- `id` (String) Populate this field to look up a Property Set by ID. Required when `name` is omitted.
-- `name` (String) Populate this field to look up a Property Set by name. Required when `id` is omitted.
+- `id` (String) Apstra ID of the Property Set. Required when `name` is omitted.
+- `name` (String) Web UID name of the Property Set. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/rack_type.md
+++ b/docs/data-sources/rack_type.md
@@ -3,14 +3,14 @@ page_title: "apstra_rack_type Data Source - terraform-provider-apstra"
 subcategory: ""
 description: |-
   This data source provides details of a specific Rack Type.
-  At least one optional attribute is required. It is incumbent on the user to ensure the criteria matches exactly one Rack Type. Matching zero Rack Types or more than one Rack Type will produce an error.
+  At least one optional attribute is required.
 ---
 
 # apstra_rack_type (Data Source)
 
 This data source provides details of a specific Rack Type.
 
-At least one optional attribute is required. It is incumbent on the user to ensure the criteria matches exactly one Rack Type. Matching zero Rack Types or more than one Rack Type will produce an error.
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -47,8 +47,8 @@ output "rack_types_with_40_or_more_generic_systems_by_ID" {
 
 ### Optional
 
-- `id` (String) Rack Type ID.  Required when the Rack Type name is omitted.
-- `name` (String) Rack Type name displayed in the Apstra web UI.  Required when Rack Type ID is omitted.
+- `id` (String) Apstra ID of the Rack Type. Required when `name` is omitted.
+- `name` (String) Web UI name of the Type. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/tag.md
+++ b/docs/data-sources/tag.md
@@ -35,8 +35,8 @@ resource "apstra_rack_type" "my_rack" {
 
 ### Optional
 
-- `id` (String) Populate this field to look up a Tag by ID. Required when `name`is omitted.
-- `name` (String) Populate this field to look up a Tag by name. Required when `id` is omitted.
+- `id` (String) Apstra ID of the Tag. Required when `name` is omitted.
+- `name` (String) Web UI name of the Tag. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/template_rack_based.md
+++ b/docs/data-sources/template_rack_based.md
@@ -3,14 +3,14 @@ page_title: "apstra_template_rack_based Data Source - terraform-provider-apstra"
 subcategory: ""
 description: |-
   This data source provides details of a specific Rack Based (3 stage) Template.
-  At least one optional attribute is required. It is incumbent on the user to ensure the criteria matches exactly one Rack Based Template. Matching zero Rack Based Templates or more than one Rack Based Template will produce an error.
+  At least one optional attribute is required.
 ---
 
 # apstra_template_rack_based (Data Source)
 
 This data source provides details of a specific Rack Based (3 stage) Template.
 
-At least one optional attribute is required. It is incumbent on the user to ensure the criteria matches exactly one Rack Based Template. Matching zero Rack Based Templates or more than one Rack Based Template will produce an error.
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -41,8 +41,8 @@ output "rack_based_template_id_to_name" {
 
 ### Optional
 
-- `id` (String) Template ID.  Required when the Template name is omitted.
-- `name` (String) Template name displayed in the Apstra web UI.  Required when Template ID is omitted.
+- `id` (String) Apstra Template ID. Required when `id` is omitted.
+- `name` (String) Web UI name of the Template. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/vni_pool.md
+++ b/docs/data-sources/vni_pool.md
@@ -3,14 +3,14 @@ page_title: "apstra_vni_pool Data Source - terraform-provider-apstra"
 subcategory: ""
 description: |-
   This data source provides details of a specific VNI Pool.
-  At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one VNI Pool. Matching zero or more VNI Pools will produce an error.
+  At least one optional attribute is required.
 ---
 
 # apstra_vni_pool (Data Source)
 
 This data source provides details of a specific VNI Pool.
 
-At least one optional attribute is required. It is incumbent upon the user to ensure the lookup criteria matches exactly one VNI Pool. Matching zero or more VNI Pools will produce an error.
+At least one optional attribute is required.
 
 ## Example Usage
 
@@ -42,8 +42,8 @@ output "available_IDs_of_in_use_pools" {
 
 ### Optional
 
-- `id` (String) ID of the desired VNI Pool.
-- `name` (String) Display name of the VNI Pool.
+- `id` (String) Apstra ID of the VNI Pool. Required when `name` is omitted.
+- `name` (String) Web UI name of the VNI Pool. Required when `id` is omitted.
 
 ### Read-Only
 


### PR DESCRIPTION
Most singleton data sources accept `ExactlyOneOf()` these optional attributes:
- `id`
- `name`

The documentation didn't use consistent language to describe the situation. Sometimes the requirement wasn't enumerated at all.

This PR normalizes the language across these data sources and removes the `it is incumbent upon the user` bit about name collisions since Apstra 4.1.2 has (mostly?) eliminated that problem.

Closes #221