### PR TITLE
Convert resources to use blueprint client cache

### DIFF
--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -324,25 +324,15 @@ func (o *DeviceAllocation) PopulateDataFromGraphDb(ctx context.Context, client *
 
 // SetInterfaceMap creates or deletes the graph db relationship between a switch
 // 'system' node and its interface map.
-func (o *DeviceAllocation) SetInterfaceMap(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
+func (o *DeviceAllocation) SetInterfaceMap(ctx context.Context, bp *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) {
 	assignments := make(apstra.SystemIdToInterfaceMapAssignment, 1)
 	if o.InitialInterfaceMapId.IsNull() {
 		assignments[o.NodeId.ValueString()] = nil
 	} else {
 		assignments[o.NodeId.ValueString()] = o.InitialInterfaceMapId.ValueString()
 	}
-	bpClient, err := client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(o.BlueprintId.ValueString()))
-	if err != nil {
-		if utils.IsApstra404(err) {
-			o.BlueprintId = types.StringNull()
-			return
-		}
-		diags.AddError(fmt.Sprintf(ErrDCBlueprintCreate, o.BlueprintId), err.Error())
 
-		return
-	}
-
-	err = bpClient.SetInterfaceMapAssignments(ctx, assignments)
+	err := bp.SetInterfaceMapAssignments(ctx, assignments)
 	if err != nil {
 		if utils.IsApstra404(err) {
 			o.BlueprintId = types.StringNull()

--- a/apstra/resource_datacenter_generic_system.go
+++ b/apstra/resource_datacenter_generic_system.go
@@ -14,8 +14,8 @@ import (
 var _ resource.ResourceWithConfigure = &resourceDatacenterGenericSystem{}
 
 type resourceDatacenterGenericSystem struct {
-	client   *apstra.Client
-	lockFunc func(context.Context, string) error
+	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)
+	lockFunc        func(context.Context, string) error
 }
 
 func (o *resourceDatacenterGenericSystem) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -23,7 +23,7 @@ func (o *resourceDatacenterGenericSystem) Metadata(_ context.Context, req resour
 }
 
 func (o *resourceDatacenterGenericSystem) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	o.client = ResourceGetClient(ctx, req, resp)
+	o.getBpClientFunc = ResourceGetTwoStageL3ClosClientFunc(ctx, req, resp)
 	o.lockFunc = ResourceGetBlueprintLockFunc(ctx, req, resp)
 }
 
@@ -42,14 +42,14 @@ func (o *resourceDatacenterGenericSystem) Create(ctx context.Context, req resour
 		return
 	}
 
-	// create a client for the datacenter reference design
-	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, plan.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddError(fmt.Sprintf("blueprint %s not found", plan.BlueprintId), err.Error())
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
+		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
 		return
 	}
 
@@ -108,14 +108,14 @@ func (o *resourceDatacenterGenericSystem) Read(ctx context.Context, req resource
 		return
 	}
 
-	// Create a blueprint client
-	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, state.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
+		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
 		return
 	}
 
@@ -163,10 +163,10 @@ func (o *resourceDatacenterGenericSystem) Update(ctx context.Context, req resour
 		return
 	}
 
-	// Create a blueprint client
-	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(plan.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, plan.BlueprintId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, plan.BlueprintId), err.Error())
+		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
 		return
 	}
 
@@ -211,13 +211,13 @@ func (o *resourceDatacenterGenericSystem) Delete(ctx context.Context, req resour
 		return
 	}
 
-	// Create a client for the datacenter reference design
-	bp, err := o.client.NewTwoStageL3ClosClient(ctx, apstra.ObjectId(state.BlueprintId.ValueString()))
+	// get a client for the datacenter reference design
+	bp, err := o.getBpClientFunc(ctx, state.BlueprintId.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
 			return // 404 is okay
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf(blueprint.ErrDCBlueprintCreate, state.BlueprintId), err.Error())
+		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
 		return
 	}
 


### PR DESCRIPTION
This PR adds resource client caching to the already-approved data source client caching.

PR stacking in this case to reduce the size of the review.