### PR TITLE
Fix doc category for resourceDatacenterConfiglet

### DIFF
--- a/apstra/resource_datacenter_configlet.go
+++ b/apstra/resource_datacenter_configlet.go
@@ -31,7 +31,7 @@ func (o *resourceDatacenterConfiglet) Configure(ctx context.Context, req resourc
 
 func (o *resourceDatacenterConfiglet) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: docCategoryDesign + "This resource imports a Configlet into a Blueprint.",
+		MarkdownDescription: docCategoryDatacenter + "This resource imports a Configlet into a Blueprint.",
 		Attributes:          blueprint.DatacenterConfiglet{}.ResourceAttributes(),
 	}
 }

--- a/docs/resources/datacenter_configlet.md
+++ b/docs/resources/datacenter_configlet.md
@@ -1,6 +1,6 @@
 ---
 page_title: "apstra_datacenter_configlet Resource - terraform-provider-apstra"
-subcategory: "Design"
+subcategory: "Reference Design: Datacenter"
 description: |-
   This resource imports a Configlet into a Blueprint.
 ---


### PR DESCRIPTION
fixes #470 
change category for MarkdownDescription as configlets can only be used in Datacenter Ref Designs