### PR TITLE
Introduce `attributeConflictValidator`

### DIFF
--- a/apstra/apstra_validator/attribute_conflict.go
+++ b/apstra/apstra_validator/attribute_conflict.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"strings"
 )
 
 type CollectionValidator interface {
-	//validator.List
-	//validator.Map
+	validator.List
+	validator.Map
 	validator.Set
 }
 
@@ -47,193 +50,150 @@ func (o attributeConflictValidator) MarkdownDescription(ctx context.Context) str
 	return o.Description(ctx)
 }
 
-//func (o attributeConflictValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
-//	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
-//		return
-//	}
-//
-//	uniqueStrings := make(map[string]bool)
-//
-//	for i, element := range req.ConfigValue.Elements() {
-//		objectPath := req.Path.AtListIndex(i)
-//
-//		objectValuable, ok := element.(basetypes.ObjectValuable)
-//		if !ok {
-//			resp.Diagnostics.AddAttributeError(
-//				req.Path,
-//				"Invalid Validator for Element Value",
-//				"While performing schema-based validation, an unexpected error occurred. "+
-//					"The attribute declares a Object values validator, however its values do not implement the types.ObjectValuable interface for custom Object types. "+
-//					"This is likely an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
-//					fmt.Sprintf("Path: %s\n", req.Path.String())+
-//					fmt.Sprintf("Element Type: %T\n", req.ConfigValue.ElementType(ctx))+
-//					fmt.Sprintf("Element Value Type: %T\n", element),
-//			)
-//
-//			return
-//		}
-//
-//		objectValue, diags := objectValuable.ToObjectValue(ctx)
-//		resp.Diagnostics.Append(diags...)
-//		if diags.HasError() {
-//			return
-//		}
-//
-//		for attrName, attrValue := range objectValue.Attributes() {
-//			if attrName != o.keyAttrs || attrValue.IsUnknown() {
-//				continue
-//			}
-//
-//			if uniqueStrings[attrValue.String()] {
-//				resp.Diagnostics.AddAttributeError(
-//					objectPath,
-//					fmt.Sprintf("%s collision", o.keyAttrs),
-//					fmt.Sprintf("Two objects cannot use the same %s", o.keyAttrs),
-//				)
-//			} else {
-//				uniqueStrings[attrValue.String()] = true
-//			}
-//			break // the correct attribute has been found; move on to the next
-//		}
-//	}
-//}
-//
-//func (o attributeConflictValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
-//	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
-//		return
-//	}
-//
-//	uniqueStrings := make(map[string]bool)
-//
-//	for mapKey, element := range req.ConfigValue.Elements() {
-//		objectPath := req.Path.AtMapKey(mapKey)
-//
-//		objectValuable, ok := element.(basetypes.ObjectValuable)
-//		if !ok {
-//			resp.Diagnostics.AddAttributeError(
-//				req.Path,
-//				"Invalid Validator for Element Value",
-//				"While performing schema-based validation, an unexpected error occurred. "+
-//					"The attribute declares a Object values validator, however its values do not implement the types.ObjectValuable interface for custom Object types. "+
-//					"This is likely an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
-//					fmt.Sprintf("Path: %s\n", req.Path.String())+
-//					fmt.Sprintf("Element Type: %T\n", req.ConfigValue.ElementType(ctx))+
-//					fmt.Sprintf("Element Value Type: %T\n", element),
-//			)
-//
-//			return
-//		}
-//
-//		objectValue, diags := objectValuable.ToObjectValue(ctx)
-//		resp.Diagnostics.Append(diags...)
-//		if diags.HasError() {
-//			return
-//		}
-//
-//		for attrName, attrValue := range objectValue.Attributes() {
-//			if attrName != o.keyAttrs || attrValue.IsUnknown() {
-//				continue
-//			}
-//
-//			if uniqueStrings[attrValue.String()] {
-//				resp.Diagnostics.AddAttributeError(
-//					objectPath,
-//					fmt.Sprintf("%s collision", o.keyAttrs),
-//					fmt.Sprintf("Two objects cannot use the same %s", o.keyAttrs),
-//				)
-//			} else {
-//				uniqueStrings[attrValue.String()] = true
-//			}
-//			break // the correct attribute has been found; move on to the next
-//		}
-//	}
-//}
+func (o attributeConflictValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	foundKeyValueCombinations := make(map[string]bool)
+	for i, element := range req.ConfigValue.Elements() { // loop over set members
+		validateRequest := attributeConflictValidateElementRequest{
+			elementValue:              element,
+			elementPath:               req.Path.AtListIndex(i),
+			foundKeyValueCombinations: foundKeyValueCombinations,
+			path:                      req.Path,
+		}
+		validateResponse := attributeConflictValidateElementResponse{}
+		o.validateElement(ctx, validateRequest, &validateResponse)
+		resp.Diagnostics.Append(validateResponse.Diagnostics...)
+	}
+}
+
+func (o attributeConflictValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	foundKeyValueCombinations := make(map[string]bool)
+	for mapKey, element := range req.ConfigValue.Elements() { // loop over set members
+		validateRequest := attributeConflictValidateElementRequest{
+			elementValue:              element,
+			elementPath:               req.Path.AtMapKey(mapKey),
+			foundKeyValueCombinations: foundKeyValueCombinations,
+			path:                      req.Path,
+		}
+		validateResponse := attributeConflictValidateElementResponse{}
+		o.validateElement(ctx, validateRequest, &validateResponse)
+		resp.Diagnostics.Append(validateResponse.Diagnostics...)
+	}
+}
 
 func (o attributeConflictValidator) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
 
-	// map of key attribute names
+	foundKeyValueCombinations := make(map[string]bool)
+	for _, element := range req.ConfigValue.Elements() { // loop over set members
+		validateRequest := attributeConflictValidateElementRequest{
+			elementValue:              element,
+			elementPath:               req.Path.AtSetValue(element),
+			foundKeyValueCombinations: foundKeyValueCombinations,
+			path:                      req.Path,
+		}
+		validateResponse := attributeConflictValidateElementResponse{}
+		o.validateElement(ctx, validateRequest, &validateResponse)
+		resp.Diagnostics.Append(validateResponse.Diagnostics...)
+	}
+}
+
+func UniqueValueCombinationsAt(attrNames ...string) CollectionValidator {
+	return attributeConflictValidator{
+		keyAttrs: attrNames,
+	}
+}
+
+type attributeConflictValidateElementRequest struct {
+	elementValue              attr.Value
+	elementPath               path.Path
+	foundKeyValueCombinations map[string]bool
+	path                      path.Path
+}
+
+type attributeConflictValidateElementResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+func (o *attributeConflictValidator) validateElement(ctx context.Context, req attributeConflictValidateElementRequest, resp *attributeConflictValidateElementResponse) {
+	objectValuable, ok := req.elementValue.(basetypes.ObjectValuable)
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.path,
+			"Invalid Validator for Element Value",
+			"While performing schema-based validation, an unexpected error occurred. "+
+				"The attribute declares a Object values validator, however its values do not implement the types.ObjectValuable interface for custom Object types. "+
+				"This is likely an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
+				fmt.Sprintf("Path: %s\n", req.path.String())+
+				fmt.Sprintf("Element Type: %T\n", req.elementValue.Type(ctx))+
+				fmt.Sprintf("Element Value Type: %T\n", req.elementValue),
+		)
+
+		return
+	}
+
+	objectValue, d := objectValuable.ToObjectValue(ctx)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// if the caller didn't specify any "key" attributes we use all of them
+	if len(o.keyAttrs) == 0 {
+		for k := range objectValue.Attributes() {
+			o.keyAttrs = append(o.keyAttrs, k)
+		}
+	}
+
+	// map of key attribute names used to quickly recognize whether an attribute is interesting
 	keyAttributeNames := make(map[string]bool, len(o.keyAttrs))
 	for _, key := range o.keyAttrs {
 		keyAttributeNames[key] = true
 	}
 
-	// map of found value combinations delimited by ':'
-	//    base64(key1):base64(key2):...:base64(keyN)
-	foundKeyValueCombinations := make(map[string]bool) // found value combinations
-
-	for _, element := range req.ConfigValue.Elements() { // loop over set members
-		objectPath := req.Path.AtSetValue(element)
-
-		objectValuable, ok := element.(basetypes.ObjectValuable)
-		if !ok {
-			resp.Diagnostics.AddAttributeError(
-				req.Path,
-				"Invalid Validator for Element Value",
-				"While performing schema-based validation, an unexpected error occurred. "+
-					"The attribute declares a Object values validator, however its values do not implement the types.ObjectValuable interface for custom Object types. "+
-					"This is likely an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
-					fmt.Sprintf("Path: %s\n", req.Path.String())+
-					fmt.Sprintf("Element Type: %T\n", req.ConfigValue.ElementType(ctx))+
-					fmt.Sprintf("Element Value Type: %T\n", element),
-			)
-
-			return
+	keyValuesMap := make(map[string]string, len(keyAttributeNames))
+	for attrName, attrValue := range objectValue.Attributes() { // loop over set member attributes
+		if !keyAttributeNames[attrName] {
+			continue // attribute is not interesting
 		}
 
-		objectValue, diags := objectValuable.ToObjectValue(ctx)
-		resp.Diagnostics.Append(diags...)
-		if diags.HasError() {
-			return
+		if attrValue.IsUnknown() {
+			return // cannot validate when attribute is unknown
 		}
 
-		if len(o.keyAttrs) == 0 {
-			// the caller didn't specify any "key" attributes, so we'll use all of them
-			for k := range objectValue.Attributes() {
-				o.keyAttrs = append(o.keyAttrs, k)
-				keyAttributeNames[k] = true
-			}
+		keyValuesMap[attrName] = base64.StdEncoding.EncodeToString([]byte(attrValue.String()))
+		if len(keyValuesMap) < len(keyAttributeNames) {
+			continue // keep going until we fill keyValuesMap
 		}
 
-		keyValuesMap := make(map[string]string, len(keyAttributeNames))
-		for attrName, attrValue := range objectValue.Attributes() { // loop over set member attributes
-			if !keyAttributeNames[attrName] {
-				continue // attribute is not interesting
-			}
-
-			if attrValue.IsUnknown() {
-				return // cannot validate when attribute is unknown
-			}
-
-			keyValuesMap[attrName] = base64.StdEncoding.EncodeToString([]byte(attrValue.String()))
-			if len(keyValuesMap) < len(keyAttributeNames) {
-				continue // keep going until we fill keyValuesMap
-			}
-
-			sb := strings.Builder{}
-			sb.WriteString(keyValuesMap[o.keyAttrs[0]]) // keyAttrs always has at least 1 entry
-			for i := range o.keyAttrs[1:] {
+		sb := strings.Builder{}
+		for i := range o.keyAttrs {
+			if i == 0 {
+				sb.WriteString(keyValuesMap[o.keyAttrs[i]])
+			} else {
 				sb.WriteString(":" + keyValuesMap[o.keyAttrs[i]])
 			}
-
-			if foundKeyValueCombinations[sb.String()] { // seen this value before?
-				resp.Diagnostics.AddAttributeError(
-					objectPath,
-					fmt.Sprintf("%s collision", o.keyAttrs),
-					fmt.Sprintf("Two objects cannot use the same %s", o.keyAttrs),
-				)
-			} else {
-				foundKeyValueCombinations[sb.String()] = true // log the name for future collision checks
-			}
-			break // all of the the required attribute have been found; move on to the next set member
 		}
-	}
-}
 
-func UniquteValueCombinationsAt(attrNames ...string) CollectionValidator {
-	return attributeConflictValidator{
-		keyAttrs: attrNames,
+		if req.foundKeyValueCombinations[sb.String()] { // seen this value before?
+			resp.Diagnostics.AddAttributeError(
+				req.elementPath,
+				fmt.Sprintf("%s collision", o.keyAttrs),
+				fmt.Sprintf("Two objects cannot use the same %s", o.keyAttrs),
+			)
+		} else {
+			req.foundKeyValueCombinations[sb.String()] = true // log the name for future collision checks
+		}
+		break // all of the the required attribute have been found; move on to the next set member
 	}
+
 }

--- a/apstra/apstra_validator/attribute_conflict.go
+++ b/apstra/apstra_validator/attribute_conflict.go
@@ -1,0 +1,239 @@
+package apstravalidator
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"strings"
+)
+
+type CollectionValidator interface {
+	//validator.List
+	//validator.Map
+	validator.Set
+}
+
+var _ CollectionValidator = attributeConflictValidator{}
+
+// attributeConflictValidator ensures that no two elements of a list, map, or
+// set of objects use the same value across all attributes enumerated in
+// keyAttrs.
+//
+// For example, if keyAttrs contains just {"name"}, then having two objects
+// with `name: "foo"` will produce a validation error.
+//
+// If keyAttrs contains {"protocol", "port"} then having two objects with
+// `protocol: "TCP"` and `port: 80` will produce a validation error.
+//
+// If keyAttrs is empty, then values across all attributes are evaluated.
+type attributeConflictValidator struct {
+	keyAttrs []string
+}
+
+func (o attributeConflictValidator) Description(_ context.Context) string {
+	if len(o.keyAttrs) == 0 {
+		return "Ensure that no two collection (list/map/set) members share values for all attributes"
+	}
+
+	return fmt.Sprintf(
+		"Ensure that no two collection (list/map/set) members share values for these attributes: [%s]",
+		strings.Join(o.keyAttrs, " "),
+	)
+}
+
+func (o attributeConflictValidator) MarkdownDescription(ctx context.Context) string {
+	return o.Description(ctx)
+}
+
+//func (o attributeConflictValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+//	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+//		return
+//	}
+//
+//	uniqueStrings := make(map[string]bool)
+//
+//	for i, element := range req.ConfigValue.Elements() {
+//		objectPath := req.Path.AtListIndex(i)
+//
+//		objectValuable, ok := element.(basetypes.ObjectValuable)
+//		if !ok {
+//			resp.Diagnostics.AddAttributeError(
+//				req.Path,
+//				"Invalid Validator for Element Value",
+//				"While performing schema-based validation, an unexpected error occurred. "+
+//					"The attribute declares a Object values validator, however its values do not implement the types.ObjectValuable interface for custom Object types. "+
+//					"This is likely an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
+//					fmt.Sprintf("Path: %s\n", req.Path.String())+
+//					fmt.Sprintf("Element Type: %T\n", req.ConfigValue.ElementType(ctx))+
+//					fmt.Sprintf("Element Value Type: %T\n", element),
+//			)
+//
+//			return
+//		}
+//
+//		objectValue, diags := objectValuable.ToObjectValue(ctx)
+//		resp.Diagnostics.Append(diags...)
+//		if diags.HasError() {
+//			return
+//		}
+//
+//		for attrName, attrValue := range objectValue.Attributes() {
+//			if attrName != o.keyAttrs || attrValue.IsUnknown() {
+//				continue
+//			}
+//
+//			if uniqueStrings[attrValue.String()] {
+//				resp.Diagnostics.AddAttributeError(
+//					objectPath,
+//					fmt.Sprintf("%s collision", o.keyAttrs),
+//					fmt.Sprintf("Two objects cannot use the same %s", o.keyAttrs),
+//				)
+//			} else {
+//				uniqueStrings[attrValue.String()] = true
+//			}
+//			break // the correct attribute has been found; move on to the next
+//		}
+//	}
+//}
+//
+//func (o attributeConflictValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+//	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+//		return
+//	}
+//
+//	uniqueStrings := make(map[string]bool)
+//
+//	for mapKey, element := range req.ConfigValue.Elements() {
+//		objectPath := req.Path.AtMapKey(mapKey)
+//
+//		objectValuable, ok := element.(basetypes.ObjectValuable)
+//		if !ok {
+//			resp.Diagnostics.AddAttributeError(
+//				req.Path,
+//				"Invalid Validator for Element Value",
+//				"While performing schema-based validation, an unexpected error occurred. "+
+//					"The attribute declares a Object values validator, however its values do not implement the types.ObjectValuable interface for custom Object types. "+
+//					"This is likely an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
+//					fmt.Sprintf("Path: %s\n", req.Path.String())+
+//					fmt.Sprintf("Element Type: %T\n", req.ConfigValue.ElementType(ctx))+
+//					fmt.Sprintf("Element Value Type: %T\n", element),
+//			)
+//
+//			return
+//		}
+//
+//		objectValue, diags := objectValuable.ToObjectValue(ctx)
+//		resp.Diagnostics.Append(diags...)
+//		if diags.HasError() {
+//			return
+//		}
+//
+//		for attrName, attrValue := range objectValue.Attributes() {
+//			if attrName != o.keyAttrs || attrValue.IsUnknown() {
+//				continue
+//			}
+//
+//			if uniqueStrings[attrValue.String()] {
+//				resp.Diagnostics.AddAttributeError(
+//					objectPath,
+//					fmt.Sprintf("%s collision", o.keyAttrs),
+//					fmt.Sprintf("Two objects cannot use the same %s", o.keyAttrs),
+//				)
+//			} else {
+//				uniqueStrings[attrValue.String()] = true
+//			}
+//			break // the correct attribute has been found; move on to the next
+//		}
+//	}
+//}
+
+func (o attributeConflictValidator) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// map of key attribute names
+	keyAttributeNames := make(map[string]bool, len(o.keyAttrs))
+	for _, key := range o.keyAttrs {
+		keyAttributeNames[key] = true
+	}
+
+	// map of found value combinations delimited by ':'
+	//    base64(key1):base64(key2):...:base64(keyN)
+	foundKeyValueCombinations := make(map[string]bool) // found value combinations
+
+	for _, element := range req.ConfigValue.Elements() { // loop over set members
+		objectPath := req.Path.AtSetValue(element)
+
+		objectValuable, ok := element.(basetypes.ObjectValuable)
+		if !ok {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid Validator for Element Value",
+				"While performing schema-based validation, an unexpected error occurred. "+
+					"The attribute declares a Object values validator, however its values do not implement the types.ObjectValuable interface for custom Object types. "+
+					"This is likely an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Path: %s\n", req.Path.String())+
+					fmt.Sprintf("Element Type: %T\n", req.ConfigValue.ElementType(ctx))+
+					fmt.Sprintf("Element Value Type: %T\n", element),
+			)
+
+			return
+		}
+
+		objectValue, diags := objectValuable.ToObjectValue(ctx)
+		resp.Diagnostics.Append(diags...)
+		if diags.HasError() {
+			return
+		}
+
+		if len(o.keyAttrs) == 0 {
+			// the caller didn't specify any "key" attributes, so we'll use all of them
+			for k := range objectValue.Attributes() {
+				o.keyAttrs = append(o.keyAttrs, k)
+				keyAttributeNames[k] = true
+			}
+		}
+
+		keyValuesMap := make(map[string]string, len(keyAttributeNames))
+		for attrName, attrValue := range objectValue.Attributes() { // loop over set member attributes
+			if !keyAttributeNames[attrName] {
+				continue // attribute is not interesting
+			}
+
+			if attrValue.IsUnknown() {
+				return // cannot validate when attribute is unknown
+			}
+
+			keyValuesMap[attrName] = base64.StdEncoding.EncodeToString([]byte(attrValue.String()))
+			if len(keyValuesMap) < len(keyAttributeNames) {
+				continue // keep going until we fill keyValuesMap
+			}
+
+			sb := strings.Builder{}
+			sb.WriteString(keyValuesMap[o.keyAttrs[0]]) // keyAttrs always has at least 1 entry
+			for i := range o.keyAttrs[1:] {
+				sb.WriteString(":" + keyValuesMap[o.keyAttrs[i]])
+			}
+
+			if foundKeyValueCombinations[sb.String()] { // seen this value before?
+				resp.Diagnostics.AddAttributeError(
+					objectPath,
+					fmt.Sprintf("%s collision", o.keyAttrs),
+					fmt.Sprintf("Two objects cannot use the same %s", o.keyAttrs),
+				)
+			} else {
+				foundKeyValueCombinations[sb.String()] = true // log the name for future collision checks
+			}
+			break // all of the the required attribute have been found; move on to the next set member
+		}
+	}
+}
+
+func UniquteValueCombinationsAt(attrNames ...string) CollectionValidator {
+	return attributeConflictValidator{
+		keyAttrs: attrNames,
+	}
+}

--- a/apstra/apstra_validator/attribute_conflict.go
+++ b/apstra/apstra_validator/attribute_conflict.go
@@ -195,5 +195,4 @@ func (o *attributeConflictValidator) validateElement(ctx context.Context, req at
 		}
 		break // all of the the required attribute have been found; move on to the next set member
 	}
-
 }

--- a/apstra/apstra_validator/attribute_conflict_test.go
+++ b/apstra/apstra_validator/attribute_conflict_test.go
@@ -444,6 +444,23 @@ func TestAttributeConflictValidator(t *testing.T) {
 			expectError:     true,
 			caseInsensitive: true,
 		},
+		"missing_key": {
+			keyAttrNames: []string{"key1", "key2"},
+			attrTypes: map[string]attr.Type{
+				"key1": types.StringType,
+			},
+			attrValues: map[string]attr.Value{
+				"one": types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("foo"),
+					},
+				),
+			},
+			expectError: true,
+		},
 	}
 
 	// test list validation

--- a/apstra/apstra_validator/attribute_conflict_test.go
+++ b/apstra/apstra_validator/attribute_conflict_test.go
@@ -1,0 +1,416 @@
+package apstravalidator
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"log"
+	"testing"
+)
+
+func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
+	ctx := context.Background()
+
+	type testCase struct {
+		keyAttrNames []string
+		attrTypes    map[string]attr.Type
+		attrValues   []attr.Value
+		expectError  bool
+	}
+
+	testCases := map[string]testCase{
+		"one_key_no_collision": {
+			keyAttrNames: []string{"key1"},
+			attrTypes: map[string]attr.Type{
+				"key1": types.StringType,
+			},
+			attrValues: []attr.Value{
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("foo"),
+					},
+				),
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("bar"),
+					},
+				),
+			},
+			expectError: false,
+		},
+		"one_key_collision": {
+			keyAttrNames: []string{"key1"},
+			attrTypes: map[string]attr.Type{
+				"key1": types.StringType,
+			},
+			attrValues: []attr.Value{
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("foo"),
+					},
+				),
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("foo"),
+					},
+				),
+			},
+			expectError: true,
+		},
+		"one_key_plus_extras_no_collision": {
+			keyAttrNames: []string{"key1"},
+			attrTypes: map[string]attr.Type{
+				"key1":   types.StringType,
+				"extra1": types.StringType,
+				"extra2": types.StringType,
+			},
+			attrValues: []attr.Value{
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1":   types.StringType,
+						"extra1": types.StringType,
+						"extra2": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1":   types.StringValue("foo"),
+						"extra1": types.StringValue("foo"),
+						"extra2": types.StringValue("foo"),
+					},
+				),
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1":   types.StringType,
+						"extra1": types.StringType,
+						"extra2": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1":   types.StringValue("bar"),
+						"extra1": types.StringValue("bar"),
+						"extra2": types.StringValue("bar"),
+					},
+				),
+			},
+			expectError: false,
+		},
+		"one_key_plus_extras_collision": {
+			keyAttrNames: []string{"key1"},
+			attrTypes: map[string]attr.Type{
+				"key1":   types.StringType,
+				"extra1": types.StringType,
+				"extra2": types.StringType,
+			},
+			attrValues: []attr.Value{
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1":   types.StringType,
+						"extra1": types.StringType,
+						"extra2": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1":   types.StringValue("foo"),
+						"extra1": types.StringValue("bar"),
+						"extra2": types.StringValue("baz"),
+					},
+				),
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1":   types.StringType,
+						"extra1": types.StringType,
+						"extra2": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1":   types.StringValue("foo"),
+						"extra1": types.StringValue("bar"),
+						"extra2": types.StringValue("baz"),
+					},
+				),
+			},
+			expectError: true,
+		},
+		"three_keys_no_collision": {
+			keyAttrNames: []string{"key1", "key2", "key3"},
+			attrTypes: map[string]attr.Type{
+				"key1": types.StringType,
+				"key2": types.StringType,
+				"key3": types.StringType,
+			},
+			attrValues: []attr.Value{
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+						"key2": types.StringType,
+						"key3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("foo"),
+						"key2": types.StringValue("bar"),
+						"key3": types.StringValue("baz"),
+					},
+				),
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+						"key2": types.StringType,
+						"key3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("bar"),
+						"key2": types.StringValue("baz"),
+						"key3": types.StringValue("foo"),
+					},
+				),
+			},
+			expectError: false,
+		},
+		"three_keys_with_extras_no_collision": {
+			keyAttrNames: []string{"key1", "key2", "key3"},
+			attrTypes: map[string]attr.Type{
+				"key1":   types.StringType,
+				"key2":   types.StringType,
+				"key3":   types.StringType,
+				"extra1": types.StringType,
+				"extra2": types.StringType,
+				"extra3": types.StringType,
+			},
+			attrValues: []attr.Value{
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1":   types.StringType,
+						"key2":   types.StringType,
+						"key3":   types.StringType,
+						"extra1": types.StringType,
+						"extra2": types.StringType,
+						"extra3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1":   types.StringValue("foo"),
+						"key2":   types.StringValue("bar"),
+						"key3":   types.StringValue("baz"),
+						"extra1": types.StringValue("foo"),
+						"extra2": types.StringValue("bar"),
+						"extra3": types.StringValue("baz"),
+					},
+				),
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1":   types.StringType,
+						"key2":   types.StringType,
+						"key3":   types.StringType,
+						"extra1": types.StringType,
+						"extra2": types.StringType,
+						"extra3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1":   types.StringValue("bar"),
+						"key2":   types.StringValue("baz"),
+						"key3":   types.StringValue("foo"),
+						"extra1": types.StringValue("foo"),
+						"extra2": types.StringValue("bar"),
+						"extra3": types.StringValue("baz"),
+					},
+				),
+			},
+			expectError: false,
+		},
+		"three_keys_collision": {
+			keyAttrNames: []string{"key1", "key2", "key3"},
+			attrTypes: map[string]attr.Type{
+				"key1": types.StringType,
+				"key2": types.StringType,
+				"key3": types.StringType,
+			},
+			attrValues: []attr.Value{
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+						"key2": types.StringType,
+						"key3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("foo"),
+						"key2": types.StringValue("bar"),
+						"key3": types.StringValue("baz"),
+					},
+				),
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+						"key2": types.StringType,
+						"key3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("foo"),
+						"key2": types.StringValue("bar"),
+						"key3": types.StringValue("baz"),
+					},
+				),
+			},
+			expectError: true,
+		},
+		"three_keys_with_extras_collision": {
+			keyAttrNames: []string{"key1", "key2", "key3"},
+			attrTypes: map[string]attr.Type{
+				"key1":   types.StringType,
+				"key2":   types.StringType,
+				"key3":   types.StringType,
+				"extra1": types.StringType,
+				"extra2": types.StringType,
+				"extra3": types.StringType,
+			},
+			attrValues: []attr.Value{
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1":   types.StringType,
+						"key2":   types.StringType,
+						"key3":   types.StringType,
+						"extra1": types.StringType,
+						"extra2": types.StringType,
+						"extra3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1":   types.StringValue("foo"),
+						"key2":   types.StringValue("bar"),
+						"key3":   types.StringValue("baz"),
+						"extra1": types.StringValue("foo"),
+						"extra2": types.StringValue("bar"),
+						"extra3": types.StringValue("baz"),
+					},
+				),
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1":   types.StringType,
+						"key2":   types.StringType,
+						"key3":   types.StringType,
+						"extra1": types.StringType,
+						"extra2": types.StringType,
+						"extra3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1":   types.StringValue("foo"),
+						"key2":   types.StringValue("bar"),
+						"key3":   types.StringValue("baz"),
+						"extra1": types.StringValue("foo"),
+						"extra2": types.StringValue("bar"),
+						"extra3": types.StringValue("baz"),
+					},
+				),
+			},
+			expectError: true,
+		},
+		"all_keys_no_collision": {
+			keyAttrNames: []string{},
+			attrTypes: map[string]attr.Type{
+				"key1": types.StringType,
+				"key2": types.StringType,
+				"key3": types.StringType,
+			},
+			attrValues: []attr.Value{
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+						"key2": types.StringType,
+						"key3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("foo"),
+						"key2": types.StringValue("bar"),
+						"key3": types.StringValue("baz"),
+					},
+				),
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+						"key2": types.StringType,
+						"key3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("bar"),
+						"key2": types.StringValue("baz"),
+						"key3": types.StringValue("foo"),
+					},
+				),
+			},
+			expectError: false,
+		},
+		"all_keys_collision": {
+			keyAttrNames: []string{},
+			attrTypes: map[string]attr.Type{
+				"key1": types.StringType,
+				"key2": types.StringType,
+				"key3": types.StringType,
+			},
+			attrValues: []attr.Value{
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+						"key2": types.StringType,
+						"key3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("foo"),
+						"key2": types.StringValue("bar"),
+						"key3": types.StringValue("baz"),
+					},
+				),
+				types.ObjectValueMust(
+					map[string]attr.Type{
+						"key1": types.StringType,
+						"key2": types.StringType,
+						"key3": types.StringType,
+					},
+					map[string]attr.Value{
+						"key1": types.StringValue("foo"),
+						"key2": types.StringValue("bar"),
+						"key3": types.StringValue("baz"),
+					},
+				),
+			},
+			expectError: true,
+		},
+	}
+
+	for tName, tCase := range testCases {
+		tName, tCase := tName, tCase
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			request := validator.SetRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    types.SetValueMust(types.ObjectType{AttrTypes: tCase.attrTypes}, tCase.attrValues),
+			}
+			response := validator.SetResponse{}
+			validator := UniquteValueCombinationsAt(tCase.keyAttrNames...)
+			validator.ValidateSet(ctx, request, &response)
+
+			if !response.Diagnostics.HasError() && tCase.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !tCase.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+
+			if response.Diagnostics.HasError() {
+				for _, error := range response.Diagnostics.Errors() {
+					log.Println(validator.Description(ctx))
+					log.Println(error.Summary())
+					log.Println(error.Detail())
+				}
+			}
+		})
+	}
+}

--- a/apstra/apstra_validator/attribute_conflict_test.go
+++ b/apstra/apstra_validator/attribute_conflict_test.go
@@ -10,14 +10,24 @@ import (
 	"testing"
 )
 
-func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
+func TestAttributeConflictValidator(t *testing.T) {
 	ctx := context.Background()
 
 	type testCase struct {
 		keyAttrNames []string
 		attrTypes    map[string]attr.Type
-		attrValues   []attr.Value
+		attrValues   map[string]attr.Value
 		expectError  bool
+	}
+
+	attrValueSlice := func(in map[string]attr.Value) []attr.Value {
+		result := make([]attr.Value, len(in))
+		var i int
+		for _, attrValue := range in {
+			result[i] = attrValue
+			i++
+		}
+		return result
 	}
 
 	testCases := map[string]testCase{
@@ -26,8 +36,8 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 			attrTypes: map[string]attr.Type{
 				"key1": types.StringType,
 			},
-			attrValues: []attr.Value{
-				types.ObjectValueMust(
+			attrValues: map[string]attr.Value{
+				"one": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 					},
@@ -35,7 +45,7 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 						"key1": types.StringValue("foo"),
 					},
 				),
-				types.ObjectValueMust(
+				"two": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 					},
@@ -51,8 +61,8 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 			attrTypes: map[string]attr.Type{
 				"key1": types.StringType,
 			},
-			attrValues: []attr.Value{
-				types.ObjectValueMust(
+			attrValues: map[string]attr.Value{
+				"one": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 					},
@@ -60,7 +70,7 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 						"key1": types.StringValue("foo"),
 					},
 				),
-				types.ObjectValueMust(
+				"two": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 					},
@@ -78,8 +88,8 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 				"extra1": types.StringType,
 				"extra2": types.StringType,
 			},
-			attrValues: []attr.Value{
-				types.ObjectValueMust(
+			attrValues: map[string]attr.Value{
+				"one": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1":   types.StringType,
 						"extra1": types.StringType,
@@ -91,7 +101,7 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 						"extra2": types.StringValue("foo"),
 					},
 				),
-				types.ObjectValueMust(
+				"two": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1":   types.StringType,
 						"extra1": types.StringType,
@@ -113,8 +123,8 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 				"extra1": types.StringType,
 				"extra2": types.StringType,
 			},
-			attrValues: []attr.Value{
-				types.ObjectValueMust(
+			attrValues: map[string]attr.Value{
+				"one": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1":   types.StringType,
 						"extra1": types.StringType,
@@ -126,7 +136,7 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 						"extra2": types.StringValue("baz"),
 					},
 				),
-				types.ObjectValueMust(
+				"two": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1":   types.StringType,
 						"extra1": types.StringType,
@@ -148,8 +158,8 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 				"key2": types.StringType,
 				"key3": types.StringType,
 			},
-			attrValues: []attr.Value{
-				types.ObjectValueMust(
+			attrValues: map[string]attr.Value{
+				"one": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 						"key2": types.StringType,
@@ -161,7 +171,7 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 						"key3": types.StringValue("baz"),
 					},
 				),
-				types.ObjectValueMust(
+				"two": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 						"key2": types.StringType,
@@ -186,8 +196,8 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 				"extra2": types.StringType,
 				"extra3": types.StringType,
 			},
-			attrValues: []attr.Value{
-				types.ObjectValueMust(
+			attrValues: map[string]attr.Value{
+				"one": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1":   types.StringType,
 						"key2":   types.StringType,
@@ -205,7 +215,7 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 						"extra3": types.StringValue("baz"),
 					},
 				),
-				types.ObjectValueMust(
+				"two": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1":   types.StringType,
 						"key2":   types.StringType,
@@ -233,8 +243,8 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 				"key2": types.StringType,
 				"key3": types.StringType,
 			},
-			attrValues: []attr.Value{
-				types.ObjectValueMust(
+			attrValues: map[string]attr.Value{
+				"one": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 						"key2": types.StringType,
@@ -246,7 +256,7 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 						"key3": types.StringValue("baz"),
 					},
 				),
-				types.ObjectValueMust(
+				"two": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 						"key2": types.StringType,
@@ -271,8 +281,8 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 				"extra2": types.StringType,
 				"extra3": types.StringType,
 			},
-			attrValues: []attr.Value{
-				types.ObjectValueMust(
+			attrValues: map[string]attr.Value{
+				"one": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1":   types.StringType,
 						"key2":   types.StringType,
@@ -290,7 +300,7 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 						"extra3": types.StringValue("baz"),
 					},
 				),
-				types.ObjectValueMust(
+				"two": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1":   types.StringType,
 						"key2":   types.StringType,
@@ -318,8 +328,8 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 				"key2": types.StringType,
 				"key3": types.StringType,
 			},
-			attrValues: []attr.Value{
-				types.ObjectValueMust(
+			attrValues: map[string]attr.Value{
+				"one": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 						"key2": types.StringType,
@@ -331,7 +341,7 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 						"key3": types.StringValue("baz"),
 					},
 				),
-				types.ObjectValueMust(
+				"two": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 						"key2": types.StringType,
@@ -353,8 +363,8 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 				"key2": types.StringType,
 				"key3": types.StringType,
 			},
-			attrValues: []attr.Value{
-				types.ObjectValueMust(
+			attrValues: map[string]attr.Value{
+				"one": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 						"key2": types.StringType,
@@ -366,7 +376,7 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 						"key3": types.StringValue("baz"),
 					},
 				),
-				types.ObjectValueMust(
+				"two": types.ObjectValueMust(
 					map[string]attr.Type{
 						"key1": types.StringType,
 						"key2": types.StringType,
@@ -383,18 +393,19 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 		},
 	}
 
+	// test list validation
 	for tName, tCase := range testCases {
 		tName, tCase := tName, tCase
 		t.Run(tName, func(t *testing.T) {
 			t.Parallel()
-			request := validator.SetRequest{
+			request := validator.ListRequest{
 				Path:           path.Root("test"),
 				PathExpression: path.MatchRoot("test"),
-				ConfigValue:    types.SetValueMust(types.ObjectType{AttrTypes: tCase.attrTypes}, tCase.attrValues),
+				ConfigValue:    types.ListValueMust(types.ObjectType{AttrTypes: tCase.attrTypes}, attrValueSlice(tCase.attrValues)),
 			}
-			response := validator.SetResponse{}
-			validator := UniquteValueCombinationsAt(tCase.keyAttrNames...)
-			validator.ValidateSet(ctx, request, &response)
+			response := validator.ListResponse{}
+			v := UniqueValueCombinationsAt(tCase.keyAttrNames...)
+			v.ValidateList(ctx, request, &response)
 
 			if !response.Diagnostics.HasError() && tCase.expectError {
 				t.Fatal("expected error, got no error")
@@ -405,10 +416,74 @@ func TestAttributeConflictValidator_ValidateSet(t *testing.T) {
 			}
 
 			if response.Diagnostics.HasError() {
-				for _, error := range response.Diagnostics.Errors() {
-					log.Println(validator.Description(ctx))
-					log.Println(error.Summary())
-					log.Println(error.Detail())
+				for _, diags := range response.Diagnostics.Errors() {
+					log.Println(v.Description(ctx))
+					log.Println(diags.Summary())
+					log.Println(diags.Detail())
+				}
+			}
+		})
+	}
+
+	// test map validation
+	for tName, tCase := range testCases {
+		tName, tCase := tName, tCase
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			request := validator.MapRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    types.MapValueMust(types.ObjectType{AttrTypes: tCase.attrTypes}, tCase.attrValues),
+			}
+			response := validator.MapResponse{}
+			v := UniqueValueCombinationsAt(tCase.keyAttrNames...)
+			v.ValidateMap(ctx, request, &response)
+
+			if !response.Diagnostics.HasError() && tCase.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !tCase.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+
+			if response.Diagnostics.HasError() {
+				for _, diags := range response.Diagnostics.Errors() {
+					log.Println(v.Description(ctx))
+					log.Println(diags.Summary())
+					log.Println(diags.Detail())
+				}
+			}
+		})
+	}
+
+	// test set validation
+	for tName, tCase := range testCases {
+		tName, tCase := tName, tCase
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			request := validator.SetRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    types.SetValueMust(types.ObjectType{AttrTypes: tCase.attrTypes}, attrValueSlice(tCase.attrValues)),
+			}
+			response := validator.SetResponse{}
+			v := UniqueValueCombinationsAt(tCase.keyAttrNames...)
+			v.ValidateSet(ctx, request, &response)
+
+			if !response.Diagnostics.HasError() && tCase.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !tCase.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+
+			if response.Diagnostics.HasError() {
+				for _, diags := range response.Diagnostics.Errors() {
+					log.Println(v.Description(ctx))
+					log.Println(diags.Summary())
+					log.Println(diags.Detail())
 				}
 			}
 		})


### PR DESCRIPTION
This PR introduces `attributeConflictValidator` to simplify validation of lists/maps/sets of objects which must have unique values in some attributes or combination of attributes.

It's intended to validate resources like this:

```hcl
resource "rack_info" "a" {
  switches = [      // this is a set
    {
      name  = "foo" // <- names must be unique
      model = "juniper_xyz"
    },
    {
      name  = "bar" // <- so far so good...
      model = "juniper_xyz"
    },
    {
      name  = "foo" // <- well this is a problem!
      model = "juniper_abc"
    },
  ]

  servers = [
    {
      name = "foo"
      links = [ // this is a set which must have unique values for switch+port
        {
          switch       = "foo"      // <- names don't have to be unique
          port         = "ge-0/0/0" // <- ports don't have to be unique
          transform_id = 1
        },
        {
          switch       = "bar"      // <- different name is good news
          port         = "ge-0/0/0" // <- same port is okay
          transform_id = 1
        },
        {
          switch       = "foo"      // <- same name and same port
          port         = "ge-0/0/0" // <- is a problem
          transform_id = 2
        },
      ]
    }
  ]
}
```

in the `rack_info` schema we'd add validators:

```go
// the switches attribute would get this:
Validators: []validator.Set{UniqueValueCombinationsAt("name")}

// the servers.links attribute would get this:
Validators: []validator.Set{UniqueValueCombinationsAt("switch", "port")}
```
