### PR TITLE
Add support for eternal generic systems

### DIFF
--- a/apstra/resource_datacenter_generic_system.go
+++ b/apstra/resource_datacenter_generic_system.go
@@ -69,7 +69,7 @@ func (o *resourceDatacenterGenericSystem) Create(ctx context.Context, req resour
 	}
 
 	// unfortunately we only learn the link IDs, not the generic system ID
-	linkIds, err := bp.CreateLinksWithNewServer(ctx, request)
+	linkIds, err := bp.CreateLinksWithNewSystem(ctx, request)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create generic system", err.Error())
 		return

--- a/docs/resources/datacenter_generic_system.md
+++ b/docs/resources/datacenter_generic_system.md
@@ -83,6 +83,7 @@ resource "apstra_datacenter_generic_system" "example" {
 ### Optional
 
 - `asn` (Number) AS number of the Generic System
+- `external` (Boolean) Set `true` to create an External Generic System
 - `hostname` (String) System hostname.
 - `loopback_ipv4` (String) IPv4 address of loopback interface in CIDR notation
 - `loopback_ipv6` (String) IPv6 address of loopback interface in CIDR notation

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20230908175900-7b4f7e00abfa
+	github.com/Juniper/apstra-go-sdk v0.0.0-20230908183717-4883c9affb93
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20230907203620-edfc8d77ec13
+	github.com/Juniper/apstra-go-sdk v0.0.0-20230908175900-7b4f7e00abfa
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230908175900-7b4f7e00abfa h1:8NwwYKH83Texy1J5oIX/f3HtbpAC8myi28YH4unkPA4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230908175900-7b4f7e00abfa/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230908183717-4883c9affb93 h1:cJvdMo0P4rHPg/TtzpHzEp5N+k6ABecbiNJSC3+59UI=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230908183717-4883c9affb93/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230907203620-edfc8d77ec13 h1:kXws8AtWnKchC7sZvvvRZbsV1xkluvdBce+0lUFNNSc=
-github.com/Juniper/apstra-go-sdk v0.0.0-20230907203620-edfc8d77ec13/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230908175900-7b4f7e00abfa h1:8NwwYKH83Texy1J5oIX/f3HtbpAC8myi28YH4unkPA4=
+github.com/Juniper/apstra-go-sdk v0.0.0-20230908175900-7b4f7e00abfa/go.mod h1:/bOt1ftHy9phf3PPgxMH5d/41S3N9xpxzeOj8JMLh2E=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=


### PR DESCRIPTION
This PR adds the `external` attribute to the existing `apstra_datacenter_generic_system` resource to support "external generic" systems.

`external` (a boolean) drives the new `Type` element in the `CreateLinksWithNewSystemRequestSystem` structure.