### PR TITLE
Fix compiled-in version and commit strings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,8 +6,8 @@
 #
 before:
   hooks:
-#    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
-#    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
+    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
+    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
     - go run github.com/chrismarget-j/go-licenses save --ignore github.com/Juniper/terraform-provider-apstra --ignore github.com/Juniper/apstra-go-sdk --save_path=./Third_Party_Code --force ./...
     - sh -c "go run github.com/chrismarget-j/go-licenses report ./... --ignore github.com/Juniper/terraform-provider-apstra --ignore github.com/Juniper/apstra-go-sdk/apstra --template .notices.tpl > Third_Party_Code/NOTICES.md"
     - go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,8 +6,8 @@
 #
 before:
   hooks:
-    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
-    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
+#    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
+#    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
     - go run github.com/chrismarget-j/go-licenses save --ignore github.com/Juniper/terraform-provider-apstra --ignore github.com/Juniper/apstra-go-sdk --save_path=./Third_Party_Code --force ./...
     - sh -c "go run github.com/chrismarget-j/go-licenses report ./... --ignore github.com/Juniper/terraform-provider-apstra --ignore github.com/Juniper/apstra-go-sdk/apstra --template .notices.tpl > Third_Party_Code/NOTICES.md"
     - go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
@@ -22,7 +22,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X terraform-provider-apstra/apstra.tag={{.Version}} -X terraform-provider-apstra/apstra.commit={{.Commit}}'
+    - '-s -w -X github.com/Juniper/terraform-provider-apstra/apstra.tag={{.Version}} -X github.com/Juniper/terraform-provider-apstra/apstra.commit={{.Commit}}'
   goos:
 #    - freebsd
     - windows


### PR DESCRIPTION
When the module path was changed in #330, the `ldflags` options in `.goreleaser.yml` should have been updated to populate existing variables at their new module path.

Closes #380