### PR TITLE
Avoid race by copying known attribute from plan to state

### DIFF
--- a/apstra/resource_datacenter_virtual_network.go
+++ b/apstra/resource_datacenter_virtual_network.go
@@ -182,6 +182,9 @@ func (o *resourceDatacenterVirtualNetwork) Create(ctx context.Context, req resou
 	if !plan.Vni.IsUnknown() {
 		state.Vni = plan.Vni
 	}
+	if !plan.ReserveVlan.IsUnknown() {
+		state.ReserveVlan = plan.ReserveVlan
+	}
 
 	// set the state
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
@@ -287,6 +290,9 @@ func (o *resourceDatacenterVirtualNetwork) Update(ctx context.Context, req resou
 	}
 	if !plan.IPv6Gateway.IsUnknown() {
 		state.IPv6Gateway = plan.IPv6Gateway
+	}
+	if !plan.ReserveVlan.IsUnknown() {
+		state.ReserveVlan = plan.ReserveVlan
 	}
 
 	// if the plan modifier didn't take action...


### PR DESCRIPTION
We haven't replicated the condition reported by the user (suspect this requires an under-provisioned server + being unlucky).

Still this is a likely fix, and safe even if it misses the mark.