### PR TITLE
Improve BGP `hold_time` and `keepalive_time` validation

### DIFF
--- a/apstra/apstra_validator/at_least_product_of.go
+++ b/apstra/apstra_validator/at_least_product_of.go
@@ -1,0 +1,160 @@
+package apstravalidator
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"math/big"
+)
+
+var (
+	_ validator.Float64 = DifferentFromValidator{}
+	_ validator.Int64   = DifferentFromValidator{}
+	_ validator.Number  = DifferentFromValidator{}
+)
+
+// AtLeastProductOfValidator is the underlying struct implementing AtLeastProductOf.
+type AtLeastProductOfValidator struct {
+	PathExpression path.Expression
+	Multiplier     float64
+}
+
+type AtLeastProductOfValidatorRequest struct {
+	Config         tfsdk.Config
+	ConfigValue    attr.Value
+	Path           path.Path
+	PathExpression path.Expression
+}
+
+type AtLeastProductOfValidatorResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+func (o AtLeastProductOfValidator) Description(ctx context.Context) string {
+	return o.MarkdownDescription(ctx)
+}
+
+func (o AtLeastProductOfValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("Ensure that if an attribute is set, it's value is at least "+
+		"%f * any value at: %q",
+		o.Multiplier, o.PathExpression)
+}
+
+func (o AtLeastProductOfValidator) Validate(ctx context.Context, req AtLeastProductOfValidatorRequest, resp *AtLeastProductOfValidatorResponse) {
+	// If attribute configuration is null or unknown, there is nothing
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// convert this value to *big.Float
+	var thisBF *big.Float
+	switch t := req.ConfigValue.(type) {
+	case basetypes.Float64Value:
+		thisBF = big.NewFloat(t.ValueFloat64())
+	case basetypes.Int64Value:
+		thisBF = big.NewFloat(float64(t.ValueInt64()))
+	case basetypes.NumberValue:
+		thisBF = t.ValueBigFloat()
+	}
+
+	multiplier := big.NewFloat(o.Multiplier)
+
+	matchedPaths, diags := req.Config.PathMatches(ctx, o.PathExpression)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
+	for _, mp := range matchedPaths {
+		var mpVal attr.Value
+		diags = req.Config.GetAttribute(ctx, mp, &mpVal)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Unknown and Null attributes can't be multiplied
+		if mpVal.IsNull() || mpVal.IsUnknown() {
+			continue
+		}
+
+		// convert the value we're comparing to *big.Float
+		var mpBF *big.Float
+		switch t := mpVal.(type) {
+		case basetypes.Float64Value:
+			mpBF = big.NewFloat(t.ValueFloat64())
+		case basetypes.Int64Value:
+			mpBF = big.NewFloat(float64(t.ValueInt64()))
+		case basetypes.NumberValue:
+			mpBF = t.ValueBigFloat()
+		}
+
+		if thisBF.Cmp(mpBF.Mul(mpBF, multiplier)) == -1 {
+			resp.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+				req.Path,
+				fmt.Sprintf("value must be at least %f times the value at %s (%s), got %s",
+					multiplier, mp, mpVal, req.ConfigValue),
+			))
+		}
+	}
+}
+
+// AtLeastProductOf checks that a set of path.Expression have values equal to the
+// current attribute when the current attribute is non-null.
+//
+// Relative path.Expression will be resolved using the attribute being
+// validated.
+func AtLeastProductOf(multiplier float64, expression path.Expression) *AtLeastProductOfValidator {
+	return &AtLeastProductOfValidator{
+		PathExpression: expression,
+		Multiplier:     multiplier,
+	}
+}
+
+func (o AtLeastProductOfValidator) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := AtLeastProductOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastProductOfValidatorResponse{}
+
+	o.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (o AtLeastProductOfValidator) ValidateInt64(ctx context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	validateReq := AtLeastProductOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastProductOfValidatorResponse{}
+
+	o.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (o AtLeastProductOfValidator) ValidateNumber(ctx context.Context, req validator.NumberRequest, resp *validator.NumberResponse) {
+	validateReq := AtLeastProductOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastProductOfValidatorResponse{}
+
+	o.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}

--- a/apstra/connectivity_template/bgp_peering_generic_system.go
+++ b/apstra/connectivity_template/bgp_peering_generic_system.go
@@ -75,6 +75,7 @@ func (o BgpPeeringGenericSystem) DataSourceAttributes() map[string]dataSourceSch
 			Optional:            true,
 			Validators: []validator.Int64{
 				int64validator.Between(0, math.MaxUint16+1),
+				int64validator.AlsoRequires(path.MatchRoot("hold_time")),
 			},
 		},
 		"hold_time": dataSourceSchema.Int64Attribute{
@@ -82,6 +83,7 @@ func (o BgpPeeringGenericSystem) DataSourceAttributes() map[string]dataSourceSch
 			Optional:            true,
 			Validators: []validator.Int64{
 				int64validator.Between(0, math.MaxUint16+1),
+				int64validator.AlsoRequires(path.MatchRoot("keepalive_time")),
 				apstravalidator.AtLeastProductOf(3, path.MatchRoot("keepalive_time")),
 			},
 		},

--- a/apstra/connectivity_template/bgp_peering_generic_system.go
+++ b/apstra/connectivity_template/bgp_peering_generic_system.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	apstravalidator "terraform-provider-apstra/apstra/apstra_validator"
 	"terraform-provider-apstra/apstra/utils"
 )
 
@@ -72,12 +73,17 @@ func (o BgpPeeringGenericSystem) DataSourceAttributes() map[string]dataSourceSch
 		"keepalive_time": dataSourceSchema.Int64Attribute{
 			MarkdownDescription: "BGP keepalive time (seconds).",
 			Optional:            true,
-			Validators:          []validator.Int64{int64validator.Between(0, math.MaxUint16+1)},
+			Validators: []validator.Int64{
+				int64validator.Between(0, math.MaxUint16+1),
+			},
 		},
 		"hold_time": dataSourceSchema.Int64Attribute{
 			MarkdownDescription: "BGP hold time (seconds).",
 			Optional:            true,
-			Validators:          []validator.Int64{int64validator.Between(0, math.MaxUint16+1)},
+			Validators: []validator.Int64{
+				int64validator.Between(0, math.MaxUint16+1),
+				apstravalidator.AtLeastProductOf(3, path.MatchRoot("keepalive_time")),
+			},
 		},
 		"ipv4_addressing_type": dataSourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("One of `%s` (or omit)",

--- a/apstra/connectivity_template/bgp_peering_ip_endpoint.go
+++ b/apstra/connectivity_template/bgp_peering_ip_endpoint.go
@@ -64,6 +64,7 @@ func (o BgpPeeringIpEndpoint) DataSourceAttributes() map[string]dataSourceSchema
 			Optional:            true,
 			Validators: []validator.Int64{
 				int64validator.Between(0, math.MaxUint16+1),
+				int64validator.AlsoRequires(path.MatchRoot("hold_time")),
 			},
 		},
 		"hold_time": dataSourceSchema.Int64Attribute{
@@ -71,6 +72,7 @@ func (o BgpPeeringIpEndpoint) DataSourceAttributes() map[string]dataSourceSchema
 			Optional:            true,
 			Validators: []validator.Int64{
 				int64validator.Between(0, math.MaxUint16+1),
+				int64validator.AlsoRequires(path.MatchRoot("keepalive_time")),
 				apstravalidator.AtLeastProductOf(3, path.MatchRoot("keepalive_time")),
 			},
 		},

--- a/apstra/connectivity_template/bgp_peering_ip_endpoint.go
+++ b/apstra/connectivity_template/bgp_peering_ip_endpoint.go
@@ -62,12 +62,17 @@ func (o BgpPeeringIpEndpoint) DataSourceAttributes() map[string]dataSourceSchema
 		"keepalive_time": dataSourceSchema.Int64Attribute{
 			MarkdownDescription: "BGP keepalive time (seconds).",
 			Optional:            true,
-			Validators:          []validator.Int64{int64validator.Between(0, math.MaxUint16+1)},
+			Validators: []validator.Int64{
+				int64validator.Between(0, math.MaxUint16+1),
+			},
 		},
 		"hold_time": dataSourceSchema.Int64Attribute{
 			MarkdownDescription: "BGP hold time (seconds).",
 			Optional:            true,
-			Validators:          []validator.Int64{int64validator.Between(0, math.MaxUint16+1)},
+			Validators: []validator.Int64{
+				int64validator.Between(0, math.MaxUint16+1),
+				apstravalidator.AtLeastProductOf(3, path.MatchRoot("keepalive_time")),
+			},
 		},
 		"local_asn": dataSourceSchema.Int64Attribute{
 			MarkdownDescription: "This feature is configured on a per-peer basis. It allows a router " +

--- a/apstra/connectivity_template/dynamic_bgp_peering.go
+++ b/apstra/connectivity_template/dynamic_bgp_peering.go
@@ -59,12 +59,17 @@ func (o DynamicBgpPeering) DataSourceAttributes() map[string]dataSourceSchema.At
 		"keepalive_time": dataSourceSchema.Int64Attribute{
 			MarkdownDescription: "BGP keepalive time (seconds).",
 			Optional:            true,
-			Validators:          []validator.Int64{int64validator.Between(0, math.MaxUint16+1)},
+			Validators: []validator.Int64{
+				int64validator.Between(0, math.MaxUint16+1),
+			},
 		},
 		"hold_time": dataSourceSchema.Int64Attribute{
 			MarkdownDescription: "BGP hold time (seconds).",
 			Optional:            true,
-			Validators:          []validator.Int64{int64validator.Between(0, math.MaxUint16+1)},
+			Validators: []validator.Int64{
+				int64validator.Between(0, math.MaxUint16+1),
+				apstravalidator.AtLeastProductOf(3, path.MatchRoot("keepalive_time")),
+			},
 		},
 		"ipv4_enabled": dataSourceSchema.BoolAttribute{
 			MarkdownDescription: "Enable to allow IPv4 peers.",

--- a/apstra/connectivity_template/dynamic_bgp_peering.go
+++ b/apstra/connectivity_template/dynamic_bgp_peering.go
@@ -61,6 +61,7 @@ func (o DynamicBgpPeering) DataSourceAttributes() map[string]dataSourceSchema.At
 			Optional:            true,
 			Validators: []validator.Int64{
 				int64validator.Between(0, math.MaxUint16+1),
+				int64validator.AlsoRequires(path.MatchRoot("hold_time")),
 			},
 		},
 		"hold_time": dataSourceSchema.Int64Attribute{
@@ -68,6 +69,7 @@ func (o DynamicBgpPeering) DataSourceAttributes() map[string]dataSourceSchema.At
 			Optional:            true,
 			Validators: []validator.Int64{
 				int64validator.Between(0, math.MaxUint16+1),
+				int64validator.AlsoRequires(path.MatchRoot("keepalive_time")),
 				apstravalidator.AtLeastProductOf(3, path.MatchRoot("keepalive_time")),
 			},
 		},


### PR DESCRIPTION
This PR introduces a new input validator for `int`, `float` and `number` terraform types:

```go
func AtLeastProductOf(multiplier float64, expression path.Expression) *AtLeastProductOfValidator {}
```

It ensures that the attribute undergoing validation has a value of at least `multiplier` times the value at `expression`.

The new validator is used on the BGP `hold_time` attribute of each of these data sources to ensure they have a value of at least 3x `keepalive_time`:
- `apstra_datacenter_ct_bgp_peering_ip_endpoint`
- `apstra_datacenter_ct_bgp_peering_generic_system`
- `apstra_datacenter_ct_dynamic_bgp_peering`

Additionally, an `AlsoRequires()` validator has been applied to both the `hold_time` and `keepalive_time` attributes in each of these data sources to ensure that these attributes are always deployed together.

Closes #257