### PR TITLE
Expand blueprint deployment comment env vars before template vars

### DIFF
--- a/apstra/blueprint/deploy.go
+++ b/apstra/blueprint/deploy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"os"
+	"strings"
 	"terraform-provider-apstra/apstra/utils"
 	"text/template"
 )
@@ -65,10 +66,11 @@ func (o Deploy) ResourceAttributes() map[string]resourceSchema.Attribute {
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"comment": resourceSchema.StringAttribute{
-			MarkdownDescription: "Comment associated with the Deployment/Commit. This field supports templating " +
-				"using the `text/template` library (currently supported replacements: ['Version']) and " +
-				"environment variable expansion using `os.ExpandEnv` to include contextual information like the " +
-				"Terraform username, CI system job ID, etc...",
+			MarkdownDescription: fmt.Sprintf("Comment associated with the Deployment/Commit. "+
+				"This field supports templating using the `text/template` library (currently supported "+
+				"replacements: [`%s`]) and environment variable expansion using `os.ExpandEnv` to "+
+				"include contextual information like the Terraform username, CI system job ID, etc...",
+				strings.Join(CommentTemplateReplacements, "`, `")),
 			Computed:   true,
 			Optional:   true,
 			Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
@@ -121,7 +123,11 @@ func (o *Deploy) Deploy(ctx context.Context, commentTemplate *CommentTemplate, c
 		return
 	}
 
-	t, err := new(template.Template).Parse(o.Comment.ValueString())
+	// expand environment variables in the comment
+	commentWithEnv := os.ExpandEnv(o.Comment.ValueString())
+
+	// parse the comment template
+	t, err := new(template.Template).Parse(commentWithEnv)
 	if err != nil {
 		diags.AddWarning(
 			fmt.Sprintf("error creating deployment comment template from string %q", o.Comment.ValueString()),
@@ -133,9 +139,10 @@ func (o *Deploy) Deploy(ctx context.Context, commentTemplate *CommentTemplate, c
 		diags.AddWarning("error executing deployment comment template", err.Error())
 	}
 
+	// request deployment via the API
 	response, err := client.DeployBlueprint(ctx, &apstra.BlueprintDeployRequest{
 		Id:          apstra.ObjectId(o.BlueprintId.ValueString()),
-		Description: os.ExpandEnv(buf.String()),
+		Description: buf.String(),
 		Version:     status.Version,
 	})
 	if err != nil {
@@ -203,6 +210,8 @@ func (o *Deploy) Read(ctx context.Context, client *apstra.Client, diags *diag.Di
 	o.ActiveRevision = types.Int64Value(int64(revision.RevisionId))
 	o.StagedRevision = types.Int64Value(int64(status.Version))
 }
+
+var CommentTemplateReplacements = []string{"{{`{{.TerraformVersion}}`}}", "{{`{{.ProviderVersion}}`}}"}
 
 type CommentTemplate struct {
 	ProviderVersion  string

--- a/docs/resources/blueprint_deployment.md
+++ b/docs/resources/blueprint_deployment.md
@@ -99,7 +99,7 @@ resource "apstra_blueprint_deployment" "deploy" {
 
 ### Optional
 
-- `comment` (String) Comment associated with the Deployment/Commit. This field supports templating using the `text/template` library (currently supported replacements: ['Version']) and environment variable expansion using `os.ExpandEnv` to include contextual information like the Terraform username, CI system job ID, etc...
+- `comment` (String) Comment associated with the Deployment/Commit. This field supports templating using the `text/template` library (currently supported replacements: [`{{.TerraformVersion}}`, `{{.ProviderVersion}}`]) and environment variable expansion using `os.ExpandEnv` to include contextual information like the Terraform username, CI system job ID, etc...
 
 ### Read-Only
 

--- a/docs/resources/blueprint_deployment.md
+++ b/docs/resources/blueprint_deployment.md
@@ -50,7 +50,7 @@ resource "apstra_datacenter_device_allocation" "interface_map_assignment" {
   for_each         = local.switches
   blueprint_id     = apstra_datacenter_blueprint.instantiation.id
   node_name        = each.key
-  interface_map_id = each.value
+  initial_interface_map_id = each.value
 }
 
 # Assign ASN pools to fabric roles to eliminate build errors so we

--- a/docs/resources/datacenter_blueprint.md
+++ b/docs/resources/datacenter_blueprint.md
@@ -50,7 +50,7 @@ resource "apstra_datacenter_device_allocation" "interface_map_assignment" {
   for_each         = local.switches
   blueprint_id     = apstra_datacenter_blueprint.instantiation.id
   node_name        = each.key
-  interface_map_id = each.value
+  initial_interface_map_id = each.value
 }
 
 # Assign ASN pools to fabric roles to eliminate build errors so we

--- a/docs/resources/datacenter_device_allocation.md
+++ b/docs/resources/datacenter_device_allocation.md
@@ -31,7 +31,7 @@ resource "apstra_datacenter_blueprint" "r" {
 # initial_interface_map_id by first determining the device type, and then
 # looking for candidate interface maps which can map the specific hardware
 # to the logical device specified by the fabric role. When multiple
-# candidate interface maps exist supplying interface_map_id becomes
+# candidate interface maps exist supplying initial_interface_map_id becomes
 # mandatory.
 locals {
   switches = {

--- a/examples/resources/apstra_blueprint_deployment/example.tf
+++ b/examples/resources/apstra_blueprint_deployment/example.tf
@@ -36,7 +36,7 @@ resource "apstra_datacenter_device_allocation" "interface_map_assignment" {
   for_each         = local.switches
   blueprint_id     = apstra_datacenter_blueprint.instantiation.id
   node_name        = each.key
-  interface_map_id = each.value
+  initial_interface_map_id = each.value
 }
 
 # Assign ASN pools to fabric roles to eliminate build errors so we

--- a/examples/resources/apstra_datacenter_blueprint/example.tf
+++ b/examples/resources/apstra_datacenter_blueprint/example.tf
@@ -36,7 +36,7 @@ resource "apstra_datacenter_device_allocation" "interface_map_assignment" {
   for_each         = local.switches
   blueprint_id     = apstra_datacenter_blueprint.instantiation.id
   node_name        = each.key
-  interface_map_id = each.value
+  initial_interface_map_id = each.value
 }
 
 # Assign ASN pools to fabric roles to eliminate build errors so we

--- a/examples/resources/apstra_datacenter_device_allocation/example.tf
+++ b/examples/resources/apstra_datacenter_device_allocation/example.tf
@@ -17,7 +17,7 @@ resource "apstra_datacenter_blueprint" "r" {
 # initial_interface_map_id by first determining the device type, and then
 # looking for candidate interface maps which can map the specific hardware
 # to the logical device specified by the fabric role. When multiple
-# candidate interface maps exist supplying interface_map_id becomes
+# candidate interface maps exist supplying initial_interface_map_id becomes
 # mandatory.
 locals {
   switches = {

--- a/lab_guide_demo/5_blueprints.tf
+++ b/lab_guide_demo/5_blueprints.tf
@@ -34,7 +34,7 @@
 #resource "apstra_datacenter_device_allocation" "lab_guide" {
 #  for_each         = local.switches
 #  blueprint_id     = apstra_datacenter_blueprint.lab_guide.id
-#  interface_map_id = data.apstra_interface_map.lab_guide.id
+#  initial_interface_map_id = data.apstra_interface_map.lab_guide.id
 #  node_name        = each.key
 #  device_key       = each.value.device_key
 #}


### PR DESCRIPTION
Commit comments expand two categories of embedded strings:

- Go `text/template` expansion which replaces `{{.TerraformVersion}}` and `{{.ProviderVersion}}` with the actual version strings.
- Go `os.ExpandEnv` which replaces environment variables like `$USER` with their contents.

This PR swaps the order of the expansion so that `os.ExpandEnv` runs before the `text/template` mechanism.

This makes it possible to use configs like this:

```hcl
resource "apstra_blueprint_deployment" "deploy" {
  blueprint_id = apstra_datacenter_blueprint.instantiation.id
  comment      = "$COMMENT"
}
```

And then run them like this:

```shell
COMMENT="Commit by Terraform {{.TerraformVersion}}" terraform apply
```

Closes #286