### PR TITLE
Convert Data Sources to use new blueprint client cache

### DIFF
--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -324,25 +324,15 @@ func (o *DeviceAllocation) PopulateDataFromGraphDb(ctx context.Context, client *
 
 // SetInterfaceMap creates or deletes the graph db relationship between a switch
 // 'system' node and its interface map.
-func (o *DeviceAllocation) SetInterfaceMap(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
+func (o *DeviceAllocation) SetInterfaceMap(ctx context.Context, bp *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) {
 	assignments := make(apstra.SystemIdToInterfaceMapAssignment, 1)
 	if o.InitialInterfaceMapId.IsNull() {
 		assignments[o.NodeId.ValueString()] = nil
 	} else {
 		assignments[o.NodeId.ValueString()] = o.InitialInterfaceMapId.ValueString()
 	}
-	bpClient, err := client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(o.BlueprintId.ValueString()))
-	if err != nil {
-		if utils.IsApstra404(err) {
-			o.BlueprintId = types.StringNull()
-			return
-		}
-		diags.AddError(fmt.Sprintf(ErrDCBlueprintCreate, o.BlueprintId), err.Error())
 
-		return
-	}
-
-	err = bpClient.SetInterfaceMapAssignments(ctx, assignments)
+	err := bp.SetInterfaceMapAssignments(ctx, assignments)
 	if err != nil {
 		if utils.IsApstra404(err) {
 			o.BlueprintId = types.StringNull()

--- a/apstra/blueprint/vn_binding_constructor.go
+++ b/apstra/blueprint/vn_binding_constructor.go
@@ -57,13 +57,7 @@ func (o VnBindingConstructor) DataSourceAttributes() map[string]dataSourceSchema
 	}
 }
 
-func (o *VnBindingConstructor) Compute(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
-	bpClient, err := client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(o.BlueprintId.ValueString()))
-	if err != nil {
-		diags.AddError(fmt.Sprintf(ErrDCBlueprintCreate, o.BlueprintId), err.Error())
-		return
-	}
-
+func (o *VnBindingConstructor) Compute(ctx context.Context, bpClient *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) {
 	// only one VLAN per constructor; get it in the expected form
 	var vlanId *apstra.Vlan
 	if utils.Known(o.VlanId) {

--- a/apstra/constants.go
+++ b/apstra/constants.go
@@ -17,6 +17,8 @@ const (
 	errDataSourceReadFail                     = "Data Source Read() failure'"
 	errResourceReadFail                       = "Resource Read() failure'"
 	errImportJsonMissingRequiredField         = "Import ID JSON missing required field"
+	errBpClientCreateSummary                  = "Failed to create client for Blueprint %s"
+	errBpNotFoundSummary                      = "Blueprint %s not found"
 
 	docCategorySeparator    = " --- "
 	docCategoryDesign       = "Design" + docCategorySeparator

--- a/apstra/data_source_blueprint_iba_widget.go
+++ b/apstra/data_source_blueprint_iba_widget.go
@@ -14,7 +14,7 @@ import (
 var _ datasource.DataSourceWithConfigure = &dataSourceBlueprintIbaWidget{}
 
 type dataSourceBlueprintIbaWidget struct {
-	client *apstra.Client
+	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)
 }
 
 func (o *dataSourceBlueprintIbaWidget) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -22,7 +22,7 @@ func (o *dataSourceBlueprintIbaWidget) Metadata(_ context.Context, req datasourc
 }
 
 func (o *dataSourceBlueprintIbaWidget) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	o.client = DataSourceGetClient(ctx, req, resp)
+	o.getBpClientFunc = DataSourceGetTwoStageL3ClosClientFunc(ctx, req, resp)
 }
 
 func (o *dataSourceBlueprintIbaWidget) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -41,21 +41,21 @@ func (o *dataSourceBlueprintIbaWidget) Read(ctx context.Context, req datasource.
 		return
 	}
 
-	bpClient, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(config.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, config.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
-			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found",
-				config.BlueprintId), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf(errBpNotFoundSummary, config.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(errBpClientCreateSummary, config.BlueprintId), err.Error())
 		return
 	}
 
 	var api *apstra.IbaWidget
 	switch {
 	case !config.Name.IsNull():
-		api, err = bpClient.GetIbaWidgetByLabel(ctx, config.Name.ValueString())
+		api, err = bp.GetIbaWidgetByLabel(ctx, config.Name.ValueString())
 		if err != nil {
 			if utils.IsApstra404(err) {
 				resp.Diagnostics.AddAttributeError(
@@ -70,7 +70,7 @@ func (o *dataSourceBlueprintIbaWidget) Read(ctx context.Context, req datasource.
 			return
 		}
 	case !config.Id.IsNull():
-		api, err = bpClient.GetIbaWidget(ctx, apstra.ObjectId(config.Id.ValueString()))
+		api, err = bp.GetIbaWidget(ctx, apstra.ObjectId(config.Id.ValueString()))
 		if err != nil {
 			if utils.IsApstra404(err) {
 				resp.Diagnostics.AddAttributeError(

--- a/apstra/data_source_datacenter_external_gateway.go
+++ b/apstra/data_source_datacenter_external_gateway.go
@@ -13,7 +13,7 @@ import (
 var _ datasource.DataSourceWithConfigure = &dataSourceDatacenterExternalGateway{}
 
 type dataSourceDatacenterExternalGateway struct {
-	client *apstra.Client
+	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)
 }
 
 func (o *dataSourceDatacenterExternalGateway) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -21,7 +21,7 @@ func (o *dataSourceDatacenterExternalGateway) Metadata(_ context.Context, req da
 }
 
 func (o *dataSourceDatacenterExternalGateway) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	o.client = DataSourceGetClient(ctx, req, resp)
+	o.getBpClientFunc = DataSourceGetTwoStageL3ClosClientFunc(ctx, req, resp)
 }
 
 func (o *dataSourceDatacenterExternalGateway) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -40,14 +40,14 @@ func (o *dataSourceDatacenterExternalGateway) Read(ctx context.Context, req data
 		return
 	}
 
-	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(config.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, config.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
-			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found",
-				config.BlueprintId), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf(errBpNotFoundSummary, config.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, config.BlueprintId), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(errBpClientCreateSummary, config.BlueprintId), err.Error())
 		return
 	}
 

--- a/apstra/data_source_datacenter_interfaces_by_system.go
+++ b/apstra/data_source_datacenter_interfaces_by_system.go
@@ -14,7 +14,7 @@ import (
 var _ datasource.DataSourceWithConfigure = &dataSourceInterfacesBySystem{}
 
 type dataSourceInterfacesBySystem struct {
-	client *apstra.Client
+	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)
 }
 
 func (o *dataSourceInterfacesBySystem) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -22,7 +22,7 @@ func (o *dataSourceInterfacesBySystem) Metadata(_ context.Context, req datasourc
 }
 
 func (o *dataSourceInterfacesBySystem) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	o.client = DataSourceGetClient(ctx, req, resp)
+	o.getBpClientFunc = DataSourceGetTwoStageL3ClosClientFunc(ctx, req, resp)
 }
 
 func (o *dataSourceInterfacesBySystem) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -40,20 +40,19 @@ func (o *dataSourceInterfacesBySystem) Read(ctx context.Context, req datasource.
 		return
 	}
 
-	// create a blueprint client
-	bpClient, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(config.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, config.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
-			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found",
-				config.BlueprintId), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf(errBpNotFoundSummary, config.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(errBpClientCreateSummary, config.BlueprintId), err.Error())
 		return
 	}
 
 	// prepare and execute a graph query
-	interfaces, query := config.RunQuery(ctx, bpClient, &resp.Diagnostics)
+	interfaces, query := config.RunQuery(ctx, bp, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/apstra/data_source_datacenter_routing_policies.go
+++ b/apstra/data_source_datacenter_routing_policies.go
@@ -19,7 +19,7 @@ import (
 var _ datasource.DataSourceWithConfigure = &dataSourceDatacenterRoutingPolicies{}
 
 type dataSourceDatacenterRoutingPolicies struct {
-	client *apstra.Client
+	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)
 }
 
 func (o *dataSourceDatacenterRoutingPolicies) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -27,7 +27,7 @@ func (o *dataSourceDatacenterRoutingPolicies) Metadata(_ context.Context, req da
 }
 
 func (o *dataSourceDatacenterRoutingPolicies) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	o.client = DataSourceGetClient(ctx, req, resp)
+	o.getBpClientFunc = DataSourceGetTwoStageL3ClosClientFunc(ctx, req, resp)
 }
 
 func (o *dataSourceDatacenterRoutingPolicies) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -88,20 +88,19 @@ func (o *dataSourceDatacenterRoutingPolicies) Read(ctx context.Context, req data
 		return
 	}
 
-	// create a blueprint client
-	bpClient, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(config.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, config.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
-			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found",
-				config.BlueprintId), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf(errBpNotFoundSummary, config.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(errBpClientCreateSummary, config.BlueprintId), err.Error())
 		return
 	}
 
 	// collect all routing policies in the blueprint
-	apiResponse, err := bpClient.GetAllRoutingPolicies(ctx)
+	apiResponse, err := bp.GetAllRoutingPolicies(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to retrieve routing policies", err.Error())
 		return

--- a/apstra/data_source_iba_widgets.go
+++ b/apstra/data_source_iba_widgets.go
@@ -16,7 +16,7 @@ import (
 var _ datasource.DataSourceWithConfigure = &dataSourceBlueprintIbaWidgets{}
 
 type dataSourceBlueprintIbaWidgets struct {
-	client *apstra.Client
+	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)
 }
 
 func (o *dataSourceBlueprintIbaWidgets) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -24,7 +24,7 @@ func (o *dataSourceBlueprintIbaWidgets) Metadata(_ context.Context, req datasour
 }
 
 func (o *dataSourceBlueprintIbaWidgets) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	o.client = DataSourceGetClient(ctx, req, resp)
+	o.getBpClientFunc = DataSourceGetTwoStageL3ClosClientFunc(ctx, req, resp)
 }
 
 func (o *dataSourceBlueprintIbaWidgets) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -57,17 +57,19 @@ func (o *dataSourceBlueprintIbaWidgets) Read(ctx context.Context, req datasource
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	bpClient, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(config.BlueprintId.ValueString()))
+
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, config.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
-			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", config.BlueprintId), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf(errBpNotFoundSummary, config.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(errBpClientCreateSummary, config.BlueprintId), err.Error())
 		return
 	}
 
-	ws, err := bpClient.GetAllIbaWidgets(ctx)
+	ws, err := bp.GetAllIbaWidgets(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("error retrieving IBA Widgets", err.Error())
 		return

--- a/apstra/resource_datacenter_external_gateway.go
+++ b/apstra/resource_datacenter_external_gateway.go
@@ -70,10 +70,10 @@ func (o *resourceDatacenterExternalGateway) ImportState(ctx context.Context, req
 	bp, err := o.getBpClientFunc(ctx, state.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
-			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", state.BlueprintId), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf(errBpNotFoundSummary, state.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(errBpClientCreateSummary, state.BlueprintId), err.Error())
 		return
 	}
 
@@ -97,10 +97,10 @@ func (o *resourceDatacenterExternalGateway) Create(ctx context.Context, req reso
 	bp, err := o.getBpClientFunc(ctx, plan.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
-			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf(errBpNotFoundSummary, plan.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(errBpClientCreateSummary, plan.BlueprintId), err.Error())
 		return
 	}
 
@@ -148,7 +148,7 @@ func (o *resourceDatacenterExternalGateway) Read(ctx context.Context, req resour
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(errBpClientCreateSummary, state.BlueprintId), err.Error())
 		return
 	}
 
@@ -171,7 +171,7 @@ func (o *resourceDatacenterExternalGateway) Update(ctx context.Context, req reso
 	// get a client for the datacenter reference design
 	bp, err := o.getBpClientFunc(ctx, plan.BlueprintId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(errBpClientCreateSummary, plan.BlueprintId), err.Error())
 		return
 	}
 
@@ -217,7 +217,7 @@ func (o *resourceDatacenterExternalGateway) Delete(ctx context.Context, req reso
 		if utils.IsApstra404(err) {
 			return // 404 is okay
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf(errBpClientCreateSummary, state.BlueprintId), err.Error())
 		return
 	}
 

--- a/apstra/resource_datacenter_generic_system.go
+++ b/apstra/resource_datacenter_generic_system.go
@@ -14,8 +14,8 @@ import (
 var _ resource.ResourceWithConfigure = &resourceDatacenterGenericSystem{}
 
 type resourceDatacenterGenericSystem struct {
-	client   *apstra.Client
-	lockFunc func(context.Context, string) error
+	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)
+	lockFunc        func(context.Context, string) error
 }
 
 func (o *resourceDatacenterGenericSystem) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -23,7 +23,7 @@ func (o *resourceDatacenterGenericSystem) Metadata(_ context.Context, req resour
 }
 
 func (o *resourceDatacenterGenericSystem) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	o.client = ResourceGetClient(ctx, req, resp)
+	o.getBpClientFunc = ResourceGetTwoStageL3ClosClientFunc(ctx, req, resp)
 	o.lockFunc = ResourceGetBlueprintLockFunc(ctx, req, resp)
 }
 
@@ -42,14 +42,14 @@ func (o *resourceDatacenterGenericSystem) Create(ctx context.Context, req resour
 		return
 	}
 
-	// create a client for the datacenter reference design
-	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, plan.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
+		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
 		return
 	}
 
@@ -108,14 +108,14 @@ func (o *resourceDatacenterGenericSystem) Read(ctx context.Context, req resource
 		return
 	}
 
-	// Create a blueprint client
-	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, state.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
+		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
 		return
 	}
 
@@ -163,10 +163,10 @@ func (o *resourceDatacenterGenericSystem) Update(ctx context.Context, req resour
 		return
 	}
 
-	// Create a blueprint client
-	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, plan.BlueprintId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
+		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
 		return
 	}
 
@@ -211,13 +211,13 @@ func (o *resourceDatacenterGenericSystem) Delete(ctx context.Context, req resour
 		return
 	}
 
-	// Create a client for the datacenter reference design
-	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, state.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
 			return // 404 is okay
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
+		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
 		return
 	}
 


### PR DESCRIPTION
This PR touches a bunch of files. Review will be easiest on a commit-by-commit basis:
- [introduce constants for blueprint client errors](https://github.com/Juniper/terraform-provider-apstra/pull/483/commits/1222f34bc75d2701a0f657199c31639a73a8a4d1)
- [convert binding constructor data source to use bp client cache](https://github.com/Juniper/terraform-provider-apstra/pull/483/commits/ee728ec3e8b25a91f1808d51fd269cfff2f7c6a0) (a slightly complicated case)
- [convert virtual networks data source to use client cache](https://github.com/Juniper/terraform-provider-apstra/pull/483/commits/e4ca0980dbf022c458cdc723f716ba7c2c5d9b2d) (a slightly complicated case)
- [convert remaining data sources to use bp client cache](https://github.com/Juniper/terraform-provider-apstra/pull/483/commits/2930732cc742f96bf54aa893df9113ff15adf18f) (all of the simple cases)

Closes #481