### PR TITLE
Remove AFI on/off switches from `apstra_datacenter_ct_bgp_peering_generic_system`

### DIFF
--- a/apstra/connectivity_template/primitive.go
+++ b/apstra/connectivity_template/primitive.go
@@ -147,6 +147,9 @@ func SdkPrimitivesToJsonStrings(ctx context.Context, in []*apstra.ConnectivityTe
 	result := make([]attr.Value, len(in))
 	for i := range in {
 		p := PrimitiveFromSdk(ctx, in[i], diags)
+		if diags.HasError() {
+			return nil
+		}
 		result[i] = types.StringValue(p.Marshal(ctx, diags))
 		if diags.HasError() {
 			return nil

--- a/docs/data-sources/datacenter_ct_bgp_peering_generic_system.md
+++ b/docs/data-sources/datacenter_ct_bgp_peering_generic_system.md
@@ -27,8 +27,6 @@ This data source composes a Connectivity Template Primitive as a JSON string, su
 
 # Declare a "BGP Peering (Generic System)" Connectivity Template Primitive:
 data "apstra_datacenter_ct_bgp_peering_generic_system" "bgp_server" {
-  ipv4_afi_enabled     = true
-  ipv6_afi_enabled     = true
   ipv4_addressing_type = "addressed"
   ipv6_addressing_type = "link_local"
   bfd_enabled          = true
@@ -40,8 +38,6 @@ data "apstra_datacenter_ct_bgp_peering_generic_system" "bgp_server" {
 # {
 #   "type": "AttachLogicalLink",
 #   "data": {
-#     "ipv4_afi_enabled": true,
-#     "ipv6_afi_enabled": true,
 #     "ttl": 1,
 #     "bfd_enabled": true,
 #     "password": "big secret",
@@ -79,7 +75,7 @@ data "apstra_datacenter_ct_ip_link" "ip_link_with_bgp" {
 #     "ipv4_addressing_type": "numbered",
 #     "ipv6_addressing_type": "link_local",
 #     "child_primitives": [
-#       "{\"type\":\"AttachLogicalLink\",\"data\":{\"ipv4_afi_enabled\":true,\"ipv6_afi_enabled\":true,\"ttl\":1,\"bfd_enabled\":true,\"password\":\"big secret\",\"keepalive_time\":null,\"hold_time\":null,\"ipv4_addressing_type\":\"addressed\",\"ipv6_addressing_type\":\"link_local\",\"local_asn\":null,\"neighbor_asn_dynamic\":false,\"peer_from_loopback\":false,\"peer_to\":\"interface_or_ip_endpoint\",\"child_primitives\":null}}"
+#       "{\"type\":\"AttachLogicalLink\",\"data\":{\"ttl\":1,\"bfd_enabled\":true,\"password\":\"big secret\",\"keepalive_time\":null,\"hold_time\":null,\"ipv4_addressing_type\":\"addressed\",\"ipv6_addressing_type\":\"link_local\",\"local_asn\":null,\"neighbor_asn_dynamic\":false,\"peer_from_loopback\":false,\"peer_to\":\"interface_or_ip_endpoint\",\"child_primitives\":null}}"
 #     ]
 #   }
 # }
@@ -87,8 +83,8 @@ data "apstra_datacenter_ct_ip_link" "ip_link_with_bgp" {
 # Finally, use the IP Link's `primitive` element in a Connectivity Template:
 resource "apstra_datacenter_connectivity_template" "t" {
   blueprint_id = "b726704d-f80e-4733-9103-abd6ccd8752c"
-  name         = "test-net-handoff"
-  description  = "ip handoff with static routes to test nets"
+  name         = "bgp server"
+  description  = "ip handoff to bgp-enabled server"
   tags         = [
     "test",
     "terraform",
@@ -108,9 +104,7 @@ resource "apstra_datacenter_connectivity_template" "t" {
 - `child_primitives` (Set of String) Set of JSON strings describing Connectivity Template Primitives which are children of this Connectivity Template Primitive. Use the `primitive` attribute of other Connectivity Template Primitives data sources here.
 - `hold_time` (Number) BGP hold time (seconds).
 - `ipv4_addressing_type` (String) One of `none`, `addressed` (or omit)
-- `ipv4_afi_enabled` (Boolean) IPv4 Address Family Identifier
 - `ipv6_addressing_type` (String) One of `none`, `addressed`, `link_local` (or omit)
-- `ipv6_afi_enabled` (Boolean) IPv6 Address Family Identifier
 - `keepalive_time` (Number) BGP keepalive time (seconds).
 - `local_asn` (Number) This feature is configured on a per-peer basis. It allows a router to appear to be a member of a second autonomous system (AS) by prepending a local-as AS number, in addition to its real AS number, announced to its eBGP peer, resulting in an AS path length of two.
 - `neighbor_asn_dynamic` (Boolean) Default behavior is `static`

--- a/examples/data-sources/apstra_datacenter_ct_bgp_peering_generic_system/example.tf
+++ b/examples/data-sources/apstra_datacenter_ct_bgp_peering_generic_system/example.tf
@@ -13,8 +13,6 @@
 
 # Declare a "BGP Peering (Generic System)" Connectivity Template Primitive:
 data "apstra_datacenter_ct_bgp_peering_generic_system" "bgp_server" {
-  ipv4_afi_enabled     = true
-  ipv6_afi_enabled     = true
   ipv4_addressing_type = "addressed"
   ipv6_addressing_type = "link_local"
   bfd_enabled          = true
@@ -26,8 +24,6 @@ data "apstra_datacenter_ct_bgp_peering_generic_system" "bgp_server" {
 # {
 #   "type": "AttachLogicalLink",
 #   "data": {
-#     "ipv4_afi_enabled": true,
-#     "ipv6_afi_enabled": true,
 #     "ttl": 1,
 #     "bfd_enabled": true,
 #     "password": "big secret",
@@ -65,7 +61,7 @@ data "apstra_datacenter_ct_ip_link" "ip_link_with_bgp" {
 #     "ipv4_addressing_type": "numbered",
 #     "ipv6_addressing_type": "link_local",
 #     "child_primitives": [
-#       "{\"type\":\"AttachLogicalLink\",\"data\":{\"ipv4_afi_enabled\":true,\"ipv6_afi_enabled\":true,\"ttl\":1,\"bfd_enabled\":true,\"password\":\"big secret\",\"keepalive_time\":null,\"hold_time\":null,\"ipv4_addressing_type\":\"addressed\",\"ipv6_addressing_type\":\"link_local\",\"local_asn\":null,\"neighbor_asn_dynamic\":false,\"peer_from_loopback\":false,\"peer_to\":\"interface_or_ip_endpoint\",\"child_primitives\":null}}"
+#       "{\"type\":\"AttachLogicalLink\",\"data\":{\"ttl\":1,\"bfd_enabled\":true,\"password\":\"big secret\",\"keepalive_time\":null,\"hold_time\":null,\"ipv4_addressing_type\":\"addressed\",\"ipv6_addressing_type\":\"link_local\",\"local_asn\":null,\"neighbor_asn_dynamic\":false,\"peer_from_loopback\":false,\"peer_to\":\"interface_or_ip_endpoint\",\"child_primitives\":null}}"
 #     ]
 #   }
 # }
@@ -73,8 +69,8 @@ data "apstra_datacenter_ct_ip_link" "ip_link_with_bgp" {
 # Finally, use the IP Link's `primitive` element in a Connectivity Template:
 resource "apstra_datacenter_connectivity_template" "t" {
   blueprint_id = "b726704d-f80e-4733-9103-abd6ccd8752c"
-  name         = "test-net-handoff"
-  description  = "ip handoff with static routes to test nets"
+  name         = "bgp server"
+  description  = "ip handoff to bgp-enabled server"
   tags         = [
     "test",
     "terraform",


### PR DESCRIPTION
This PR is based on the understanding that the "BGP Peering (Generic System)" CT primitive's "IPv4 AFI" and "IPv6 AFI" on/off switches are superfluous user inputs.

The correct setting for these switches can be inferred based on whether the user specifies a peering scheme for IPv4 or IPv6 neighbors. Note that this is an Apstra-imposed constraint. Enabling IPv4 SAFI via IPv6 transport and vice-versa doesn't seem inherently problematic, but Apstra doesn't allow it.

Other changes:

- An error condition check has been added where none existed before
- A validator which ensures that at least one peer addressing strategy (IPv4 or IPv6) has been added

Closes #261