### PR TITLE
Bugfix: Update only the changed attributes of generic system links

### DIFF
--- a/apstra/blueprint/datacenter_generic_system.go
+++ b/apstra/blueprint/datacenter_generic_system.go
@@ -343,7 +343,6 @@ func (o *DatacenterGenericSystem) UpdateLinkSet(ctx context.Context, state *Data
 		return
 	}
 
-	// passing prior link state here could speed things up because we won't need to call every set operation
 	o.updateLinkParams(ctx, updateLinksPlan, updateLinksState, bp, diags)
 	if diags.HasError() {
 		return

--- a/apstra/blueprint/datacenter_generic_system.go
+++ b/apstra/blueprint/datacenter_generic_system.go
@@ -316,12 +316,15 @@ func (o *DatacenterGenericSystem) UpdateLinkSet(ctx context.Context, state *Data
 	}
 
 	// compare plan and state, make lists of links to add / check+update / delete
-	var addLinks, updateLinks, delLinks []*DatacenterGenericSystemLink
+	var addLinks, updateLinksPlan, updateLinksState, delLinks []*DatacenterGenericSystemLink
 	for digest := range planLinksMap {
 		if _, ok := stateLinksMap[digest]; !ok {
 			addLinks = append(addLinks, planLinksMap[digest])
 		} else {
-			updateLinks = append(updateLinks, planLinksMap[digest])
+			// "updateLinks" is two slices: plan and state, so that we can
+			// compare and change only required attributes.
+			updateLinksPlan = append(updateLinksPlan, planLinksMap[digest])
+			updateLinksState = append(updateLinksState, stateLinksMap[digest])
 		}
 	}
 	for digest := range stateLinksMap {
@@ -341,7 +344,7 @@ func (o *DatacenterGenericSystem) UpdateLinkSet(ctx context.Context, state *Data
 	}
 
 	// passing prior link state here could speed things up because we won't need to call every set operation
-	o.updateLinkParams(ctx, updateLinks, bp, diags)
+	o.updateLinkParams(ctx, updateLinksPlan, updateLinksState, bp, diags)
 	if diags.HasError() {
 		return
 	}
@@ -397,9 +400,9 @@ func (o *DatacenterGenericSystem) deleteLinksFromSystem(ctx context.Context, lin
 // embedded), but it does not operate on those links (all of the links). Rather
 // it operates only on the links passed as a function argument because only
 // those links need to be updated/validated.
-func (o *DatacenterGenericSystem) updateLinkParams(ctx context.Context, links []*DatacenterGenericSystemLink, bp *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) {
+func (o *DatacenterGenericSystem) updateLinkParams(ctx context.Context, planLinks, stateLinks []*DatacenterGenericSystemLink, bp *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) {
 	// one at a time, check/update each link
-	for _, link := range links {
+	for i, link := range planLinks {
 		// we don't keep the link ID, but we have each link's target switch and
 		// interface name. That's enough to uniquely identify the link from the
 		// graph data store
@@ -408,7 +411,7 @@ func (o *DatacenterGenericSystem) updateLinkParams(ctx context.Context, links []
 			return
 		}
 
-		link.updateParams(ctx, linkId, bp, diags) // collect all errors
+		link.updateParams(ctx, linkId, stateLinks[i], bp, diags) // collect all errors
 	}
 }
 

--- a/apstra/blueprint/datacenter_generic_system_link.go
+++ b/apstra/blueprint/datacenter_generic_system_link.go
@@ -152,40 +152,45 @@ func (o *DatacenterGenericSystemLink) getTransformId(ctx context.Context, client
 // - tags
 // Because the DatacenterGenericSystemLink object doesn't know the link ID,
 // the ID of the link's graph node is passed as a function argument.
-func (o *DatacenterGenericSystemLink) updateParams(ctx context.Context, id apstra.ObjectId, client *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) {
-	// set the transform ID
-	err := client.SetTransformIdByIfName(ctx, apstra.ObjectId(o.TargetSwitchId.ValueString()),
-		o.TargetSwitchIfName.ValueString(), int(o.TargetSwitchIfTransformId.ValueInt64()))
-	if err != nil {
-		var ace apstra.ClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrCannotChangeTransform {
-			diags.AddWarning("could not change interface transform", err.Error())
-		} else {
-			diags.AddError("failed to set interface transform", err.Error())
-			return
+func (o *DatacenterGenericSystemLink) updateParams(ctx context.Context, id apstra.ObjectId, state *DatacenterGenericSystemLink, client *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) {
+	// set the transform ID if it has changed
+	if !o.TargetSwitchIfTransformId.Equal(state.TargetSwitchIfTransformId) {
+		err := client.SetTransformIdByIfName(ctx, apstra.ObjectId(o.TargetSwitchId.ValueString()),
+			o.TargetSwitchIfName.ValueString(), int(o.TargetSwitchIfTransformId.ValueInt64()))
+		if err != nil {
+			var ace apstra.ClientErr
+			if errors.As(err, &ace) && ace.Type() == apstra.ErrCannotChangeTransform {
+				diags.AddWarning("could not change interface transform", err.Error())
+			} else {
+				diags.AddError("failed to set interface transform", err.Error())
+				return
+			}
 		}
 	}
 
-	var tags []string
-	diags.Append(o.Tags.ElementsAs(ctx, &tags, false)...)
-	if tags == nil {
-		tags = []string{} // convert nil -> empty slice to clear tags
-	}
+	// set the tags and lag mode if either have changed
+	if !o.Tags.Equal(state.Tags) || !o.LagMode.Equal(state.LagMode) {
+		var tags []string
+		diags.Append(o.Tags.ElementsAs(ctx, &tags, false)...)
+		if tags == nil {
+			tags = []string{} // convert nil -> empty slice to clear tags
+		}
 
-	var lagMode apstra.RackLinkLagMode
-	err = lagMode.FromString(o.LagMode.ValueString())
-	if err != nil {
-		diags.AddError(fmt.Sprintf("failed to parse lag mode %s", o.LagMode), err.Error())
-		return
-	}
+		var lagMode apstra.RackLinkLagMode
+		err := lagMode.FromString(o.LagMode.ValueString())
+		if err != nil {
+			diags.AddError(fmt.Sprintf("failed to parse lag mode %s", o.LagMode), err.Error())
+			return
+		}
 
-	// set lag params + tag set
-	err = client.SetLinkLagParams(ctx, &apstra.SetLinkLagParamsRequest{id: apstra.LinkLagParams{
-		GroupLabel: o.GroupLabel.ValueString(),
-		LagMode:    lagMode,
-		Tags:       tags,
-	}})
-	if err != nil {
-		diags.AddError(fmt.Sprintf("failed to set link %s LAG parameters", id), err.Error())
+		// set lag params + tag set
+		err = client.SetLinkLagParams(ctx, &apstra.SetLinkLagParamsRequest{id: apstra.LinkLagParams{
+			GroupLabel: o.GroupLabel.ValueString(),
+			LagMode:    lagMode,
+			Tags:       tags,
+		}})
+		if err != nil {
+			diags.AddError(fmt.Sprintf("failed to set link %s LAG parameters", id), err.Error())
+		}
 	}
 }


### PR DESCRIPTION
This PR enhances `DatacenterGenericSystemLink.updateParams()` so that it accepts a `*DatacenterGenericSystemLink` representing the link's prior state.

The prior state is used to ensure that only changed attributes are updated, rather than updating each attribute unconditionally.

This is particularly important in the case of breakout ports: An API call to set the transform ID *to the existing value* produces an error about interrupting service to other members of the breakout.

Not making the call in the first place (because we know the prior state) works around that problem.