### PR TITLE
WIP -> enable autosync of all keys for property sets

### DIFF
--- a/apstra/blueprint/datacenter_property_set.go
+++ b/apstra/blueprint/datacenter_property_set.go
@@ -124,7 +124,6 @@ func (o DatacenterPropertySet) ResourceAttributes() map[string]resourceSchema.At
 		"sync_with_catalog": resourceSchema.BoolAttribute{
 			MarkdownDescription: "Keep the data synchronized with the catalog.On every apply, " +
 				"check staleness and update data if required. Cannot be set if 'keys' is filled out",
-			Computed: true,
 			Optional: true,
 			Validators: []validator.Bool{
 				boolvalidator.ExactlyOneOf(path.Expressions{
@@ -147,35 +146,3 @@ func (o *DatacenterPropertySet) LoadApiData(_ context.Context, in *apstra.TwoSta
 	}
 	o.Keys = types.SetValueMust(types.StringType, keys)
 }
-
-// this function will read the object from apstra and fill out the data structure
-// func (o *DatacenterPropertySet) ReadData (ctx context.Context, bpid, in  apstra.ObjectId,
-// 	diags *diag.Diagnostics) error {
-// 	var dpset DatacenterPropertySet
-//
-// 	bpClient, err := o.client.NewTwoStageL3ClosClient(ctx, bpid)
-// 	if err != nil {
-// 		diags.AddError("failed to create blueprint client", err.Error())
-// 		return err
-// 		}
-// 	}
-//
-// 	api, err := bpClient.GetPropertySet(ctx, apstra.ObjectId(state.Id.ValueString()))
-// 	if err != nil {
-// 		if utils.IsApstra404(err) {
-// 			resp.State.RemoveResource(ctx)
-// 			return
-// 		}
-// 		resp.Diagnostics.AddAttributeError(path.Root("name"),
-// 			fmt.Sprintf("Failed to read imported PropertySet %s", state.Id), err.Error())
-// 		return
-// 	}
-// 	if (state.Keys.IsNull() || state.Keys.IsUnknown()) && state. {
-//
-// 	}
-// 	// create new state object
-// 	var newState blueprint.DatacenterPropertySet
-// 	newState.LoadApiData(ctx, api, &resp.Diagnostics)
-//
-//
-// }

--- a/apstra/provider_test.go
+++ b/apstra/provider_test.go
@@ -10,6 +10,7 @@ const (
 provider "apstra" {
   tls_validation_disabled = true
   blueprint_mutex_enabled = false
+  experimental = true
 }
 `
 )

--- a/apstra/resource_datacenter_property_set.go
+++ b/apstra/resource_datacenter_property_set.go
@@ -14,10 +14,18 @@ import (
 )
 
 var _ resource.ResourceWithConfigure = &resourceDatacenterPropertySet{}
+var _ resource.ResourceWithModifyPlan = &resourceDatacenterPropertySet{}
 
 type resourceDatacenterPropertySet struct {
 	client   *apstra.Client
 	lockFunc func(context.Context, string) error
+}
+
+func (o *resourceDatacenterPropertySet) ModifyPlan(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {
+	// TODO implement me
+	response.Diagnostics.AddWarning("Got into Maodify Plan", "bla bla ba")
+	// If stale and keys is empty
+	response.RequiresReplace = path.Paths{path.Root("stale")}
 }
 
 func (o *resourceDatacenterPropertySet) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -53,7 +61,6 @@ func (o *resourceDatacenterPropertySet) ImportPropertySet(ctx context.Context, d
 			err.Error())
 		return nil
 	}
-	d.AddWarning("Got here", "ee")
 
 	// Perform the import
 	id, err := bpClient.ImportPropertySet(ctx, apstra.ObjectId(dps.Id.ValueString()), keysToImport...)
@@ -158,28 +165,28 @@ func (o *resourceDatacenterPropertySet) Read(ctx context.Context, req resource.R
 		return
 	}
 	// Keys are empty, configlet is stale and SyncWithCatalog is true
-	if (state.Keys.IsNull() || state.Keys.IsUnknown()) && state.SyncWithCatalog.ValueBool() && api.Stale {
-		err = bpClient.UpdatePropertySet(ctx, apstra.ObjectId(state.Id.ValueString()), nil...)
-		if err != nil {
-			if utils.IsApstra404(err) {
-				resp.State.RemoveResource(ctx)
-				return
-			}
-			resp.Diagnostics.AddAttributeError(path.Root("name"),
-				fmt.Sprintf("Failed to read imported PropertySet %s", state.Id), err.Error())
-			return
-		}
-		api, err = bpClient.GetPropertySet(ctx, apstra.ObjectId(state.Id.ValueString()))
-		if err != nil {
-			if utils.IsApstra404(err) {
-				resp.State.RemoveResource(ctx)
-				return
-			}
-			resp.Diagnostics.AddAttributeError(path.Root("name"),
-				fmt.Sprintf("Failed to read imported PropertySet %s", state.Id), err.Error())
-			return
-		}
-	}
+	// if (state.Keys.IsNull() || state.Keys.IsUnknown()) && state.SyncWithCatalog.ValueBool() && api.Stale {
+	// 	err = bpClient.UpdatePropertySet(ctx, apstra.ObjectId(state.Id.ValueString()), nil...)
+	// 	if err != nil {
+	// 		if utils.IsApstra404(err) {
+	// 			resp.State.RemoveResource(ctx)
+	// 			return
+	// 		}
+	// 		resp.Diagnostics.AddAttributeError(path.Root("name"),
+	// 			fmt.Sprintf("Failed to read imported PropertySet %s", state.Id), err.Error())
+	// 		return
+	// 	}
+	// 	api, err = bpClient.GetPropertySet(ctx, apstra.ObjectId(state.Id.ValueString()))
+	// 	if err != nil {
+	// 		if utils.IsApstra404(err) {
+	// 			resp.State.RemoveResource(ctx)
+	// 			return
+	// 		}
+	// 		resp.Diagnostics.AddAttributeError(path.Root("name"),
+	// 			fmt.Sprintf("Failed to read imported PropertySet %s", state.Id), err.Error())
+	// 		return
+	// 	}
+	// }
 	// create new state object
 	var newState blueprint.DatacenterPropertySet
 	newState.LoadApiData(ctx, api, &resp.Diagnostics)


### PR DESCRIPTION
This is a WIP, so no tests are ready yet for eg.
However, the proposal here is to do a full download of keys if the list of keys is empty and to do an auto sync on Read for the resource provider if it tunrs out that hte list of keys is empty and that the property set is stale.

