### PR TITLE
Bump upstream SDK for new CT primitive layout logic

### DIFF
--- a/apstra/connectivity_template/routing_policy.go
+++ b/apstra/connectivity_template/routing_policy.go
@@ -77,7 +77,7 @@ func (o *RoutingPolicy) loadSdkPrimitive(ctx context.Context, in apstra.Connecti
 func (o *RoutingPolicy) loadSdkPrimitiveAttributes(_ context.Context, in *apstra.ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy, _ *diag.Diagnostics) {
 	o.RoutingPolicyId = types.StringNull()
 	if in.RpToAttach != nil {
-		o.RoutingPolicyId = types.StringValue(*in.RpToAttach)
+		o.RoutingPolicyId = types.StringValue(in.RpToAttach.String())
 	}
 }
 
@@ -88,8 +88,9 @@ type routingPolicyPrototype struct {
 }
 
 func (o routingPolicyPrototype) attributes(_ context.Context, _ path.Path, _ *diag.Diagnostics) apstra.ConnectivityTemplatePrimitiveAttributes {
+	rpId := apstra.ObjectId(*o.RoutingPolicyId)
 	return &apstra.ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{
-		RpToAttach: o.RoutingPolicyId,
+		RpToAttach: &rpId,
 	}
 }
 

--- a/apstra/connectivity_template/routing_zone_constraint.go
+++ b/apstra/connectivity_template/routing_zone_constraint.go
@@ -77,7 +77,7 @@ func (o *RoutingZoneConstraint) loadSdkPrimitive(ctx context.Context, in apstra.
 func (o *RoutingZoneConstraint) loadSdkPrimitiveAttributes(_ context.Context, in *apstra.ConnectivityTemplatePrimitiveAttributesAttachRoutingZoneConstraint, _ *diag.Diagnostics) {
 	o.RoutingZoneConstraintId = types.StringNull()
 	if in.RoutingZoneConstraint != nil {
-		o.RoutingZoneConstraintId = types.StringValue(*in.RoutingZoneConstraint)
+		o.RoutingZoneConstraintId = types.StringValue(in.RoutingZoneConstraint.String())
 	}
 }
 
@@ -88,8 +88,9 @@ type routingZoneConstraintPrototype struct {
 }
 
 func (o routingZoneConstraintPrototype) attributes(_ context.Context, _ path.Path, _ *diag.Diagnostics) apstra.ConnectivityTemplatePrimitiveAttributes {
+	rzcId := apstra.ObjectId(*o.RoutingZoneConstraintId)
 	return &apstra.ConnectivityTemplatePrimitiveAttributesAttachRoutingZoneConstraint{
-		RoutingZoneConstraint: o.RoutingZoneConstraintId,
+		RoutingZoneConstraint: &rzcId,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20230809171707-9523c7d97f49
+	github.com/Juniper/apstra-go-sdk v0.0.0-20230809212353-aa9b6951bf95
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230809171707-9523c7d97f49 h1:iYfkiqazjuv7U3OIfg5cd2ju2WbWMIGREAOygGCiZTs=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230809171707-9523c7d97f49/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230809212353-aa9b6951bf95 h1:Oo3qp1Gbx+HmCnR2ZFYbHpi0owNcAzzwxCQB2ueGPZM=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230809212353-aa9b6951bf95/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=


### PR DESCRIPTION
New SDK version ensures that CT primitives don't wind up on top of each other.

Additionally, absorb SDK bug fix which changes embedded IDs in Routing Zone Constraint and Routing Policy primitives from `*string` to `*ObjectId`