### PR TITLE
audit-resource-blueprint-id for requires-replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+
 # terraform-provider-apstra
 
 This is a [Terraform](https://www.terraform.io)
@@ -20,40 +25,73 @@ The terraform configuration must:
 find the Apstra service.
 
 ```hcl
-terraform {
-  required_providers {
-    apstra = {
-      source = "Juniper/apstra"
+    terraform {
+      required_providers {
+        apstra = {
+          source = "Juniper/apstra"
+        }
+      }
     }
-  }
-}
-
-provider "apstra" {
-  url = "<apstra-server-url>"
-}
+    
+    provider "apstra" {
+      url = "<apstra-server-url>"
+    }
 ```
 
 ### Terraform Init
 
 Run the following at a command prompt while in the same directory as the
 configuration file to fetch the Apstra provider plugin.
-```shell
+```console
 terraform init
 ```
 
-### Supply Apstra credentials
-Apstra credentials can be supplied through environment variables:
-```shell
+### Apstra credentials can be supplied through environment variables:
+```console
 export APSTRA_USER=<username>
 export APSTRA_PASS=<password>
 ```
 
 Alternatively, credentials can be embedded in the URL using HTTP basic
 authentication format (we don't actually *do* basic authentication, but the
-format is: `https://user:password@host`). Any special characters in the username
+format is: ``https://user:pass@host``). Any special characters in the username
 and password must be URL-encoded when using this approach.
 
 ### Start configuring resources
 
 Full documentation for provider, resources and data sources can be found
 [here](https://registry.terraform.io/providers/Juniper/apstra/latest/docs).
+
+See the [open issues](https://github.com/Juniper/terraform-provider-apstra/issues) for a full list of proposed features (and known issues).
+
+## Public Roadmap
+
+View the [Roadmap](https://github.com/orgs/Juniper/projects/5/views/2) if you would like to see what is next on our plate.
+
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement".
+Don't forget to give the project a star! Thanks again!
+
+1. Fork the Project
+1. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
+1. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
+1. Push to the Branch (`git push origin feature/AmazingFeature`)
+1. Open a Pull Request
+
+
+            
+            
+            
+
+[contributors-shield]: https://img.shields.io/github/contributors/Juniper/terraform-provider-apstra?style=for-the-badge
+[contributors-url]: https://github.com/Juniper/terraform-provider-apstra/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/Juniper/terraform-provider-apstra.svg?style=for-the-badge
+[forks-url]: https://github.com/Juniper/terraform-provider-apstra/network/members
+[stars-shield]: https://img.shields.io/github/stars/Juniper/terraform-provider-apstra.svg?style=for-the-badge
+[stars-url]: https://github.com/Juniper/terraform-provider-apstra/stargazers
+[issues-shield]: https://img.shields.io/github/issues/Juniper/terraform-provider-apstra.svg?style=for-the-badge
+[issues-url]: https://github.com/Juniper/terraform-provider-apstra/issues

--- a/apstra/blueprint/connectivity_template.go
+++ b/apstra/blueprint/connectivity_template.go
@@ -36,6 +36,7 @@ func (o ConnectivityTemplate) ResourceAttributes() map[string]resourceSchema.Att
 			MarkdownDescription: "Apstra Blueprint ID.",
 			Required:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
+			PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured()},
 		},
 		"name": resourceSchema.StringAttribute{
 			MarkdownDescription: "Name displayed in web UI.",


### PR DESCRIPTION
Reviewed all resources with datacenter or blueprint that would need required_replace on the id.
Fixes #408 
added planmodifier for connectivity_template.go and updated README.md to add some jazz