### PR TITLE
WIP: Change eliminate maps from `rack_type` schema

### DIFF
--- a/apstra/design/rack_type_access_switch.go
+++ b/apstra/design/rack_type_access_switch.go
@@ -209,7 +209,8 @@ func (o *AccessSwitch) Request(ctx context.Context, path path.Path, rack *RackTy
 
 	lacpActive := apstra.RackLinkLagModeActive.String()
 
-	links := o.GetLinks(ctx, diags)
+	links := make([]RackLink, len(o.Links.Elements()))
+	diags.Append(o.Links.ElementsAs(ctx, &links, false)...)
 	if diags.HasError() {
 		return nil
 	}
@@ -260,20 +261,6 @@ func (o *AccessSwitch) LoadApiData(ctx context.Context, in *apstra.RackElementAc
 	o.Links = NewLinkSet(ctx, in.Links, diags)
 	o.TagIds = types.SetNull(types.StringType)
 	o.Tags = NewTagSet(ctx, in.Tags, diags)
-}
-
-func (o *AccessSwitch) GetLinks(ctx context.Context, diags *diag.Diagnostics) []RackLink {
-	links := make([]RackLink, len(o.Links.Elements()))
-	diags.Append(o.Links.ElementsAs(ctx, &links, false)...)
-	if diags.HasError() {
-		return nil
-	}
-
-	// copy the link name from the map key into the object's Name field
-	for i, link := range links {
-		links[i] = link
-	}
-	return links
 }
 
 func (o *AccessSwitch) CopyWriteOnlyElements(ctx context.Context, src *AccessSwitch, diags *diag.Diagnostics) {

--- a/apstra/design/rack_type_access_switch.go
+++ b/apstra/design/rack_type_access_switch.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -41,7 +40,7 @@ type AccessSwitch struct {
 	EsiLagInfo         types.Object `tfsdk:"esi_lag_info"`
 	RedundancyProtocol types.String `tfsdk:"redundancy_protocol"`
 	Count              types.Int64  `tfsdk:"count"`
-	Links              types.Map    `tfsdk:"links"`
+	Links              types.Set    `tfsdk:"links"`
 	TagIds             types.Set    `tfsdk:"tag_ids"`
 	Tags               types.Set    `tfsdk:"tags"`
 }
@@ -70,10 +69,9 @@ func (o AccessSwitch) DataSourceAttributes() map[string]dataSourceSchema.Attribu
 			MarkdownDescription: "Count of Access Switches of this type.",
 			Computed:            true,
 		},
-		"links": dataSourceSchema.MapNestedAttribute{
+		"links": dataSourceSchema.SetNestedAttribute{
 			MarkdownDescription: "Details links from this Access Switch to upstream switches within this Rack Type.",
 			Computed:            true,
-			Validators:          []validator.Map{mapvalidator.SizeAtLeast(1)},
 			NestedObject: dataSourceSchema.NestedAttributeObject{
 				Attributes: RackLink{}.DataSourceAttributes(),
 			},
@@ -119,10 +117,10 @@ func (o AccessSwitch) ResourceAttributes() map[string]resourceSchema.Attribute {
 			Required:            true,
 			Validators:          []validator.Int64{int64validator.AtLeast(1)},
 		},
-		"links": resourceSchema.MapNestedAttribute{
+		"links": resourceSchema.SetNestedAttribute{
 			MarkdownDescription: "Each Access Switch is required to have at least one Link to a Leaf Switch.",
 			Required:            true,
-			Validators:          []validator.Map{mapvalidator.SizeAtLeast(1)},
+			Validators:          []validator.Set{setvalidator.SizeAtLeast(1)},
 			NestedObject: resourceSchema.NestedAttributeObject{
 				Attributes: RackLink{}.ResourceAttributes(),
 			},
@@ -168,7 +166,7 @@ func (o AccessSwitch) ResourceAttributesNested() map[string]resourceSchema.Attri
 			MarkdownDescription: "Number of Access Switches of this type.",
 			Computed:            true,
 		},
-		"links": resourceSchema.MapNestedAttribute{
+		"links": resourceSchema.SetNestedAttribute{
 			MarkdownDescription: "Each Access Switch is required to have at least one Link to a Leaf Switch.",
 			Computed:            true,
 			NestedObject: resourceSchema.NestedAttributeObject{
@@ -197,7 +195,7 @@ func (o AccessSwitch) AttrTypes() map[string]attr.Type {
 		"esi_lag_info":        types.ObjectType{AttrTypes: EsiLagInfo{}.AttrTypes()},
 		"redundancy_protocol": types.StringType,
 		"count":               types.Int64Type,
-		"links":               types.MapType{ElemType: types.ObjectType{AttrTypes: RackLink{}.AttrTypes()}},
+		"links":               types.SetType{ElemType: types.ObjectType{AttrTypes: RackLink{}.AttrTypes()}},
 		"tag_ids":             types.SetType{ElemType: types.StringType},
 		"tags":                types.SetType{ElemType: types.ObjectType{AttrTypes: Tag{}.AttrTypes()}},
 	}
@@ -217,20 +215,14 @@ func (o *AccessSwitch) Request(ctx context.Context, path path.Path, rack *RackTy
 	}
 
 	linkRequests := make([]apstra.RackLinkRequest, len(links))
-	i := 0
-	for name, link := range links {
+	for i, link := range links {
 		link.LagMode = types.StringValue(lacpActive)
-		lr := link.Request(ctx, path.AtName("links").AtMapKey(name), rack, diags)
-		if diags.HasError() {
-			return nil
-		}
-		lr.Label = name
+		lr := link.Request(ctx, path.AtName("links").AtListIndex(i), rack, diags)
 		if diags.HasError() {
 			return nil
 		}
 
 		linkRequests[i] = *lr
-		i++
 	}
 
 	tagIds := make([]apstra.ObjectId, len(o.TagIds.Elements()))
@@ -265,22 +257,21 @@ func (o *AccessSwitch) LoadApiData(ctx context.Context, in *apstra.RackElementAc
 	o.EsiLagInfo = NewEsiLagInfo(ctx, in.EsiLagInfo, diags)
 	o.RedundancyProtocol = utils.StringValueWithNull(ctx, in.RedundancyProtocol.String(), apstra.AccessRedundancyProtocolNone.String(), diags)
 	o.Count = types.Int64Value(int64(in.InstanceCount))
-	o.Links = NewLinkMap(ctx, in.Links, diags)
+	o.Links = NewLinkSet(ctx, in.Links, diags)
 	o.TagIds = types.SetNull(types.StringType)
 	o.Tags = NewTagSet(ctx, in.Tags, diags)
 }
 
-func (o *AccessSwitch) GetLinks(ctx context.Context, diags *diag.Diagnostics) map[string]RackLink {
-	links := make(map[string]RackLink, len(o.Links.Elements()))
-	d := o.Links.ElementsAs(ctx, &links, false)
-	diags.Append(d...)
+func (o *AccessSwitch) GetLinks(ctx context.Context, diags *diag.Diagnostics) []RackLink {
+	links := make([]RackLink, len(o.Links.Elements()))
+	diags.Append(o.Links.ElementsAs(ctx, &links, false)...)
 	if diags.HasError() {
 		return nil
 	}
 
 	// copy the link name from the map key into the object's Name field
-	for name, link := range links {
-		links[name] = link
+	for i, link := range links {
+		links[i] = link
 	}
 	return links
 }
@@ -294,30 +285,29 @@ func (o *AccessSwitch) CopyWriteOnlyElements(ctx context.Context, src *AccessSwi
 	o.LogicalDeviceId = types.StringValue(src.LogicalDeviceId.ValueString())
 	o.TagIds = utils.SetValueOrNull(ctx, types.StringType, src.TagIds.Elements(), diags)
 
-	var d diag.Diagnostics
-
-	srcLinks := make(map[string]RackLink, len(src.Links.Elements()))
-	d = src.Links.ElementsAs(ctx, &srcLinks, false)
-	diags.Append(d...)
+	// extract the source links because we need the tag IDs
+	srcLinks := make([]RackLink, len(src.Links.Elements()))
+	diags.Append(src.Links.ElementsAs(ctx, &srcLinks, false)...)
 	if diags.HasError() {
 		return
 	}
 
-	dstLinks := make(map[string]RackLink, len(o.Links.Elements()))
-	d = o.Links.ElementsAs(ctx, &dstLinks, false)
-	diags.Append(d...)
+	// extract the destination links because we'll copy the tag IDs here
+	dstLinks := make([]RackLink, len(o.Links.Elements()))
+	diags.Append(o.Links.ElementsAs(ctx, &dstLinks, false)...)
 	if diags.HasError() {
 		return
 	}
 
-	for name, dstLink := range dstLinks {
-		if srcLink, ok := srcLinks[name]; ok {
-			dstLink.CopyWriteOnlyElements(ctx, &srcLink, diags)
-			dstLinks[name] = dstLink
-		}
+	// copy from each source to each destination
+	for i := range dstLinks[:utils.Min(len(srcLinks), len(dstLinks))] {
+		dstLinks[i].CopyWriteOnlyElements(ctx, &srcLinks[i], diags)
+	}
+	if diags.HasError() {
+		return
 	}
 
-	o.Links = utils.MapValueOrNull(ctx, types.ObjectType{AttrTypes: RackLink{}.AttrTypes()}, dstLinks, diags)
+	o.Links = utils.SetValueOrNull(ctx, types.ObjectType{AttrTypes: RackLink{}.AttrTypes()}, dstLinks, diags)
 	if diags.HasError() {
 		return
 	}

--- a/apstra/design/rack_type_generic_system.go
+++ b/apstra/design/rack_type_generic_system.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -34,7 +33,7 @@ type GenericSystem struct {
 	PortChannelIdMin types.Int64  `tfsdk:"port_channel_id_min"`
 	PortChannelIdMax types.Int64  `tfsdk:"port_channel_id_max"`
 	Count            types.Int64  `tfsdk:"count"`
-	Links            types.Map    `tfsdk:"links"`
+	Links            types.Set    `tfsdk:"links"`
 	TagIds           types.Set    `tfsdk:"tag_ids"`
 	Tags             types.Set    `tfsdk:"tags"`
 }
@@ -62,10 +61,9 @@ func (o GenericSystem) DataSourceAttributes() map[string]dataSourceSchema.Attrib
 			MarkdownDescription: "Number of Generic Systems of this type.",
 			Computed:            true,
 		},
-		"links": dataSourceSchema.MapNestedAttribute{
+		"links": dataSourceSchema.SetNestedAttribute{
 			MarkdownDescription: "Details links from this Generic System to upstream switches within this Rack Type.",
 			Computed:            true,
-			Validators:          []validator.Map{mapvalidator.SizeAtLeast(1)},
 			NestedObject: dataSourceSchema.NestedAttributeObject{
 				Attributes: RackLink{}.DataSourceAttributes(),
 			},
@@ -122,10 +120,10 @@ func (o GenericSystem) ResourceAttributes() map[string]resourceSchema.Attribute 
 			Required:            true,
 			Validators:          []validator.Int64{int64validator.AtLeast(1)},
 		},
-		"links": resourceSchema.MapNestedAttribute{
+		"links": resourceSchema.SetNestedAttribute{
 			MarkdownDescription: "Each Generic System is required to have at least one Link to a Leaf Switch or Access Switch.",
 			Required:            true,
-			Validators:          []validator.Map{mapvalidator.SizeAtLeast(1)},
+			Validators:          []validator.Set{setvalidator.SizeAtLeast(1)},
 			NestedObject: resourceSchema.NestedAttributeObject{
 				Attributes: RackLink{}.ResourceAttributes(),
 			},
@@ -169,7 +167,7 @@ func (o GenericSystem) ResourceAttributesNested() map[string]resourceSchema.Attr
 			MarkdownDescription: "Number of Generic Systems of this type.",
 			Computed:            true,
 		},
-		"links": resourceSchema.MapNestedAttribute{
+		"links": resourceSchema.SetNestedAttribute{
 			MarkdownDescription: "Each Generic System is required to have at least one Link to a Leaf Switch or Access Switch.",
 			Computed:            true,
 			NestedObject: resourceSchema.NestedAttributeObject{
@@ -198,7 +196,7 @@ func (o GenericSystem) AttrTypes() map[string]attr.Type {
 		"port_channel_id_min": types.Int64Type,
 		"port_channel_id_max": types.Int64Type,
 		"count":               types.Int64Type,
-		"links":               types.MapType{ElemType: types.ObjectType{AttrTypes: RackLink{}.AttrTypes()}},
+		"links":               types.SetType{ElemType: types.ObjectType{AttrTypes: RackLink{}.AttrTypes()}},
 		"tag_ids":             types.SetType{ElemType: types.StringType},
 		"tags":                types.SetType{ElemType: types.ObjectType{AttrTypes: Tag{}.AttrTypes()}},
 	}
@@ -219,19 +217,13 @@ func (o *GenericSystem) Request(ctx context.Context, path path.Path, rack *RackT
 	}
 
 	linkRequests := make([]apstra.RackLinkRequest, len(links))
-	i := 0
-	for name, link := range links {
-		lr := link.Request(ctx, path.AtName("links").AtMapKey(name), rack, diags)
-		if diags.HasError() {
-			return nil
-		}
-		lr.Label = name
+	for i, link := range links {
+		lr := link.Request(ctx, path.AtName("links").AtListIndex(i), rack, diags)
 		if diags.HasError() {
 			return nil
 		}
 
 		linkRequests[i] = *lr
-		i++
 	}
 
 	tagIds := make([]apstra.ObjectId, len(o.TagIds.Elements()))
@@ -256,22 +248,21 @@ func (o *GenericSystem) LoadApiData(ctx context.Context, in *apstra.RackElementG
 	o.PortChannelIdMin = types.Int64Value(int64(in.PortChannelIdMin))
 	o.PortChannelIdMax = types.Int64Value(int64(in.PortChannelIdMax))
 	o.Count = types.Int64Value(int64(in.Count))
-	o.Links = NewLinkMap(ctx, in.Links, diags)
+	o.Links = NewLinkSet(ctx, in.Links, diags)
 	o.TagIds = types.SetNull(types.StringType)
 	o.Tags = NewTagSet(ctx, in.Tags, diags)
 }
 
-func (o *GenericSystem) GetLinks(ctx context.Context, diags *diag.Diagnostics) map[string]RackLink {
-	links := make(map[string]RackLink, len(o.Links.Elements()))
-	d := o.Links.ElementsAs(ctx, &links, false)
-	diags.Append(d...)
+func (o *GenericSystem) GetLinks(ctx context.Context, diags *diag.Diagnostics) []RackLink {
+	links := make([]RackLink, len(o.Links.Elements()))
+	diags.Append(o.Links.ElementsAs(ctx, &links, false)...)
 	if diags.HasError() {
 		return nil
 	}
 
 	// copy the link name from the map key into the object's Name field
-	for name, link := range links {
-		links[name] = link
+	for i, link := range links {
+		links[i] = link
 	}
 	return links
 }
@@ -285,34 +276,32 @@ func (o *GenericSystem) CopyWriteOnlyElements(ctx context.Context, src *GenericS
 	o.LogicalDeviceId = types.StringValue(src.LogicalDeviceId.ValueString())
 	o.TagIds = utils.SetValueOrNull(ctx, types.StringType, src.TagIds.Elements(), diags)
 
-	var d diag.Diagnostics
-
-	srcLinks := make(map[string]RackLink, len(src.Links.Elements()))
-	d = src.Links.ElementsAs(ctx, &srcLinks, false)
-	diags.Append(d...)
+	// extract the source links because we need the tag IDs
+	srcLinks := make([]RackLink, len(src.Links.Elements()))
+	diags.Append(src.Links.ElementsAs(ctx, &srcLinks, false)...)
 	if diags.HasError() {
 		return
 	}
 
-	dstLinks := make(map[string]RackLink, len(o.Links.Elements()))
-	d = o.Links.ElementsAs(ctx, &dstLinks, false)
-	diags.Append(d...)
+	// extract the destination links because we'll copy the tag IDs here
+	dstLinks := make([]RackLink, len(o.Links.Elements()))
+	diags.Append(o.Links.ElementsAs(ctx, &dstLinks, false)...)
 	if diags.HasError() {
 		return
 	}
 
-	for name, dstLink := range dstLinks {
-		if srcLink, ok := srcLinks[name]; ok {
-			dstLink.CopyWriteOnlyElements(ctx, &srcLink, diags)
-			dstLinks[name] = dstLink
-		}
+	// copy from each source to each destination
+	for i := range dstLinks[:utils.Min(len(srcLinks), len(dstLinks))] {
+		dstLinks[i].CopyWriteOnlyElements(ctx, &srcLinks[i], diags)
 	}
-
-	o.Links = utils.MapValueOrNull(ctx, types.ObjectType{AttrTypes: RackLink{}.AttrTypes()}, dstLinks, diags)
 	if diags.HasError() {
 		return
 	}
 
+	o.Links = utils.SetValueOrNull(ctx, types.ObjectType{AttrTypes: RackLink{}.AttrTypes()}, dstLinks, diags)
+	if diags.HasError() {
+		return
+	}
 }
 
 func NewGenericSystemMap(ctx context.Context, in []apstra.RackElementGenericSystem, diags *diag.Diagnostics) types.Map {

--- a/apstra/design/rack_type_generic_system.go
+++ b/apstra/design/rack_type_generic_system.go
@@ -211,7 +211,8 @@ func (o *GenericSystem) Request(ctx context.Context, path path.Path, rack *RackT
 		poIdMaxVal = int(o.PortChannelIdMax.ValueInt64())
 	}
 
-	links := o.GetLinks(ctx, diags)
+	links := make([]RackLink, len(o.Links.Elements()))
+	diags.Append(o.Links.ElementsAs(ctx, &links, false)...)
 	if diags.HasError() {
 		return nil
 	}
@@ -251,20 +252,6 @@ func (o *GenericSystem) LoadApiData(ctx context.Context, in *apstra.RackElementG
 	o.Links = NewLinkSet(ctx, in.Links, diags)
 	o.TagIds = types.SetNull(types.StringType)
 	o.Tags = NewTagSet(ctx, in.Tags, diags)
-}
-
-func (o *GenericSystem) GetLinks(ctx context.Context, diags *diag.Diagnostics) []RackLink {
-	links := make([]RackLink, len(o.Links.Elements()))
-	diags.Append(o.Links.ElementsAs(ctx, &links, false)...)
-	if diags.HasError() {
-		return nil
-	}
-
-	// copy the link name from the map key into the object's Name field
-	for i, link := range links {
-		links[i] = link
-	}
-	return links
 }
 
 func (o *GenericSystem) CopyWriteOnlyElements(ctx context.Context, src *GenericSystem, diags *diag.Diagnostics) {

--- a/docs/data-sources/rack_type.md
+++ b/docs/data-sources/rack_type.md
@@ -65,7 +65,7 @@ Read-Only:
 
 - `count` (Number) Count of Access Switches of this type.
 - `esi_lag_info` (Attributes) Interconnect information for Access Switches in ESI-LAG redundancy mode. (see [below for nested schema](#nestedatt--access_switches--esi_lag_info))
-- `links` (Attributes Map) Details links from this Access Switch to upstream switches within this Rack Type. (see [below for nested schema](#nestedatt--access_switches--links))
+- `links` (Attributes Set) Details links from this Access Switch to upstream switches within this Rack Type. (see [below for nested schema](#nestedatt--access_switches--links))
 - `logical_device` (Attributes) Logical Device attributes as represented in the Global Catalog. (see [below for nested schema](#nestedatt--access_switches--logical_device))
 - `logical_device_id` (String) ID will always be `<null>` in data source contexts.
 - `redundancy_protocol` (String) Indicates whether 'the switch' is actually a LAG-capable redundant pair and if so, what type.
@@ -88,6 +88,7 @@ Read-Only:
 
 - `lag_mode` (String) LAG negotiation mode of the Link.
 - `links_per_switch` (Number) Number of Links to each switch.
+- `name` (String) Link name
 - `speed` (String) Speed of this Link.
 - `switch_peer` (String) For non-LAG connections to redundant switch pairs, this field selects the target switch.
 - `tag_ids` (Set of String) IDs will always be `<null>` in data source contexts.
@@ -152,7 +153,7 @@ Read-Only:
 Read-Only:
 
 - `count` (Number) Number of Generic Systems of this type.
-- `links` (Attributes Map) Details links from this Generic System to upstream switches within this Rack Type. (see [below for nested schema](#nestedatt--generic_systems--links))
+- `links` (Attributes Set) Details links from this Generic System to upstream switches within this Rack Type. (see [below for nested schema](#nestedatt--generic_systems--links))
 - `logical_device` (Attributes) Logical Device attributes as represented in the Global Catalog. (see [below for nested schema](#nestedatt--generic_systems--logical_device))
 - `logical_device_id` (String) ID will always be `<null>` in data source contexts.
 - `port_channel_id_max` (Number) Port channel IDs are used when rendering leaf device port-channel configuration towards generic systems.
@@ -167,6 +168,7 @@ Read-Only:
 
 - `lag_mode` (String) LAG negotiation mode of the Link.
 - `links_per_switch` (Number) Number of Links to each switch.
+- `name` (String) Link name
 - `speed` (String) Speed of this Link.
 - `switch_peer` (String) For non-LAG connections to redundant switch pairs, this field selects the target switch.
 - `tag_ids` (Set of String) IDs will always be `<null>` in data source contexts.

--- a/docs/data-sources/template_rack_based.md
+++ b/docs/data-sources/template_rack_based.md
@@ -80,7 +80,7 @@ Read-Only:
 
 - `count` (Number) Count of Access Switches of this type.
 - `esi_lag_info` (Attributes) Interconnect information for Access Switches in ESI-LAG redundancy mode. (see [below for nested schema](#nestedatt--rack_infos--rack_type--access_switches--esi_lag_info))
-- `links` (Attributes Map) Details links from this Access Switch to upstream switches within this Rack Type. (see [below for nested schema](#nestedatt--rack_infos--rack_type--access_switches--links))
+- `links` (Attributes Set) Details links from this Access Switch to upstream switches within this Rack Type. (see [below for nested schema](#nestedatt--rack_infos--rack_type--access_switches--links))
 - `logical_device` (Attributes) Logical Device attributes as represented in the Global Catalog. (see [below for nested schema](#nestedatt--rack_infos--rack_type--access_switches--logical_device))
 - `logical_device_id` (String) ID will always be `<null>` in data source contexts.
 - `redundancy_protocol` (String) Indicates whether 'the switch' is actually a LAG-capable redundant pair and if so, what type.
@@ -103,6 +103,7 @@ Read-Only:
 
 - `lag_mode` (String) LAG negotiation mode of the Link.
 - `links_per_switch` (Number) Number of Links to each switch.
+- `name` (String) Link name
 - `speed` (String) Speed of this Link.
 - `switch_peer` (String) For non-LAG connections to redundant switch pairs, this field selects the target switch.
 - `tag_ids` (Set of String) IDs will always be `<null>` in data source contexts.
@@ -167,7 +168,7 @@ Read-Only:
 Read-Only:
 
 - `count` (Number) Number of Generic Systems of this type.
-- `links` (Attributes Map) Details links from this Generic System to upstream switches within this Rack Type. (see [below for nested schema](#nestedatt--rack_infos--rack_type--generic_systems--links))
+- `links` (Attributes Set) Details links from this Generic System to upstream switches within this Rack Type. (see [below for nested schema](#nestedatt--rack_infos--rack_type--generic_systems--links))
 - `logical_device` (Attributes) Logical Device attributes as represented in the Global Catalog. (see [below for nested schema](#nestedatt--rack_infos--rack_type--generic_systems--logical_device))
 - `logical_device_id` (String) ID will always be `<null>` in data source contexts.
 - `port_channel_id_max` (Number) Port channel IDs are used when rendering leaf device port-channel configuration towards generic systems.
@@ -182,6 +183,7 @@ Read-Only:
 
 - `lag_mode` (String) LAG negotiation mode of the Link.
 - `links_per_switch` (Number) Number of Links to each switch.
+- `name` (String) Link name
 - `speed` (String) Speed of this Link.
 - `switch_peer` (String) For non-LAG connections to redundant switch pairs, this field selects the target switch.
 - `tag_ids` (Set of String) IDs will always be `<null>` in data source contexts.

--- a/docs/resources/rack_type.md
+++ b/docs/resources/rack_type.md
@@ -161,7 +161,7 @@ Read-Only:
 Required:
 
 - `count` (Number) Number of Access Switches of this type.
-- `links` (Attributes Map) Each Access Switch is required to have at least one Link to a Leaf Switch. (see [below for nested schema](#nestedatt--access_switches--links))
+- `links` (Attributes Set) Each Access Switch is required to have at least one Link to a Leaf Switch. (see [below for nested schema](#nestedatt--access_switches--links))
 - `logical_device_id` (String) Apstra Object ID of the Logical Device used to model this Access Switch.
 
 Optional:
@@ -180,6 +180,7 @@ Read-Only:
 
 Required:
 
+- `name` (String) Link name
 - `speed` (String) Speed of this Link.
 - `target_switch_name` (String) The `name` of the switch in this Rack Type to which this Link connects.
 
@@ -267,7 +268,7 @@ Read-Only:
 Required:
 
 - `count` (Number) Number of Generic Systems of this type.
-- `links` (Attributes Map) Each Generic System is required to have at least one Link to a Leaf Switch or Access Switch. (see [below for nested schema](#nestedatt--generic_systems--links))
+- `links` (Attributes Set) Each Generic System is required to have at least one Link to a Leaf Switch or Access Switch. (see [below for nested schema](#nestedatt--generic_systems--links))
 - `logical_device_id` (String) Apstra Object ID of the Logical Device used to model this Generic System.
 
 Optional:
@@ -286,6 +287,7 @@ Read-Only:
 
 Required:
 
+- `name` (String) Link name
 - `speed` (String) Speed of this Link.
 - `target_switch_name` (String) The `name` of the switch in this Rack Type to which this Link connects.
 

--- a/docs/resources/template_rack_based.md
+++ b/docs/resources/template_rack_based.md
@@ -91,7 +91,7 @@ Read-Only:
 
 - `count` (Number) Number of Access Switches of this type.
 - `esi_lag_info` (Attributes) Defines connectivity between ESI LAG peers when `redundancy_protocol` is set to `esi`. (see [below for nested schema](#nestedatt--rack_infos--rack_type--access_switches--esi_lag_info))
-- `links` (Attributes Map) Each Access Switch is required to have at least one Link to a Leaf Switch. (see [below for nested schema](#nestedatt--rack_infos--rack_type--access_switches--links))
+- `links` (Attributes Set) Each Access Switch is required to have at least one Link to a Leaf Switch. (see [below for nested schema](#nestedatt--rack_infos--rack_type--access_switches--links))
 - `logical_device` (Attributes) Logical Device attributes cloned from the Global Catalog at creation time. (see [below for nested schema](#nestedatt--rack_infos--rack_type--access_switches--logical_device))
 - `logical_device_id` (String) ID will always be `<null>` in nested contexts.
 - `redundancy_protocol` (String) Indicates whether the switch is a redundant pair.
@@ -114,6 +114,7 @@ Read-Only:
 
 - `lag_mode` (String) LAG negotiation mode of the Link.
 - `links_per_switch` (Number) Number of Links to each switch.
+- `name` (String) Link name
 - `speed` (String) Speed of this Link.
 - `switch_peer` (String) For non-lAG connections to redundant switch pairs, this field selects the target switch.
 - `tag_ids` (Set of String) IDs will always be `<null>` in nested contexts.
@@ -184,7 +185,7 @@ Read-Only:
 Read-Only:
 
 - `count` (Number) Number of Generic Systems of this type.
-- `links` (Attributes Map) Each Generic System is required to have at least one Link to a Leaf Switch or Access Switch. (see [below for nested schema](#nestedatt--rack_infos--rack_type--generic_systems--links))
+- `links` (Attributes Set) Each Generic System is required to have at least one Link to a Leaf Switch or Access Switch. (see [below for nested schema](#nestedatt--rack_infos--rack_type--generic_systems--links))
 - `logical_device` (Attributes) Logical Device attributes cloned from the Global Catalog at creation time. (see [below for nested schema](#nestedatt--rack_infos--rack_type--generic_systems--logical_device))
 - `logical_device_id` (String) ID will always be `<null>` in nested contexts.
 - `port_channel_id_max` (Number) Port channel IDs are used when rendering leaf device port-channel configuration towards generic systems.
@@ -197,6 +198,7 @@ Read-Only:
 
 Required:
 
+- `name` (String) Link name
 - `speed` (String) Speed of this Link.
 - `target_switch_name` (String) The `name` of the switch in this Rack Type to which this Link connects.
 


### PR DESCRIPTION
I'm anticipating a set of stacked, interdependent PRs.

This one converts the link schema in rack_type from this:

```hcl
links = {
  link_one = {
    # various attributes here
  }
}
```

to this:

```hcl
links = [
  {
    name = "link_one"
    # various attributes here
  }
]
```
