### PR TITLE
Update ignore path in pre-release 3rd party license compliance check

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,8 +8,8 @@ before:
   hooks:
     - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
     - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
-    - go run github.com/chrismarget-j/go-licenses save --ignore terraform-provider-apstra --ignore github.com/Juniper/apstra-go-sdk --save_path=./Third_Party_Code --force ./...
-    - sh -c "go run github.com/chrismarget-j/go-licenses report ./... --ignore terraform-provider-apstra --ignore github.com/Juniper/apstra-go-sdk/apstra --template .notices.tpl > Third_Party_Code/NOTICES.md"
+    - go run github.com/chrismarget-j/go-licenses save --ignore github.com/Juniper/terraform-provider-apstra --ignore github.com/Juniper/apstra-go-sdk --save_path=./Third_Party_Code --force ./...
+    - sh -c "go run github.com/chrismarget-j/go-licenses report ./... --ignore github.com/Juniper/terraform-provider-apstra --ignore github.com/Juniper/apstra-go-sdk/apstra --template .notices.tpl > Third_Party_Code/NOTICES.md"
     - go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
     - git update-index --refresh && git diff-index --quiet HEAD --
 builds:

--- a/apstra/blueprint/datacenter_generic_system.go
+++ b/apstra/blueprint/datacenter_generic_system.go
@@ -42,7 +42,7 @@ func (o DatacenterGenericSystem) ResourceAttributes() map[string]resourceSchema.
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"name": resourceSchema.StringAttribute{
-			MarkdownDescription: "Name displayed in thw Apstra web UI.",
+			MarkdownDescription: "Name displayed in the Apstra web UI.",
 			Optional:            true,
 			Computed:            true,
 			PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},

--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -60,7 +60,7 @@ func (o DatacenterRoutingZone) DataSourceAttributes() map[string]dataSourceSchem
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "VRF name displayed in thw Apstra web UI.",
+			MarkdownDescription: "VRF name displayed in the Apstra web UI.",
 			Computed:            true,
 			Optional:            true,
 			Validators: []validator.String{
@@ -115,7 +115,7 @@ func (o DatacenterRoutingZone) DataSourceFilterAttributes() map[string]dataSourc
 			Computed:            true,
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "VRF name displayed in thw Apstra web UI.",
+			MarkdownDescription: "VRF name displayed in the Apstra web UI.",
 			Optional:            true,
 		},
 		"vlan_id": dataSourceSchema.Int64Attribute{
@@ -170,7 +170,7 @@ func (o DatacenterRoutingZone) ResourceAttributes() map[string]resourceSchema.At
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"name": resourceSchema.StringAttribute{
-			MarkdownDescription: "VRF name displayed in thw Apstra web UI.",
+			MarkdownDescription: "VRF name displayed in the Apstra web UI.",
 			Required:            true,
 			Validators: []validator.String{
 				stringvalidator.RegexMatches(nameRE, "only underscore, dash and alphanumeric characters allowed."),

--- a/docs/data-sources/datacenter_routing_zone.md
+++ b/docs/data-sources/datacenter_routing_zone.md
@@ -58,7 +58,7 @@ output "routing_zone" {
 ### Optional
 
 - `id` (String) Apstra graph node ID. Required when `name` is omitted.
-- `name` (String) VRF name displayed in thw Apstra web UI.
+- `name` (String) VRF name displayed in the Apstra web UI.
 
 ### Read-Only
 

--- a/docs/data-sources/datacenter_routing_zones.md
+++ b/docs/data-sources/datacenter_routing_zones.md
@@ -54,7 +54,7 @@ data "apstra_datacenter_routing_zones" "rzs" {
 Optional:
 
 - `dhcp_servers` (Set of String) Set of addresses of DHCP servers (IPv4 or IPv6) which must be configured in the Routing Zone. This is a list of *required* servers, not an exact-match list.
-- `name` (String) VRF name displayed in thw Apstra web UI.
+- `name` (String) VRF name displayed in the Apstra web UI.
 - `routing_policy_id` (String) Non-EVPN blueprints must use the default policy, so this field must be null. Set this attribute in an EVPN blueprint to use a non-default policy.
 - `vlan_id` (Number) Used for VLAN tagged Layer 3 links on external connections.
 - `vni` (Number) VxLAN VNI associated with the routing zone.

--- a/docs/resources/datacenter_generic_system.md
+++ b/docs/resources/datacenter_generic_system.md
@@ -83,7 +83,7 @@ resource "apstra_datacenter_generic_system" "example" {
 ### Optional
 
 - `hostname` (String) System hostname.
-- `name` (String) Name displayed in thw Apstra web UI.
+- `name` (String) Name displayed in the Apstra web UI.
 - `tags` (Set of String) Tag labels to be applied to this Generic System. If a Tag doesn't exist in the Blueprint it will be created automatically.
 
 ### Read-Only

--- a/docs/resources/datacenter_routing_zone.md
+++ b/docs/resources/datacenter_routing_zone.md
@@ -30,7 +30,7 @@ resource "apstra_datacenter_routing_zone" "blue" {
 ### Required
 
 - `blueprint_id` (String) Apstra Blueprint ID.
-- `name` (String) VRF name displayed in thw Apstra web UI.
+- `name` (String) VRF name displayed in the Apstra web UI.
 
 ### Optional
 


### PR DESCRIPTION
This PR updates the `--ignore` path in `.goreleaser.yml`'s license compliance pre-release check.

It's required since the module path changed in #330

Closes #344#