### PR TITLE
Bug/437 vn multiple sort order

### DIFF
--- a/apstra/connectivity_template/vn_multiple.go
+++ b/apstra/connectivity_template/vn_multiple.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/apstra_validator"
+	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -74,6 +75,8 @@ func (o VnMultiple) Marshal(ctx context.Context, diags *diag.Diagnostics) string
 		// nil slice causes API errors
 		taggedVnIds = []apstra.ObjectId{}
 	}
+
+	utils.Sort(taggedVnIds)
 
 	obj := vnMultiplePrototype{
 		UntaggedVnId: untaggedVnId,

--- a/apstra/data_source_datacenter_external_gateways.go
+++ b/apstra/data_source_datacenter_external_gateways.go
@@ -136,12 +136,11 @@ func (o *dataSourceDatacenterExternalGateways) Read(ctx context.Context, req dat
 
 	// collect ids of candidates which match any filter
 	var ids []attr.Value
-candidateLoop:
 	for _, candidate := range candidates { // loop over candidates
 		for _, filter := range filters { // loop over filters
 			if filter.FilterMatch(ctx, &candidate, &resp.Diagnostics) {
 				ids = append(ids, candidate.Id)
-				continue candidateLoop
+				break
 			}
 		}
 	}

--- a/apstra/data_source_datacenter_routing_policies.go
+++ b/apstra/data_source_datacenter_routing_policies.go
@@ -135,12 +135,11 @@ func (o *dataSourceDatacenterRoutingPolicies) Read(ctx context.Context, req data
 
 	// collect ids of candidates which match any filter
 	var ids []attr.Value
-candidateLoop:
 	for _, candidate := range candidates { // loop over candidates
 		for _, filter := range filters { // loop over filters
 			if filter.FilterMatch(ctx, &candidate, &resp.Diagnostics) {
 				ids = append(ids, candidate.Id)
-				continue candidateLoop
+				break
 			}
 		}
 	}

--- a/apstra/utils/slice_utils.go
+++ b/apstra/utils/slice_utils.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"fmt"
+	"golang.org/x/exp/constraints"
+	"sort"
 )
 
 func ItemInSlice[A comparable](item A, slice []A) bool {
@@ -140,4 +142,14 @@ func SliceIntersectionOfAB[T comparable](a, b []T) []T {
 	}
 
 	return result
+}
+
+func Sort[A constraints.Ordered](in []A) {
+	if in == nil {
+		return
+	}
+
+	sort.Slice(in, func(i, j int) bool {
+		return in[i] < in[j]
+	})
 }


### PR DESCRIPTION
The VN Multiple CT primitive data source causes state churn because parent CTs with this data embedded as a JSON string were not able to recognize VN ID list [a,b,c] as equal to [c,a,b].

This PR sorts the list whenever the VN multiple primitive is marshaled to a string, eliminating the needless state churn.

VN multiple is the only CT with an embedded TF set, other than those with a set of child primitives.

The same problem may exist there. We should be on the lookout for it.

Future set-as-JSON might consider switching from this:
```json
{
  "set": [
    "abc",
    "def"
  ]
}
```

to this:
```json
{
  "set": {
    "abc": {},
    "def": {}
  }
}
```

Closes #437