### PR TITLE
Task/281

### DIFF
--- a/apstra/data_source_agent.go
+++ b/apstra/data_source_agent.go
@@ -2,12 +2,12 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	systemAgents "terraform-provider-apstra/apstra/system_agents"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 var _ datasource.DataSourceWithConfigure = &dataSourceAgent{}
@@ -41,8 +41,7 @@ func (o *dataSourceAgent) Read(ctx context.Context, req datasource.ReadRequest, 
 
 	agent, err := o.client.GetSystemAgent(ctx, apstra.ObjectId(config.AgentId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddError(fmt.Sprintf("agent %s not found",
 				config.AgentId), err.Error())
 			return

--- a/apstra/data_source_datacenter_routing_zone.go
+++ b/apstra/data_source_datacenter_routing_zone.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -45,8 +44,7 @@ func (o *dataSourceDatacenterRoutingZone) Read(ctx context.Context, req datasour
 
 	bpClient, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(config.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found",
 				config.BlueprintId), err.Error())
 			return
@@ -97,8 +95,7 @@ func (o *dataSourceDatacenterRoutingZone) Read(ctx context.Context, req datasour
 
 	dhcpServers, err := bpClient.GetSecurityZoneDhcpServers(ctx, api.Id)
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/apstra/data_source_datacenter_virtual_networks.go
+++ b/apstra/data_source_datacenter_virtual_networks.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -109,8 +108,7 @@ func (o *dataSourceDatacenterVirtualNetworks) Read(ctx context.Context, req data
 func (o *dataSourceDatacenterVirtualNetworks) getAllVnIds(ctx context.Context, bpId apstra.ObjectId, diags *diag.Diagnostics) []attr.Value {
 	bpClient, err := o.client.NewTwoStageL3ClosClient(ctx, bpId)
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			diags.AddError(fmt.Sprintf("blueprint %s not found", bpId), err.Error())
 			return nil
 		}

--- a/apstra/data_source_interface_map.go
+++ b/apstra/data_source_interface_map.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-apstra/apstra/design"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 var _ datasource.DataSourceWithConfigure = &dataSourceInterfaceMap{}
@@ -43,12 +43,11 @@ func (o *dataSourceInterfaceMap) Read(ctx context.Context, req datasource.ReadRe
 
 	var err error
 	var api *apstra.InterfaceMap
-	var ace apstra.ApstraClientErr
 
 	switch {
 	case !config.Name.IsNull():
 		api, err = o.client.GetInterfaceMapByName(ctx, config.Name.ValueString())
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound { // 404?
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("name"),
 				"Interface Map not found",
@@ -57,16 +56,13 @@ func (o *dataSourceInterfaceMap) Read(ctx context.Context, req datasource.ReadRe
 		}
 	case !config.Id.IsNull():
 		api, err = o.client.GetInterfaceMap(ctx, apstra.ObjectId(config.Id.ValueString()))
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound { // 404?
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
 				"Interface Map not found",
 				fmt.Sprintf("Interface Map with id %q does not exist", config.Id.ValueString()))
 			return
 		}
-	default:
-		resp.Diagnostics.AddError(errInsufficientConfigElements, "neither 'name' nor 'id' set")
-		return
 	}
 	if err != nil { // catch errors other than 404 from above
 		resp.Diagnostics.AddError("Error retrieving Interface Map", err.Error())

--- a/apstra/data_source_ipv6_pool.go
+++ b/apstra/data_source_ipv6_pool.go
@@ -2,13 +2,13 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"terraform-provider-apstra/apstra/resources"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 var _ datasource.DataSourceWithConfigure = &dataSourceIpv6Pool{}
@@ -42,12 +42,11 @@ func (o *dataSourceIpv6Pool) Read(ctx context.Context, req datasource.ReadReques
 
 	var err error
 	var apiData *apstra.IpPool
-	var ace apstra.ApstraClientErr
 
 	switch {
 	case !config.Name.IsNull():
 		apiData, err = o.client.GetIp6PoolByName(ctx, config.Name.ValueString())
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("name"),
 				"IPv6 Pool not found",
@@ -56,16 +55,13 @@ func (o *dataSourceIpv6Pool) Read(ctx context.Context, req datasource.ReadReques
 		}
 	case !config.Id.IsNull():
 		apiData, err = o.client.GetIp6Pool(ctx, apstra.ObjectId(config.Id.ValueString()))
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
 				"IPv6 Pool not found",
 				fmt.Sprintf("IPv6 Pool with ID %q not found", config.Id.ValueString()))
 			return
 		}
-	default:
-		resp.Diagnostics.AddError(errInsufficientConfigElements, "neither 'name' nor 'id' set")
-		return
 	}
 	if err != nil { // catch errors other than 404 from above
 		resp.Diagnostics.AddError("Error retrieving IPv6 Pool", err.Error())

--- a/apstra/data_source_logical_device.go
+++ b/apstra/data_source_logical_device.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-apstra/apstra/design"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 var _ datasource.DataSourceWithConfigure = &dataSourceLogicalDevice{}
@@ -43,12 +43,11 @@ func (o *dataSourceLogicalDevice) Read(ctx context.Context, req datasource.ReadR
 
 	var err error
 	var api *apstra.LogicalDevice
-	var ace apstra.ApstraClientErr
 
 	switch {
 	case !config.Name.IsNull():
 		api, err = o.client.GetLogicalDeviceByName(ctx, config.Name.ValueString())
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("name"),
 				"Logical Device not found",
@@ -57,16 +56,13 @@ func (o *dataSourceLogicalDevice) Read(ctx context.Context, req datasource.ReadR
 		}
 	case !config.Id.IsNull():
 		api, err = o.client.GetLogicalDevice(ctx, apstra.ObjectId(config.Id.ValueString()))
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
 				"Logical Device not found",
 				fmt.Sprintf("Logical Device with id %q not found", config.Id.ValueString()))
 			return
 		}
-	default:
-		resp.Diagnostics.AddError(errInsufficientConfigElements, "neither 'name' nor 'id' set")
-		return
 	}
 	if err != nil { // catch errors other than 404 from above
 		resp.Diagnostics.AddError("Error retrieving Logical Device", err.Error())

--- a/apstra/data_source_property_set.go
+++ b/apstra/data_source_property_set.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-apstra/apstra/design"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 var _ datasource.DataSourceWithConfigure = &dataSourcePropertySet{}
@@ -43,12 +43,11 @@ func (o *dataSourcePropertySet) Read(ctx context.Context, req datasource.ReadReq
 
 	var err error
 	var api *apstra.PropertySet
-	var ace apstra.ApstraClientErr
 
 	switch {
 	case !config.Name.IsNull():
 		api, err = o.client.GetPropertySetByLabel(ctx, config.Name.ValueString())
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("name"),
 				"PropertySet not found",
@@ -57,16 +56,13 @@ func (o *dataSourcePropertySet) Read(ctx context.Context, req datasource.ReadReq
 		}
 	case !config.Id.IsNull():
 		api, err = o.client.GetPropertySet(ctx, apstra.ObjectId(config.Id.ValueString()))
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
 				"PropertySet not found",
 				fmt.Sprintf("PropertySet with ID %q not found", config.Id.ValueString()))
 			return
 		}
-	default:
-		resp.Diagnostics.AddError(errInsufficientConfigElements, "neither 'name' nor 'id' set")
-		return
 	}
 	if err != nil { // catch errors other than 404 from above
 		resp.Diagnostics.AddError("Error retrieving PropertySet", err.Error())

--- a/apstra/data_source_rack_type.go
+++ b/apstra/data_source_rack_type.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-apstra/apstra/design"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 var _ datasource.DataSourceWithConfigure = &dataSourceRackType{}
@@ -43,12 +43,11 @@ func (o *dataSourceRackType) Read(ctx context.Context, req datasource.ReadReques
 
 	var err error
 	var api *apstra.RackType
-	var ace apstra.ApstraClientErr
 
 	switch {
 	case !config.Name.IsNull():
 		api, err = o.client.GetRackTypeByName(ctx, config.Name.ValueString())
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound { // 404?
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("name"),
 				"Rack Type not found",
@@ -57,16 +56,13 @@ func (o *dataSourceRackType) Read(ctx context.Context, req datasource.ReadReques
 		}
 	case !config.Id.IsNull():
 		api, err = o.client.GetRackType(ctx, apstra.ObjectId(config.Id.ValueString()))
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound { // 404?
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
 				"Rack Type not found",
 				fmt.Sprintf("Rack Type with ID %q does not exist", config.Id.ValueString()))
 			return
 		}
-	default:
-		resp.Diagnostics.AddError(errInsufficientConfigElements, "neither 'name' nor 'id' set")
-		return
 	}
 	if err != nil { // catch errors other than 404 from above
 		resp.Diagnostics.AddError("Error retrieving Rack Type", err.Error())

--- a/apstra/data_source_tag.go
+++ b/apstra/data_source_tag.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-apstra/apstra/design"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 var _ datasource.DataSourceWithConfigure = &dataSourceTag{}
@@ -43,12 +43,11 @@ func (o *dataSourceTag) Read(ctx context.Context, req datasource.ReadRequest, re
 
 	var err error
 	var api *apstra.DesignTag
-	var ace apstra.ApstraClientErr
 
 	switch {
 	case !config.Name.IsNull():
 		api, err = o.client.GetTagByLabel(ctx, config.Name.ValueString())
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("name"),
 				"Tag not found",
@@ -57,16 +56,13 @@ func (o *dataSourceTag) Read(ctx context.Context, req datasource.ReadRequest, re
 		}
 	case !config.Id.IsNull():
 		api, err = o.client.GetTag(ctx, apstra.ObjectId(config.Id.ValueString()))
-		if err != nil && errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
 				"Tag not found",
 				fmt.Sprintf("Tag with ID %q not found", config.Id.ValueString()))
 			return
 		}
-	default:
-		resp.Diagnostics.AddError(errInsufficientConfigElements, "neither 'name' nor 'id' set")
-		return
 	}
 	if err != nil { // catch errors other than 404 from above
 		resp.Diagnostics.AddError("Error retrieving Tag", err.Error())

--- a/apstra/data_source_template_rack_based.go
+++ b/apstra/data_source_template_rack_based.go
@@ -54,7 +54,7 @@ func (o *dataSourceTemplateRackBased) Read(ctx context.Context, req datasource.R
 					"Rack Based Template not found",
 					fmt.Sprintf("Rack Based Template with name %q does not exist", config.Name.ValueString()))
 			case apstra.ErrWrongType:
-				resp.Diagnostics.AddError("Specified Template has wrong type", err.Error())
+				resp.Diagnostics.AddError(fmt.Sprintf("Specified Template has wrong type: %s", api.Type()), err.Error())
 			}
 			return
 		}

--- a/apstra/resource_agent_profile.go
+++ b/apstra/resource_agent_profile.go
@@ -141,10 +141,10 @@ func (o *resourceAgentProfile) Delete(ctx context.Context, req resource.DeleteRe
 	// Delete Agent Profile by calling API
 	err := o.client.DeleteAgentProfile(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() != apstra.ErrNotfound { // 404 is okay - it's the objective
-			resp.Diagnostics.AddError("error deleting Agent Profile", err.Error())
-			return
+		if utils.IsApstra404(err) {
+			return // 404 is okay
 		}
+		resp.Diagnostics.AddError("error deleting Agent Profile", err.Error())
+		return
 	}
 }

--- a/apstra/resource_asn_pool.go
+++ b/apstra/resource_asn_pool.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-apstra/apstra/resources"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 var _ resource.ResourceWithConfigure = &resourceAsnPool{}
@@ -104,12 +104,11 @@ func (o *resourceAsnPool) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// read pool back from Apstra to get usage statistics
-	var ace apstra.ApstraClientErr
 	var pool *apstra.AsnPool
 	for {
 		pool, err = o.client.GetAsnPool(ctx, id)
 		if err != nil {
-			if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+			if utils.IsApstra404(err) {
 				resp.Diagnostics.AddAttributeError(
 					path.Root("id"),
 					"ASN Pool not found",
@@ -146,15 +145,13 @@ func (o *resourceAsnPool) Read(ctx context.Context, req resource.ReadRequest, re
 	// Get ASN pool from API and then update what is in state from what the API returns
 	p, err := o.client.GetAsnPool(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			// resource deleted outside of terraform
 			resp.State.RemoveResource(ctx)
 			return
-		} else {
-			resp.Diagnostics.AddError("error reading ASN pool", err.Error())
-			return
 		}
+		resp.Diagnostics.AddError("error reading ASN pool", err.Error())
+		return
 	}
 
 	// create state object
@@ -181,14 +178,8 @@ func (o *resourceAsnPool) Update(ctx context.Context, req resource.UpdateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	var ace apstra.ApstraClientErr
 	err := o.client.UpdateAsnPool(ctx, apstra.ObjectId(plan.Id.ValueString()), request)
 	if err != nil {
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound { // deleted manually since 'plan'?
-			resp.State.RemoveResource(ctx)
-			return
-		}
-		// some other unknown error
 		resp.Diagnostics.AddError("error updating ASN Pool", err.Error())
 		return
 	}
@@ -196,7 +187,7 @@ func (o *resourceAsnPool) Update(ctx context.Context, req resource.UpdateRequest
 	// read pool back from Apstra to get usage statistics
 	p, err := o.client.GetAsnPool(ctx, apstra.ObjectId(plan.Id.ValueString()))
 	if err != nil {
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
 				"ASN Pool not found",
@@ -228,10 +219,10 @@ func (o *resourceAsnPool) Delete(ctx context.Context, req resource.DeleteRequest
 	// Delete ASN pool by calling API
 	err := o.client.DeleteAsnPool(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() != apstra.ErrNotfound { // 404 is okay - it's the objective
-			resp.Diagnostics.AddError("error deleting ASN pool", err.Error())
+		if utils.IsApstra404(err) {
+			return // 404 is okay
 		}
+		resp.Diagnostics.AddError("error deleting ASN pool", err.Error())
 		return
 	}
 }

--- a/apstra/resource_datacenter_blueprint.go
+++ b/apstra/resource_datacenter_blueprint.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/go-version"
@@ -160,8 +159,7 @@ func (o *resourceDatacenterBlueprint) Read(ctx context.Context, req resource.Rea
 	// Some interesting details are in BlueprintStatus.
 	apiData, err := o.client.GetBlueprintStatus(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/apstra/resource_datacenter_connectivity_template.go
+++ b/apstra/resource_datacenter_connectivity_template.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -46,8 +45,7 @@ func (o *resourceDatacenterConnectivityTemplate) Create(ctx context.Context, req
 	// create a client for the datacenter reference design
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
@@ -93,8 +91,7 @@ func (o *resourceDatacenterConnectivityTemplate) Read(ctx context.Context, req r
 	// Create a blueprint client
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -104,8 +101,7 @@ func (o *resourceDatacenterConnectivityTemplate) Read(ctx context.Context, req r
 
 	api, err := bp.GetConnectivityTemplate(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/apstra/resource_datacenter_generic_system.go
+++ b/apstra/resource_datacenter_generic_system.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -46,8 +45,7 @@ func (o *resourceDatacenterGenericSystem) Create(ctx context.Context, req resour
 	// create a client for the datacenter reference design
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
@@ -109,8 +107,7 @@ func (o *resourceDatacenterGenericSystem) Read(ctx context.Context, req resource
 	// Create a blueprint client
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -122,8 +119,7 @@ func (o *resourceDatacenterGenericSystem) Read(ctx context.Context, req resource
 	// effect of discovering whether the generic system has been deleted.
 	err = state.GetLabelAndHostname(ctx, bp)
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/apstra/resource_datacenter_resource_pool_allocation.go
+++ b/apstra/resource_datacenter_resource_pool_allocation.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -54,8 +53,7 @@ func (o *resourcePoolAllocation) Create(ctx context.Context, req resource.Create
 	// create a client for the datacenter reference design
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
@@ -100,8 +98,7 @@ func (o *resourcePoolAllocation) Read(ctx context.Context, req resource.ReadRequ
 	// Create a blueprint client
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -118,8 +115,7 @@ func (o *resourcePoolAllocation) Read(ctx context.Context, req resource.ReadRequ
 
 	apiData, err := bp.GetResourceAllocation(ctx, &allocationRequest.ResourceGroup)
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/apstra/resource_datacenter_routing_policy.go
+++ b/apstra/resource_datacenter_routing_policy.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -46,8 +45,7 @@ func (o *resourceDatacenterRoutingPolicy) Create(ctx context.Context, req resour
 	// create a client for the datacenter reference design
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
@@ -94,8 +92,7 @@ func (o *resourceDatacenterRoutingPolicy) Read(ctx context.Context, req resource
 	// Create a blueprint client
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -105,8 +102,7 @@ func (o *resourceDatacenterRoutingPolicy) Read(ctx context.Context, req resource
 
 	rp, err := bp.GetRoutingPolicy(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/apstra/resource_datacenter_routing_zone.go
+++ b/apstra/resource_datacenter_routing_zone.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -119,8 +118,7 @@ func (o *resourceDatacenterRoutingZone) Create(ctx context.Context, req resource
 	// create a client for the datacenter reference design
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
@@ -187,8 +185,7 @@ func (o *resourceDatacenterRoutingZone) Read(ctx context.Context, req resource.R
 	// Create a blueprint client
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -198,8 +195,7 @@ func (o *resourceDatacenterRoutingZone) Read(ctx context.Context, req resource.R
 
 	sz, err := bp.GetSecurityZone(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -214,8 +210,7 @@ func (o *resourceDatacenterRoutingZone) Read(ctx context.Context, req resource.R
 
 	dhcpServers, err := bp.GetSecurityZoneDhcpServers(ctx, sz.Id)
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/apstra/resource_datacenter_virtual_network.go
+++ b/apstra/resource_datacenter_virtual_network.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -112,8 +111,7 @@ func (o *resourceDatacenterVirtualNetwork) Create(ctx context.Context, req resou
 	// create a client for the datacenter reference design
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
@@ -200,8 +198,7 @@ func (o *resourceDatacenterVirtualNetwork) Read(ctx context.Context, req resourc
 	// create a client for the datacenter reference design
 	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -212,8 +209,7 @@ func (o *resourceDatacenterVirtualNetwork) Read(ctx context.Context, req resourc
 	// retrieve the virtual network
 	vn, err := bp.GetVirtualNetwork(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/apstra/resource_ipv6_pool.go
+++ b/apstra/resource_ipv6_pool.go
@@ -2,7 +2,6 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"net"
 	"terraform-provider-apstra/apstra/resources"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 var _ resource.ResourceWithConfigure = &resourceAsnPool{}
@@ -121,12 +121,11 @@ func (o *resourceIpv6Pool) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	// read pool back from Apstra to get usage statistics
-	var ace apstra.ApstraClientErr
 	var pool *apstra.IpPool
 	for { // loop until creation complete
 		pool, err = o.client.GetIp6Pool(ctx, id)
 		if err != nil {
-			if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+			if utils.IsApstra404(err) {
 				resp.Diagnostics.AddError(
 					"IPv6 Pool not found",
 					fmt.Sprintf("Just-created IPv6 Pool with ID %q not found", id))
@@ -162,15 +161,13 @@ func (o *resourceIpv6Pool) Read(ctx context.Context, req resource.ReadRequest, r
 	// Get Ipv6 pool from API and then update what is in state from what the API returns
 	p, err := o.client.GetIp6Pool(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			// resource deleted outside of terraform
 			resp.State.RemoveResource(ctx)
 			return
-		} else {
-			resp.Diagnostics.AddError("error reading IPv6 pool", err.Error())
-			return
 		}
+		resp.Diagnostics.AddError("error reading IPv6 pool", err.Error())
+		return
 	}
 
 	// create new state object
@@ -198,14 +195,8 @@ func (o *resourceIpv6Pool) Update(ctx context.Context, req resource.UpdateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	var ace apstra.ApstraClientErr
 	err := o.client.UpdateIp6Pool(ctx, apstra.ObjectId(plan.Id.ValueString()), request)
 	if err != nil {
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound { // deleted manually since 'plan'?
-			resp.State.RemoveResource(ctx)
-			return
-		}
-		// some other unknown error
 		resp.Diagnostics.AddError("error updating IPv6 Pool", err.Error())
 		return
 	}
@@ -213,7 +204,7 @@ func (o *resourceIpv6Pool) Update(ctx context.Context, req resource.UpdateReques
 	// read pool back from Apstra to get usage statistics
 	p, err := o.client.GetIp6Pool(ctx, apstra.ObjectId(plan.Id.ValueString()))
 	if err != nil {
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
 				"IPv6 Pool not found",
@@ -246,10 +237,10 @@ func (o *resourceIpv6Pool) Delete(ctx context.Context, req resource.DeleteReques
 	// Delete IPv6 pool by calling API
 	err := o.client.DeleteIp6Pool(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() != apstra.ErrNotfound {
-			resp.Diagnostics.AddError(
-				"error deleting IPv6 pool", err.Error())
+		if utils.IsApstra404(err) {
+			return // 404 is okay
 		}
+		resp.Diagnostics.AddError(
+			"error deleting IPv6 pool", err.Error())
 	}
 }

--- a/apstra/resource_rack_type.go
+++ b/apstra/resource_rack_type.go
@@ -2,12 +2,12 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-apstra/apstra/design"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 var _ resource.ResourceWithConfigure = &resourceRackType{}
@@ -91,8 +91,7 @@ func (o *resourceRackType) Read(ctx context.Context, req resource.ReadRequest, r
 	// fetch the rack type detail from the API
 	rt, err := o.client.GetRackType(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -180,10 +179,10 @@ func (o *resourceRackType) Delete(ctx context.Context, req resource.DeleteReques
 
 	err := o.client.DeleteRackType(ctx, apstra.ObjectId(state.Id.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			return // 404 is okay in Delete()
 		}
 		resp.Diagnostics.AddError("error deleting Rack Type", err.Error())
+		return
 	}
 }

--- a/apstra/system_agents/managed_device.go
+++ b/apstra/system_agents/managed_device.go
@@ -2,7 +2,6 @@ package systemAgents
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -17,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"net"
 	apstravalidator "terraform-provider-apstra/apstra/apstra_validator"
+	"terraform-provider-apstra/apstra/utils"
 )
 
 type ManagedDevice struct {
@@ -151,8 +151,7 @@ func (o *ManagedDevice) LoadApiData(_ context.Context, in *apstra.SystemAgent, _
 func (o *ManagedDevice) ValidateAgentProfile(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
 	agentProfile, err := client.GetAgentProfile(ctx, apstra.ObjectId(o.AgentProfileId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 			diags.AddAttributeError(
 				path.Root("agent_profile_id"),
 				"agent profile not found",
@@ -201,8 +200,7 @@ func (o *ManagedDevice) GetDeviceKey(ctx context.Context, client *apstra.Client,
 	// Get SystemInfo from API
 	systemInfo, err := client.GetSystemInfo(ctx, apstra.SystemId(o.SystemId.ValueString()))
 	if err != nil {
-		var ace apstra.ApstraClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+		if utils.IsApstra404(err) {
 		} else {
 			diags.AddError(
 				"error reading managed device system info",


### PR DESCRIPTION

The SDK's `ApstraClientErr` will be renamed to `ClientErr` at some point because `apstra.ApstraClientErr` is redundant.

This goals of this PR are to:
 - reduce references to the `ApstraClientErr` type but expanding use of `utils.IsApstra404(()`.
 - improve readability

Mostly this means changing lines like:

```go
var ace apstra.ApstraClientErr
if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
```

to:

```go
if utils.IsApstra404(err) {
```

Additionally:
- the `default` case for singleton data sources (input `name` or `id`) has been removed where config validation makes it impossible to miss both the `name` case and the `id` case.
- some err examinations have been reduced from `err != nil && <desired type>` to just `<desired type>` because `IsApstra404()` handles `nil` errors gracefully.