### PR TITLE
fix the string validator for rack names

### DIFF
--- a/apstra/design/rack_type.go
+++ b/apstra/design/rack_type.go
@@ -133,7 +133,7 @@ func (o RackType) ResourceAttributes() map[string]resourceSchema.Attribute {
 		"name": resourceSchema.StringAttribute{
 			MarkdownDescription: "Rack Type name, displayed in the Apstra web UI.",
 			Required:            true,
-			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
+			Validators:          []validator.String{stringvalidator.LengthBetween(1, 17)},
 		},
 		"description": resourceSchema.StringAttribute{
 			MarkdownDescription: "Rack Type description, displayed in the Apstra web UI.",


### PR DESCRIPTION
I discovered this limit while writing configs for the AI racks.