### PR TITLE
Improve 'forbidden when value is' validator

### DIFF
--- a/apstra/apstra_validator/forbidden_when_value_is.go
+++ b/apstra/apstra_validator/forbidden_when_value_is.go
@@ -74,8 +74,8 @@ func (o ForbiddenWhenValueIsValidator) Validate(ctx context.Context, req Forbidd
 				continue // Collect all errors
 			}
 
-			// Unknown and Null attributes can't satisfy the valueIs condition
-			if mpVal.IsNull() || mpVal.IsUnknown() {
+			// Unknown attributes can't satisfy the valueIs condition
+			if mpVal.IsUnknown() {
 				return
 			}
 

--- a/apstra/apstra_validator/forbidden_when_value_is.go
+++ b/apstra/apstra_validator/forbidden_when_value_is.go
@@ -16,8 +16,8 @@ var (
 )
 
 type ForbiddenWhenValueIsValidator struct {
-	expression path.Expression
-	value      string
+	Expression path.Expression
+	Value      attr.Value
 }
 
 type ForbiddenWhenValueIsRequest struct {
@@ -32,7 +32,7 @@ type ForbiddenWhenValueIsResponse struct {
 }
 
 func (o ForbiddenWhenValueIsValidator) Description(_ context.Context) string {
-	return fmt.Sprintf("Ensures that no value is supplied when attribute at %q has value %q", o.expression.String(), o.value)
+	return fmt.Sprintf("Ensures that no value is supplied when attribute at %q has value %s", o.Expression, o.Value)
 }
 
 func (o ForbiddenWhenValueIsValidator) MarkdownDescription(ctx context.Context) string {
@@ -50,7 +50,7 @@ func (o ForbiddenWhenValueIsValidator) Validate(ctx context.Context, req Forbidd
 		return
 	}
 
-	mergedExpressions := req.PathExpression.MergeExpressions(o.expression)
+	mergedExpressions := req.PathExpression.MergeExpressions(o.Expression)
 
 	for _, expression := range mergedExpressions {
 		matchedPaths, diags := req.Config.PathMatches(ctx, expression)
@@ -66,6 +66,7 @@ func (o ForbiddenWhenValueIsValidator) Validate(ctx context.Context, req Forbidd
 				continue
 			}
 
+			// get the attribute we'll be checking against
 			var mpVal attr.Value
 			diags = req.Config.GetAttribute(ctx, mp, &mpVal)
 			resp.Diagnostics.Append(diags...)
@@ -78,10 +79,11 @@ func (o ForbiddenWhenValueIsValidator) Validate(ctx context.Context, req Forbidd
 				return
 			}
 
-			if mpVal.String() == o.value {
+			// is the forbidden value found in the matched path?
+			if o.Value.Equal(mpVal) {
 				resp.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
 					req.Path,
-					fmt.Sprintf("value not permitted when %q has value %q, got %q", mp, mpVal, req.ConfigValue),
+					fmt.Sprintf("value not permitted when %q has value %s, got %q", mp, mpVal, req.ConfigValue),
 				))
 			}
 		}
@@ -223,58 +225,9 @@ func (o ForbiddenWhenValueIsValidator) ValidateString(ctx context.Context, req v
 	resp.Diagnostics.Append(validateResp.Diagnostics...)
 }
 
-func BoolForbiddenWhenValueIs(expression path.Expression, value string) validator.Bool {
+func ForbiddenWhenValueIs(expression path.Expression, value attr.Value) ForbiddenWhenValueIsValidator {
 	return ForbiddenWhenValueIsValidator{
-		expression: expression,
-		value:      value,
-	}
-}
-
-func Float64ForbiddenWhenValueIs(expression path.Expression, value string) validator.Float64 {
-	return ForbiddenWhenValueIsValidator{
-		expression: expression,
-		value:      value,
-	}
-}
-
-func Int64ForbiddenWhenValueIs(expression path.Expression, value string) validator.Int64 {
-	return ForbiddenWhenValueIsValidator{
-		expression: expression,
-		value:      value,
-	}
-}
-
-func MapForbiddenWhenValueIs(expression path.Expression, value string) validator.Map {
-	return ForbiddenWhenValueIsValidator{
-		expression: expression,
-		value:      value,
-	}
-}
-
-func NumberForbiddenWhenValueIs(expression path.Expression, value string) validator.Number {
-	return ForbiddenWhenValueIsValidator{
-		expression: expression,
-		value:      value,
-	}
-}
-
-func ObjectForbiddenWhenValueIs(expression path.Expression, value string) validator.Object {
-	return ForbiddenWhenValueIsValidator{
-		expression: expression,
-		value:      value,
-	}
-}
-
-func SetForbiddenWhenValueIs(expression path.Expression, value string) validator.Set {
-	return ForbiddenWhenValueIsValidator{
-		expression: expression,
-		value:      value,
-	}
-}
-
-func StringForbiddenWhenValueIs(expression path.Expression, value string) validator.String {
-	return ForbiddenWhenValueIsValidator{
-		expression: expression,
-		value:      value,
+		Expression: expression,
+		Value:      value,
 	}
 }

--- a/apstra/apstra_validator/forbidden_when_value_is_test.go
+++ b/apstra/apstra_validator/forbidden_when_value_is_test.go
@@ -1,0 +1,103 @@
+package apstravalidator_test
+
+import (
+	"context"
+	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/apstra_validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"testing"
+)
+
+func TestForbiddenWhenValueIsValidator(t *testing.T) {
+	ctx := context.Background()
+
+	type testCase struct {
+		req        apstravalidator.ForbiddenWhenValueIsRequest
+		other      path.Expression
+		otherValue attr.Value
+		expErrors  bool
+	}
+
+	testCases := map[string]testCase{
+		"base": {
+			req: apstravalidator.ForbiddenWhenValueIsRequest{
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				ConfigValue:    types.StringValue("bar value"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.Int64Attribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.Number,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.Number, 42),
+						"bar": tftypes.NewValue(tftypes.String, "bar value"),
+					}),
+				},
+			},
+			other:      path.MatchRoot("foo"),
+			otherValue: types.Int64Value(0),
+			expErrors:  false,
+		},
+		"catch_forbidden_value": {
+			req: apstravalidator.ForbiddenWhenValueIsRequest{
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				ConfigValue:    types.StringValue("bar value"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.Int64Attribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.Number,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.Number, 42),
+						"bar": tftypes.NewValue(tftypes.String, "bar value"),
+					}),
+				},
+			},
+			other:      path.MatchRoot("foo"),
+			otherValue: types.Int64Value(42),
+			expErrors:  true,
+		},
+	}
+
+	for name, test := range testCases {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var res apstravalidator.ForbiddenWhenValueIsResponse
+
+			apstravalidator.ForbiddenWhenValueIsValidator{
+				Expression: test.other,
+				Value:      test.otherValue,
+			}.Validate(ctx, test.req, &res)
+
+			if test.expErrors && !res.Diagnostics.HasError() {
+				t.Fatal("expected error(s), got none")
+			}
+
+			if !test.expErrors && res.Diagnostics.HasError() {
+				t.Fatalf("not expecting errors, got %d: %v", res.Diagnostics.ErrorsCount(), res.Diagnostics)
+			}
+		})
+	}
+}

--- a/apstra/apstra_validator/forbidden_when_value_is_test.go
+++ b/apstra/apstra_validator/forbidden_when_value_is_test.go
@@ -77,6 +77,33 @@ func TestForbiddenWhenValueIsValidator(t *testing.T) {
 			otherValue: types.Int64Value(42),
 			expErrors:  true,
 		},
+		"catch_forbidden_null": {
+			req: apstravalidator.ForbiddenWhenValueIsRequest{
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				ConfigValue:    types.StringValue("bar value"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.Int64Attribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.Number,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.Number, nil),
+						"bar": tftypes.NewValue(tftypes.String, "bar value"),
+					}),
+				},
+			},
+			other:      path.MatchRoot("foo"),
+			otherValue: types.Int64Null(),
+			expErrors:  true,
+		},
 	}
 
 	for name, test := range testCases {

--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -219,7 +219,7 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 				int64validator.Between(resources.VniMin, resources.VniMax),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("type"),
-					types.Int64Value(int64(apstra.VnTypeVlan)),
+					types.StringValue(apstra.VnTypeVlan.String()),
 				),
 			},
 		},

--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -217,9 +217,9 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 			Computed: true,
 			Validators: []validator.Int64{
 				int64validator.Between(resources.VniMin, resources.VniMax),
-				apstravalidator.Int64ForbiddenWhenValueIs(
+				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("type"),
-					fmt.Sprintf("%q", apstra.VnTypeVlan.String()),
+					types.Int64Value(int64(apstra.VnTypeVlan)),
 				),
 			},
 		},


### PR DESCRIPTION
The `ForbiddenWhenValueIsValidator` is used to specify that a given attribute must be `null` when *some other attribute* has a trigger value.

It's useful for cases like the `mlag_info` attribute on a leaf switch, which must not be configured (must be `null`) when a switch redundancy protocol is `esi`.

I wrote it for the general case (it works regardless of the type of the attribute being validated and the attribute with the trigger value), but it has some clunkiness:

- I wrote a helper function for each type of attribute (string, int64, boolean, etc...)
- The trigger value can only be expressed as a string

This PR changes much of that:
- There is now a single helper function `ForbiddenWhenValueIs()`, which works for all types
- The trigger value is no longer a string, but now an `attr.Value`, so we can tell the difference between `42` and `"42"`.
- We now have tests!

The only user of this validator has been updated to consume the new helper function.