### PR TITLE
Introduce provider-managed cache for TwoStageL3ClosClient objects

### DIFF
--- a/apstra/configure.go
+++ b/apstra/configure.go
@@ -26,6 +26,25 @@ func DataSourceGetClient(_ context.Context, req datasource.ConfigureRequest, res
 	return nil
 }
 
+func DataSourceGetTwoStageL3ClosClientFunc(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) func(context.Context, string) (*apstra.TwoStageL3ClosClient, error) {
+	if req.ProviderData == nil {
+		return nil
+	}
+
+	var pd *providerData
+	var ok bool
+	if pd, ok = req.ProviderData.(*providerData); ok {
+		return pd.getTwoStageL3ClosClient
+	}
+
+	resp.Diagnostics.AddError(
+		errDataSourceConfigureProviderDataSummary,
+		fmt.Sprintf(errDataSourceConfigureProviderDataDetail, *pd, req.ProviderData),
+	)
+
+	return nil
+}
+
 func ResourceGetClient(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) *apstra.Client {
 	if req.ProviderData == nil {
 		return nil
@@ -113,5 +132,24 @@ func ResourceGetBlueprintUnlockFunc(_ context.Context, req resource.ConfigureReq
 		errResourceConfigureProviderDataDetail,
 		fmt.Sprintf(errResourceConfigureProviderDataDetail, *pd, req.ProviderData),
 	)
+	return nil
+}
+
+func ResourceGetTwoStageL3ClosClientFunc(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) func(context.Context, string) (*apstra.TwoStageL3ClosClient, error) {
+	if req.ProviderData == nil {
+		return nil
+	}
+
+	var pd *providerData
+	var ok bool
+	if pd, ok = req.ProviderData.(*providerData); ok {
+		return pd.getTwoStageL3ClosClient
+	}
+
+	resp.Diagnostics.AddError(
+		errResourceConfigureProviderDataSummary,
+		fmt.Sprintf(errResourceConfigureProviderDataDetail, *pd, req.ProviderData),
+	)
+
 	return nil
 }


### PR DESCRIPTION
This PR introduces a cache (`map[string]apstra.TwoStageL3ClosClient`) of blueprint client objects.

Prior to this change, each CRUD method on each resource (and data source) had to create a `TwoStageL3ClosClient` object for interaction with a blueprint. Creating the client requires an extra API call which can take quite a long time when the server is under load.

Now, instead of invoking `client.NewTwoStageL3ClosClient()`, the resources which need a client run a function handed to them by the provider.

This means that clients which previously retrieved a `*apstra.Client` object in `Configure()` now retrieve the function which retrieves the client from the provider's cache.

Cache misses are handled by creating (and storing) the required `apstra.TwoStageL3ClosClient`, so the object should only be created one time.

A single resource (`resourceDatacenterExternalGateway`) has been converted to use this new strategy. We'll convert the others in a follow-up PR.

Closes #137