### PR TITLE
Add import/export RTs to routing zone resource/datasources

### DIFF
--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -167,8 +167,7 @@ func (o DatacenterRoutingZone) DataSourceFilterAttributes() map[string]dataSourc
 			MarkdownDescription: "This is a set of *required* RTs, not an exact-match list.",
 			Optional:            true,
 			ElementType:         types.StringType,
-			Validators: []validator.Set{
-				setvalidator.SizeAtLeast(1)},
+			Validators:          []validator.Set{setvalidator.SizeAtLeast(1)},
 		},
 	}
 }

--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -342,8 +342,13 @@ func (o *DatacenterRoutingZone) LoadApiData(ctx context.Context, sz *apstra.Secu
 		o.Vni = types.Int64Null()
 	}
 
-	o.ImportRouteTargets = utils.SetValueOrNull(ctx, types.StringType, sz.RtPolicy.ImportRTs, diags)
-	o.ExportRouteTargets = utils.SetValueOrNull(ctx, types.StringType, sz.RtPolicy.ExportRTs, diags)
+	if sz.RtPolicy != nil && sz.RtPolicy.ImportRTs != nil {
+		o.ImportRouteTargets = utils.SetValueOrNull(ctx, types.StringType, sz.RtPolicy.ImportRTs, diags)
+	}
+
+	if sz.RtPolicy != nil && sz.RtPolicy.ExportRTs != nil {
+		o.ExportRouteTargets = utils.SetValueOrNull(ctx, types.StringType, sz.RtPolicy.ExportRTs, diags)
+	}
 }
 
 func (o *DatacenterRoutingZone) LoadApiDhcpServers(ctx context.Context, IPs []net.IP, diags *diag.Diagnostics) {

--- a/apstra/helpers.go
+++ b/apstra/helpers.go
@@ -1,5 +1,12 @@
 package tfapstra
 
+import (
+	"fmt"
+	"golang.org/x/exp/constraints"
+	"math/rand"
+	"unsafe"
+)
+
 // sliceWithoutElement returns a copy of in with all occurrences of e removed.
 // the returned int indicates the number of occurrences removed.
 func sliceWithoutElement[A comparable](in []A, e A) ([]A, int) {
@@ -13,4 +20,16 @@ func sliceWithoutElement[A comparable](in []A, e A) ([]A, int) {
 		resultIdx++
 	}
 	return result[:resultIdx], len(in) - resultIdx
+}
+
+func FillWithRandomIntegers[A constraints.Integer](a []A) {
+	maxSize := unsafe.Sizeof(uint64(0))
+
+	for i := 0; i < len(a); i++ {
+		if unsafe.Sizeof(a[i]) > maxSize {
+			panic(fmt.Sprintf("FillWithRandomIntegers got unexpectedly large integer type %v", a[i]))
+		}
+
+		a[i] = A(rand.Uint64())
+	}
 }

--- a/apstra/helpers.go
+++ b/apstra/helpers.go
@@ -23,13 +23,18 @@ func sliceWithoutElement[A comparable](in []A, e A) ([]A, int) {
 }
 
 func FillWithRandomIntegers[A constraints.Integer](a []A) {
+	if len(a) == 0 {
+		return
+	}
+
+	var nominal A
 	maxSize := unsafe.Sizeof(uint64(0))
+	nominalSize := unsafe.Sizeof(nominal)
+	if nominalSize > maxSize {
+		panic(fmt.Sprintf("FillWithRandomIntegers got unexpectedly large integer type %v", nominal))
+	}
 
 	for i := 0; i < len(a); i++ {
-		if unsafe.Sizeof(a[i]) > maxSize {
-			panic(fmt.Sprintf("FillWithRandomIntegers got unexpectedly large integer type %v", a[i]))
-		}
-
 		a[i] = A(rand.Uint64())
 	}
 }

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -2,6 +2,7 @@ package tfapstra
 
 import (
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"golang.org/x/exp/constraints"
 	"testing"
 )
 
@@ -92,5 +93,64 @@ func TestSliceWithoutElement(t *testing.T) {
 			}
 			continue
 		}
+	}
+}
+
+func notAllZeros[A constraints.Integer](in []A) bool {
+	for i := range in {
+		if in[i] != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRandomIntegers(t *testing.T) {
+	dataI := make([]int, 50)
+	dataS8 := make([]uint8, 50)
+	dataS16 := make([]uint16, 50)
+	dataS32 := make([]uint32, 50)
+	dataS64 := make([]uint64, 50)
+	dataU8 := make([]uint8, 50)
+	dataU16 := make([]uint16, 50)
+	dataU32 := make([]uint32, 50)
+	dataU64 := make([]uint64, 50)
+
+	FillWithRandomIntegers(dataI)
+	FillWithRandomIntegers(dataS8)
+	FillWithRandomIntegers(dataS16)
+	FillWithRandomIntegers(dataS32)
+	FillWithRandomIntegers(dataS64)
+	FillWithRandomIntegers(dataU8)
+	FillWithRandomIntegers(dataU16)
+	FillWithRandomIntegers(dataU32)
+	FillWithRandomIntegers(dataU64)
+
+	if !notAllZeros(dataI) {
+		t.Fail()
+	}
+	if !notAllZeros(dataS8) {
+		t.Fail()
+	}
+	if !notAllZeros(dataS16) {
+		t.Fail()
+	}
+	if !notAllZeros(dataS32) {
+		t.Fail()
+	}
+	if !notAllZeros(dataS64) {
+		t.Fail()
+	}
+	if !notAllZeros(dataU8) {
+		t.Fail()
+	}
+	if !notAllZeros(dataU16) {
+		t.Fail()
+	}
+	if !notAllZeros(dataU32) {
+		t.Fail()
+	}
+	if !notAllZeros(dataU64) {
+		t.Fail()
 	}
 }

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -106,6 +106,9 @@ func notAllZeros[A constraints.Integer](in []A) bool {
 }
 
 func TestRandomIntegers(t *testing.T) {
+	type uFoo uint16
+	type sFoo int16
+
 	dataI := make([]int, 50)
 	dataS8 := make([]uint8, 50)
 	dataS16 := make([]uint16, 50)
@@ -115,6 +118,8 @@ func TestRandomIntegers(t *testing.T) {
 	dataU16 := make([]uint16, 50)
 	dataU32 := make([]uint32, 50)
 	dataU64 := make([]uint64, 50)
+	dataSFoo := make([]sFoo, 50)
+	dataUFoo := make([]uFoo, 50)
 
 	FillWithRandomIntegers(dataI)
 	FillWithRandomIntegers(dataS8)
@@ -125,6 +130,8 @@ func TestRandomIntegers(t *testing.T) {
 	FillWithRandomIntegers(dataU16)
 	FillWithRandomIntegers(dataU32)
 	FillWithRandomIntegers(dataU64)
+	FillWithRandomIntegers(dataSFoo)
+	FillWithRandomIntegers(dataUFoo)
 
 	if !notAllZeros(dataI) {
 		t.Fail()
@@ -151,6 +158,12 @@ func TestRandomIntegers(t *testing.T) {
 		t.Fail()
 	}
 	if !notAllZeros(dataU64) {
+		t.Fail()
+	}
+	if !notAllZeros(dataSFoo) {
+		t.Fail()
+	}
+	if !notAllZeros(dataUFoo) {
 		t.Fail()
 	}
 }

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -96,13 +96,13 @@ func TestSliceWithoutElement(t *testing.T) {
 	}
 }
 
-func notAllZeros[A constraints.Integer](in []A) bool {
+func allZeros[A constraints.Integer](in []A) bool {
 	for i := range in {
 		if in[i] != 0 {
-			return true
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func TestRandomIntegers(t *testing.T) {
@@ -133,37 +133,37 @@ func TestRandomIntegers(t *testing.T) {
 	FillWithRandomIntegers(dataSFoo)
 	FillWithRandomIntegers(dataUFoo)
 
-	if !notAllZeros(dataI) {
+	if allZeros(dataI) {
 		t.Fail()
 	}
-	if !notAllZeros(dataS8) {
+	if allZeros(dataS8) {
 		t.Fail()
 	}
-	if !notAllZeros(dataS16) {
+	if allZeros(dataS16) {
 		t.Fail()
 	}
-	if !notAllZeros(dataS32) {
+	if allZeros(dataS32) {
 		t.Fail()
 	}
-	if !notAllZeros(dataS64) {
+	if allZeros(dataS64) {
 		t.Fail()
 	}
-	if !notAllZeros(dataU8) {
+	if allZeros(dataU8) {
 		t.Fail()
 	}
-	if !notAllZeros(dataU16) {
+	if allZeros(dataU16) {
 		t.Fail()
 	}
-	if !notAllZeros(dataU32) {
+	if allZeros(dataU32) {
 		t.Fail()
 	}
-	if !notAllZeros(dataU64) {
+	if allZeros(dataU64) {
 		t.Fail()
 	}
-	if !notAllZeros(dataSFoo) {
+	if allZeros(dataSFoo) {
 		t.Fail()
 	}
-	if !notAllZeros(dataUFoo) {
+	if allZeros(dataUFoo) {
 		t.Fail()
 	}
 }

--- a/docs/data-sources/datacenter_routing_zone.md
+++ b/docs/data-sources/datacenter_routing_zone.md
@@ -63,8 +63,10 @@ output "routing_zone" {
 ### Read-Only
 
 - `dhcp_servers` (Set of String) Set of DHCP server IPv4 or IPv6 addresses of DHCP servers.
+- `export_route_targets` (Set of String) Used to export routes from the EVPN VRF.
 - `had_prior_vlan_id_config` (Boolean) Used to trigger plan modification when `vlan_id` has been removed from the configuration in managed resource context, this attribute will always be `null` and should be ignored in data source context.
 - `had_prior_vni_config` (Boolean) Used to trigger plan modification when `vni` has been removed from the configuration in managed resource context, this attribute will always be `null` and should be ignored in data source context.
+- `import_route_targets` (Set of String) Used to import routes into the EVPN VRF.
 - `routing_policy_id` (String) Non-EVPN blueprints must use the default policy, so this field must be null. Set this attribute in an EVPN blueprint to use a non-default policy.
 - `vlan_id` (Number) Used for VLAN tagged Layer 3 links on external connections. Leave this field blank to have it automatically assigned from a static pool in the range of 2-4094), or enter a specific value.
 - `vni` (Number) VxLAN VNI associated with the routing zone. Leave this field blank to have it automatically assigned from an allocated resource pool, or enter a specific value.

--- a/docs/data-sources/datacenter_routing_zones.md
+++ b/docs/data-sources/datacenter_routing_zones.md
@@ -41,11 +41,12 @@ data "apstra_datacenter_routing_zones" "rzs" {
 
 ### Optional
 
-- `filter` (Attributes) Routing Zone attributes used as a filter (see [below for nested schema](#nestedatt--filter))
+- `filter` (Attributes, Deprecated) Routing Zone attributes used as a filter (see [below for nested schema](#nestedatt--filter))
+- `filters` (Attributes List) List of filters used to select only desired node IDs. For a node to match a filter, all specified attributes must match (each attribute within a filter is AND-ed together). The returned node IDs represent the nodes matched by all of the filters together (filters are OR-ed together). (see [below for nested schema](#nestedatt--filters))
 
 ### Read-Only
 
-- `graph_query` (String) The graph datastore query used to perform the lookup.
+- `graph_queries` (List of String) Graph datastore queries which performed the lookup based on supplied filters.
 - `ids` (Set of String) Set of Routing Zone IDs
 
 <a id="nestedatt--filter"></a>
@@ -54,6 +55,29 @@ data "apstra_datacenter_routing_zones" "rzs" {
 Optional:
 
 - `dhcp_servers` (Set of String) Set of addresses of DHCP servers (IPv4 or IPv6) which must be configured in the Routing Zone. This is a list of *required* servers, not an exact-match list.
+- `export_route_targets` (Set of String) This is a set of *required* RTs, not an exact-match list.
+- `import_route_targets` (Set of String) This is a set of *required* RTs, not an exact-match list.
+- `name` (String) VRF name displayed in the Apstra web UI.
+- `routing_policy_id` (String) Non-EVPN blueprints must use the default policy, so this field must be null. Set this attribute in an EVPN blueprint to use a non-default policy.
+- `vlan_id` (Number) Used for VLAN tagged Layer 3 links on external connections.
+- `vni` (Number) VxLAN VNI associated with the routing zone.
+
+Read-Only:
+
+- `blueprint_id` (String) Not applicable in filter context. Ignore.
+- `had_prior_vlan_id_config` (Boolean) Not applicable in filter context. Ignore.
+- `had_prior_vni_config` (Boolean) Not applicable in filter context. Ignore.
+- `id` (String) Not applicable in filter context. Ignore.
+
+
+<a id="nestedatt--filters"></a>
+### Nested Schema for `filters`
+
+Optional:
+
+- `dhcp_servers` (Set of String) Set of addresses of DHCP servers (IPv4 or IPv6) which must be configured in the Routing Zone. This is a list of *required* servers, not an exact-match list.
+- `export_route_targets` (Set of String) This is a set of *required* RTs, not an exact-match list.
+- `import_route_targets` (Set of String) This is a set of *required* RTs, not an exact-match list.
 - `name` (String) VRF name displayed in the Apstra web UI.
 - `routing_policy_id` (String) Non-EVPN blueprints must use the default policy, so this field must be null. Set this attribute in an EVPN blueprint to use a non-default policy.
 - `vlan_id` (Number) Used for VLAN tagged Layer 3 links on external connections.

--- a/docs/resources/datacenter_routing_zone.md
+++ b/docs/resources/datacenter_routing_zone.md
@@ -35,6 +35,8 @@ resource "apstra_datacenter_routing_zone" "blue" {
 ### Optional
 
 - `dhcp_servers` (Set of String) Set of DHCP server IPv4 or IPv6 addresses of DHCP servers.
+- `export_route_targets` (Set of String) Used to export routes from the EVPN VRF.
+- `import_route_targets` (Set of String) Used to import routes into the EVPN VRF.
 - `routing_policy_id` (String) Non-EVPN blueprints must use the default policy, so this field must be null. Set this attribute in an EVPN blueprint to use a non-default policy.
 - `vlan_id` (Number) Used for VLAN tagged Layer 3 links on external connections. Leave this field blank to have it automatically assigned from a static pool in the range of 2-4094, or enter a specific value.
 - `vni` (Number) VxLAN VNI associated with the routing zone. Leave this field blank to have it automatically assigned from an allocated resource pool, or enter a specific value.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20231024012728-aaba2cdaedb7
+	github.com/Juniper/apstra-go-sdk v0.0.0-20231024231608-5d733c01a440
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20231020062015-28f9cc08359b
+	github.com/Juniper/apstra-go-sdk v0.0.0-20231024012728-aaba2cdaedb7
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20231020062015-28f9cc08359b h1:Oj9anGYGb9hu6zYxSH05Kz38zqP7svNPlITDkfyZRZs=
-github.com/Juniper/apstra-go-sdk v0.0.0-20231020062015-28f9cc08359b/go.mod h1:It+5cLgOj77K+s+7m5Nsnbms3Tu/4ObqDuBjsTR2Oh0=
+github.com/Juniper/apstra-go-sdk v0.0.0-20231024012728-aaba2cdaedb7 h1:kBG5uBoOnkRyKtrC86LHFxeE9NW6guUVeRa05cxbHg4=
+github.com/Juniper/apstra-go-sdk v0.0.0-20231024012728-aaba2cdaedb7/go.mod h1:It+5cLgOj77K+s+7m5Nsnbms3Tu/4ObqDuBjsTR2Oh0=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20231024012728-aaba2cdaedb7 h1:kBG5uBoOnkRyKtrC86LHFxeE9NW6guUVeRa05cxbHg4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20231024012728-aaba2cdaedb7/go.mod h1:It+5cLgOj77K+s+7m5Nsnbms3Tu/4ObqDuBjsTR2Oh0=
+github.com/Juniper/apstra-go-sdk v0.0.0-20231024231608-5d733c01a440 h1:zAE3k3T4EhBCJpoNrCWbv3Sow92+11O1vAhF1R/wsD0=
+github.com/Juniper/apstra-go-sdk v0.0.0-20231024231608-5d733c01a440/go.mod h1:It+5cLgOj77K+s+7m5Nsnbms3Tu/4ObqDuBjsTR2Oh0=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=


### PR DESCRIPTION
This PR adds support for `import_route_targets` and `export_route_targets` to:
- resource `apstra_datacenter_routing_zone`
- data source `apstra_datacenter_routing_zone`
- data source `apstra_datacenter_routing_zones`

In addition, it deprecates the `filter` attribute from data source `apstra_datacenter_routing_zones`, and introduces `filters`.

Closes #406