### PR TITLE
Add pre-release checks for current `main` branch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,8 @@
 #
 before:
   hooks:
+    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
+    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
     - go run github.com/chrismarget-j/go-licenses save --ignore terraform-provider-apstra --ignore github.com/Juniper/apstra-go-sdk --save_path=./Third_Party_Code --force ./...
     - sh -c "go run github.com/chrismarget-j/go-licenses report ./... --ignore terraform-provider-apstra --ignore github.com/Juniper/apstra-go-sdk/apstra --template .notices.tpl > Third_Party_Code/NOTICES.md"
     - go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs


### PR DESCRIPTION
Release v0.28.0 accidentally shipped from a bugfix branch, not the `main` branch.

This PR adds checks to the goreleaser process:
- currently on the `main` branch
- the current branch is up-to-date

Closes #301