### PR TITLE
Bugfix: Populate missing name/id attributes in `apstra_datacenter_system` data source

### DIFF
--- a/apstra/blueprint/node_system.go
+++ b/apstra/blueprint/node_system.go
@@ -47,7 +47,7 @@ func (o NodeTypeSystem) DataSourceAttributes() map[string]dataSourceSchema.Attri
 	}
 }
 
-func (o *NodeTypeSystem) ReadFromApi(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
+func (o *NodeTypeSystem) AttributesFromApi(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
 	type node struct {
 		Id         string `json:"id"`
 		Hostname   string `json:"hostname"`


### PR DESCRIPTION
The `apstra_datacenter_system` takes either `name` or `id` as input and populates system details in an object called `attributes`.

The `attributes` object has both `name` and `id` inside.

Prior to this PR, nothing was populating the top-level (input) `name` or `id` other than the user. One of those two fields (whichever the user didn't use) would always be Null when the data source returned.

This PR ensures that the top-level `name` and `id` fields are both always populated making it safe for the user to refer to `data.apstra_datacenter_system.<name>.id`, rather than `data.apstra_datacenter_system.<name>.attributes.id`

Also, the `ReadFromApi()` method has been renamed `AttributesFromApi()` to make it clear that only the `attributes` object is being populated.