### PR TITLE
Implement configurable API timeout

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ APSTRA_PASS=password
 
 ### Optional
 
+- `api_timeout` (Number) Timeout in seconds for completing API transactions with the Apstra server. Omit for default value of 10 seconds. Value of 0 results in infinite timeout.
 - `blueprint_mutex_disabled` (Boolean, Deprecated) Blueprint mutexes are signals that changes are being made in the staging Blueprint and other automation processes (including other instances of Terraform)  should wait before beginning to make changes of their own. Set this attribute 'true' to skip locking the mutex(es) which signal exclusive Blueprint access for all Blueprint changes made in this project.
 - `blueprint_mutex_enabled` (Boolean) Blueprint mutexes are signals that changes are being made in the staging Blueprint and other automation processes (including other instances of Terraform) should wait before beginning to make changes of their own. Setting this attribute 'true' causes the provider to lock a blueprint-specific mutex before making any changes.
 - `blueprint_mutex_message` (String) Blueprint mutexes are signals that changes are being made in the staging Blueprint and other automation processes (including other instances of Terraform)  should wait before beginning to make changes of their own. The mutexes embed a human-readable field to reduce confusion in the event a mutex needs to be cleared manually. This attribute overrides the default message in that field: "locked by terraform at $DATE".


### PR DESCRIPTION
This PR introduces a new provider configuration attribute: `api_timeout` and a new constant: `defaultApiTimeout = 10`

`api_timeoute` is optional. When omitted, the constant value (10s) is used.

A value of `0` configures the SDK for infinite timeout.

The `AtLeast()` validator prevents negative configuration values.

Closes #56