### PR TITLE
Set transform ID `null` when it cannot be determined

### DIFF
--- a/apstra/blueprint/datacenter_generic_system_link.go
+++ b/apstra/blueprint/datacenter_generic_system_link.go
@@ -138,6 +138,11 @@ func (o *DatacenterGenericSystemLink) getTransformId(ctx context.Context, client
 
 	transformId, err := client.GetTransformationIdByIfName(ctx, apstra.ObjectId(o.TargetSwitchId.ValueString()), o.TargetSwitchIfName.ValueString())
 	if err != nil {
+		var ace apstra.ClientErr
+		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
+			o.TargetSwitchIfTransformId = types.Int64Null()
+			return
+		}
 		diags.AddError(fmt.Sprintf("failed to get transform ID for %q", o.digest()), err.Error())
 		return
 	}


### PR DESCRIPTION
With this PR, `resourceDatacenterGenericSystem.Read()` will return `null`, rather than an error, for the `target_switch_if_transform_id` attribute when the transform ID cannot be determined.

This happens if the interface map was removed from the staging blueprint, possibly during `destroy` of a project (race condition)

Closes #370