### PR TITLE
Improve element renaming in the `apstra_datacenter_rack` resource

### DIFF
--- a/apstra/blueprint/rack.go
+++ b/apstra/blueprint/rack.go
@@ -59,7 +59,8 @@ func (o Rack) ResourceAttributes() map[string]resourceSchema.Attribute {
 			PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 		},
 		"system_name_one_shot": resourceSchema.BoolAttribute{
-			DeprecationMessage: "Please migrate your configuration to use `rack_elements_name_one_shot`.",
+			DeprecationMessage: "The `system_name_one_shot` attribute is deprecated. Please migrate your configuration " +
+				"to use `rack_elements_name_one_shot` instead.",
 			MarkdownDescription: "Because this resource only manages the Rack, names of Systems defined within the Rack " +
 				"are not within this resource's control. When `system_name_one_shot` is `true` during initial Rack " +
 				"creation, Systems within the Rack will be renamed to match the rack's `name`. Subsequent modifications " +
@@ -128,6 +129,10 @@ func (o *Rack) setRackAndChildNames(ctx context.Context, oldName string, client 
 		In([]apstra.QEEAttribute{apstra.RelationshipTypePartOfRack.QEEAttribute()}).
 		Node([]apstra.QEEAttribute{{Key: "name", Value: apstra.QEStringVal("n_part_of_rack")}})
 
+	// The linkQuery doesn't currently catch the link between subinterfaces between an ESI access switch pair.
+	// This might be okay. The link in question doesn't seem to appear in the UI.
+	// That graph traversal might look like:
+	// node(type='system', role='access').out().node(type='interface').out().node(type='interface', if_type='subinterface').out().node(type='link', name='n_link')
 	linkQuery := new(apstra.PathQuery).
 		Node([]apstra.QEEAttribute{{Key: "name", Value: apstra.QEStringVal("n_part_of_rack")}}).
 		Out([]apstra.QEEAttribute{apstra.RelationshipTypeHostedInterfaces.QEEAttribute()}).
@@ -193,8 +198,8 @@ func (o *Rack) setRackAndChildNames(ctx context.Context, oldName string, client 
 		}
 	}
 
-	// Reduce the RackElement map to a slice.
-	// Perform string substitution to rename the nodes.
+	// Reduce the RackElement map to a slice, performing string
+	// substitution to rename the nodes as we go.
 	reSlice := make([]interface{}, len(reMap))
 	i := 0
 	for _, v := range reMap {

--- a/apstra/blueprint/rack.go
+++ b/apstra/blueprint/rack.go
@@ -2,10 +2,11 @@ package blueprint
 
 import (
 	"context"
-	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/apstra_validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -17,12 +18,13 @@ import (
 )
 
 type Rack struct {
-	Id                types.String `tfsdk:"id"`
-	BlueprintId       types.String `tfsdk:"blueprint_id"`
-	Name              types.String `tfsdk:"name"`
-	PodId             types.String `tfsdk:"pod_id"`
-	RackTypeId        types.String `tfsdk:"rack_type_id"`
-	SystemNameOneShot types.Bool   `tfsdk:"system_name_one_shot"`
+	Id                      types.String `tfsdk:"id"`
+	BlueprintId             types.String `tfsdk:"blueprint_id"`
+	Name                    types.String `tfsdk:"name"`
+	PodId                   types.String `tfsdk:"pod_id"`
+	RackTypeId              types.String `tfsdk:"rack_type_id"`
+	SystemNameOneShot       types.Bool   `tfsdk:"system_name_one_shot"`
+	RackElementsNameOneShot types.Bool   `tfsdk:"rack_elements_name_one_shot"`
 }
 
 func (o Rack) ResourceAttributes() map[string]resourceSchema.Attribute {
@@ -40,8 +42,7 @@ func (o Rack) ResourceAttributes() map[string]resourceSchema.Attribute {
 		},
 		"name": resourceSchema.StringAttribute{
 			MarkdownDescription: "Name of the Rack.",
-			Computed:            true,
-			Optional:            true,
+			Required:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"pod_id": resourceSchema.StringAttribute{
@@ -58,24 +59,54 @@ func (o Rack) ResourceAttributes() map[string]resourceSchema.Attribute {
 			PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 		},
 		"system_name_one_shot": resourceSchema.BoolAttribute{
+			DeprecationMessage: "Please migrate your configuration to use `rack_elements_name_one_shot`.",
 			MarkdownDescription: "Because this resource only manages the Rack, names of Systems defined within the Rack " +
 				"are not within this resource's control. When `system_name_one_shot` is `true` during initial Rack " +
 				"creation, Systems within the Rack will be renamed to match the rack's `name`. Subsequent modifications " +
 				"to the `name` attribute will not affect the names of those systems. It's a create-time one-shot operation.",
-			Optional:   true,
-			Validators: []validator.Bool{boolvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("name"))},
+			Optional: true,
+			Validators: []validator.Bool{
+				boolvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("name")),
+				apstravalidator.MustBeOneOf([]attr.Value{
+					types.BoolValue(true),
+					types.BoolNull(),
+				}),
+				boolvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("rack_elements_name_one_shot")),
+			},
+		},
+		"rack_elements_name_one_shot": resourceSchema.BoolAttribute{
+			MarkdownDescription: "Because this resource only manages the Rack, names of Systems and other embedded " +
+				"elements with names derived from the Rack name are not within this resource's control. When `true` " +
+				"during initial Rack creation, those elements will be renamed to match the `name` attribute. Subsequent " +
+				"modifications to the `name` attribute will not affect those elements. It's a create-time operation only.",
+			Optional: true,
+			Validators: []validator.Bool{
+				boolvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("name")),
+				apstravalidator.MustBeOneOf([]attr.Value{
+					types.BoolValue(true),
+					types.BoolNull(),
+				}),
+			},
 		},
 	}
 }
 
-func (o Rack) Request() *apstra.TwoStageL3ClosRackRequest {
+func (o *Rack) Request() *apstra.TwoStageL3ClosRackRequest {
 	return &apstra.TwoStageL3ClosRackRequest{
 		PodId:      apstra.ObjectId(o.PodId.ValueString()),
 		RackTypeId: apstra.ObjectId(o.RackTypeId.ValueString()),
 	}
 }
 
-func (o Rack) SetName(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
+func (o *Rack) SetName(ctx context.Context, oldName string, client *apstra.Client, diags *diag.Diagnostics) {
+	if oldName == "" {
+		o.setRackNameOnly(ctx, client, diags)
+	} else {
+		o.setRackAndChildNames(ctx, oldName, client, diags)
+	}
+}
+
+func (o *Rack) setRackNameOnly(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
 	// data structure to use when calling PatchNode
 	var patch struct {
 		Label string `json:"label"`
@@ -85,104 +116,190 @@ func (o Rack) SetName(ctx context.Context, client *apstra.Client, diags *diag.Di
 	err := client.PatchNode(ctx, apstra.ObjectId(o.BlueprintId.ValueString()), apstra.ObjectId(o.Id.ValueString()), &patch, nil)
 	if err != nil {
 		diags.AddError("failed to rename Rack", err.Error())
-		// do not return - we must set the state below
+		return
 	}
 }
 
-func (o Rack) SetSystemNames(ctx context.Context, client *apstra.Client, oldName string, diags *diag.Diagnostics) {
-	query := new(apstra.PathQuery).
-		SetBlueprintId(apstra.ObjectId(o.BlueprintId.ValueString())).
-		SetClient(client).
-		SetBlueprintType(apstra.BlueprintTypeStaging).
-		Node([]apstra.QEEAttribute{
-			apstra.NodeTypeRack.QEEAttribute(),
-			{Key: "id", Value: apstra.QEStringVal(o.Id.ValueString())},
-		}).
+func (o *Rack) setRackAndChildNames(ctx context.Context, oldName string, client *apstra.Client, diags *diag.Diagnostics) {
+	partOfRackQuery := new(apstra.PathQuery).
+		Node([]apstra.QEEAttribute{{Key: "id", Value: apstra.QEStringVal(o.Id.ValueString())}}).
 		In([]apstra.QEEAttribute{apstra.RelationshipTypePartOfRack.QEEAttribute()}).
+		Node([]apstra.QEEAttribute{{Key: "name", Value: apstra.QEStringVal("n_part_of_rack")}})
+
+	linkQuery := new(apstra.PathQuery).
+		Node([]apstra.QEEAttribute{{Key: "name", Value: apstra.QEStringVal("n_part_of_rack")}}).
+		Out([]apstra.QEEAttribute{apstra.RelationshipTypeHostedInterfaces.QEEAttribute()}).
+		Node([]apstra.QEEAttribute{apstra.NodeTypeInterface.QEEAttribute()}).
+		Out([]apstra.QEEAttribute{apstra.RelationshipTypeLink.QEEAttribute()}).
+		Node([]apstra.QEEAttribute{
+			apstra.NodeTypeLink.QEEAttribute(),
+			{Key: "name", Value: apstra.QEStringVal("n_link")},
+		})
+
+	serverQuery := new(apstra.PathQuery).
+		Node([]apstra.QEEAttribute{{Key: "name", Value: apstra.QEStringVal("n_link")}}).
+		In([]apstra.QEEAttribute{apstra.RelationshipTypeLink.QEEAttribute()}).
+		Node([]apstra.QEEAttribute{apstra.NodeTypeInterface.QEEAttribute()}).
+		In([]apstra.QEEAttribute{apstra.RelationshipTypeHostedInterfaces.QEEAttribute()}).
 		Node([]apstra.QEEAttribute{
 			apstra.NodeTypeSystem.QEEAttribute(),
-			{Key: "system_type", Value: apstra.QEStringVal("switch")},
-			{Key: "name", Value: apstra.QEStringVal("n_system")},
+			{Key: "system_type", Value: apstra.QEStringVal("server")},
+			{Key: "external", Value: apstra.QEBoolVal(false)},
+			{Key: "name", Value: apstra.QEStringVal("n_server")},
 		})
 
-	var response struct {
-		Items []struct {
-			System struct {
-				Id       apstra.ObjectId `json:"id"`
-				Label    string          `json:"label"`
-				Hostname string          `json:"hostname"`
-				Role     string          `json:"role"`
-			} `json:"n_system"`
-		} `json:"items"`
-	}
-
-	err := query.Do(ctx, &response)
-	if err != nil {
-		diags.AddError(fmt.Sprintf("failed querying for switches in rack %s", o.Id), err.Error())
-		return
-	}
-
-	// data structure to use when calling PatchNode
-	var patch struct {
-		Label    string `json:"label"`
-		Hostname string `json:"hostname"`
-	}
-
-	// loop over each discovered switch, set the label and hostname
-	for _, item := range response.Items {
-		patch.Label = strings.Replace(item.System.Label, oldName, o.Name.ValueString(), 1)
-		patch.Hostname = strings.Replace(strings.Replace(item.System.Label, oldName, o.Name.ValueString(), 1), "_", "-", -1)
-		err := client.PatchNode(ctx, apstra.ObjectId(o.BlueprintId.ValueString()), item.System.Id, &patch, nil)
-		if err != nil {
-			diags.AddError(fmt.Sprintf("failed to rename %s switch %s in rack %s", item.System.Role, item.System.Id, o.Id), err.Error())
-		}
-	}
-}
-
-func (o Rack) SetRedundancyGroupNames(ctx context.Context, client *apstra.Client, oldName string, diags *diag.Diagnostics) {
-	query := new(apstra.PathQuery).
+	query := new(apstra.MatchQuery).
+		SetBlueprintType(apstra.BlueprintTypeStaging).
 		SetBlueprintId(apstra.ObjectId(o.BlueprintId.ValueString())).
 		SetClient(client).
-		SetBlueprintType(apstra.BlueprintTypeStaging).
-		Node([]apstra.QEEAttribute{
-			apstra.NodeTypeRack.QEEAttribute(),
-			{Key: "id", Value: apstra.QEStringVal(o.Id.ValueString())},
-		}).
-		In([]apstra.QEEAttribute{apstra.RelationshipTypePartOfRack.QEEAttribute()}).
-		Node([]apstra.QEEAttribute{
-			apstra.NodeTypeRedundancyGroup.QEEAttribute(),
-			{Key: "name", Value: apstra.QEStringVal("n_redundancy_group")},
-		})
+		Match(partOfRackQuery).
+		Optional(new(apstra.MatchQuery).
+			Match(linkQuery).
+			Optional(serverQuery))
 
 	var response struct {
 		Items []struct {
-			RedundancyGroup struct {
-				Id    apstra.ObjectId `json:"id"`
-				Label string          `json:"label"`
-			} `json:"n_redundancy_group"`
+			PartOfRack *RackElement `json:"n_part_of_rack"`
+			Link       *RackElement `json:"n_link"`
+			Server     *RackElement `json:"n_server"`
 		} `json:"items"`
 	}
 
 	err := query.Do(ctx, &response)
 	if err != nil {
-		diags.AddError(fmt.Sprintf("failed querying for redundancy groups in rack %s", o.Id), err.Error())
-		return
+		diags.AddError("failed querying for rack elements", err.Error())
 	}
 
-	// data structure to use when calling PatchNode
-	var patch struct {
-		Label string `json:"label"`
+	reMap := make(map[apstra.ObjectId]RackElement, len(response.Items)+1)
+	reMap[apstra.ObjectId(o.Id.ValueString())] = RackElement{
+		Id:    apstra.ObjectId(o.Id.ValueString()),
+		Type:  "rack",
+		Label: oldName,
 	}
-
-	// loop over each discovered redundancy group, set the label and hostname
 	for _, item := range response.Items {
-		patch.Label = strings.Replace(item.RedundancyGroup.Label, oldName, o.Name.ValueString(), 1)
-		err := client.PatchNode(ctx, apstra.ObjectId(o.BlueprintId.ValueString()), item.RedundancyGroup.Id, &patch, nil)
-		if err != nil {
-			diags.AddError(fmt.Sprintf("failed to rename redundancy group %s in rack %s", item.RedundancyGroup.Id, o.Id), err.Error())
+		if item.PartOfRack != nil {
+			reMap[item.PartOfRack.Id] = *item.PartOfRack
+		}
+		if item.Link != nil {
+			reMap[item.Link.Id] = *item.Link
+		}
+		if item.Server != nil {
+			reMap[item.Server.Id] = *item.Server
 		}
 	}
+
+	reSlice := make([]interface{}, len(reMap))
+	i := 0
+	for _, v := range reMap {
+		v.Label = strings.Replace(v.Label, oldName, o.Name.ValueString(), -1)
+		if v.Hostname != nil {
+			hostname := strings.Replace(*v.Hostname, oldName, o.Name.ValueString(), -1)
+			v.Hostname = &hostname
+		}
+		reSlice[i] = v
+		i++
+	}
+
+	err = client.PatchNodes(ctx, apstra.ObjectId(o.BlueprintId.ValueString()), reSlice)
+	if err != nil {
+		diags.AddError("failed while renaming new rack nodes", err.Error())
+	}
 }
+
+//func (o Rack) SetSystemNames(ctx context.Context, client *apstra.Client, oldName string, diags *diag.Diagnostics) {
+//	query := new(apstra.PathQuery).
+//		SetBlueprintId(apstra.ObjectId(o.BlueprintId.ValueString())).
+//		SetClient(client).
+//		SetBlueprintType(apstra.BlueprintTypeStaging).
+//		Node([]apstra.QEEAttribute{
+//			apstra.NodeTypeRack.QEEAttribute(),
+//			{Key: "id", Value: apstra.QEStringVal(o.Id.ValueString())},
+//		}).
+//		In([]apstra.QEEAttribute{apstra.RelationshipTypePartOfRack.QEEAttribute()}).
+//		Node([]apstra.QEEAttribute{
+//			apstra.NodeTypeSystem.QEEAttribute(),
+//			{Key: "system_type", Value: apstra.QEStringVal("switch")},
+//			{Key: "name", Value: apstra.QEStringVal("n_system")},
+//		})
+//
+//	var response struct {
+//		Items []struct {
+//			System struct {
+//				Id       apstra.ObjectId `json:"id"`
+//				Label    string          `json:"label"`
+//				Hostname string          `json:"hostname"`
+//				Role     string          `json:"role"`
+//			} `json:"n_system"`
+//		} `json:"items"`
+//	}
+//
+//	err := query.Do(ctx, &response)
+//	if err != nil {
+//		diags.AddError(fmt.Sprintf("failed querying for switches in rack %s", o.Id), err.Error())
+//		return
+//	}
+//
+//	// data structure to use when calling PatchNode
+//	var patch struct {
+//		Label    string `json:"label"`
+//		Hostname string `json:"hostname"`
+//	}
+//
+//	// loop over each discovered switch, set the label and hostname
+//	for _, item := range response.Items {
+//		patch.Label = strings.Replace(item.System.Label, oldName, o.Name.ValueString(), 1)
+//		patch.Hostname = strings.Replace(strings.Replace(item.System.Label, oldName, o.Name.ValueString(), 1), "_", "-", -1)
+//		err := client.PatchNode(ctx, apstra.ObjectId(o.BlueprintId.ValueString()), item.System.Id, &patch, nil)
+//		if err != nil {
+//			diags.AddError(fmt.Sprintf("failed to rename %s switch %s in rack %s", item.System.Role, item.System.Id, o.Id), err.Error())
+//		}
+//	}
+//}
+
+//func (o Rack) SetRedundancyGroupNames(ctx context.Context, client *apstra.Client, oldName string, diags *diag.Diagnostics) {
+//	query := new(apstra.PathQuery).
+//		SetBlueprintId(apstra.ObjectId(o.BlueprintId.ValueString())).
+//		SetClient(client).
+//		SetBlueprintType(apstra.BlueprintTypeStaging).
+//		Node([]apstra.QEEAttribute{
+//			apstra.NodeTypeRack.QEEAttribute(),
+//			{Key: "id", Value: apstra.QEStringVal(o.Id.ValueString())},
+//		}).
+//		In([]apstra.QEEAttribute{apstra.RelationshipTypePartOfRack.QEEAttribute()}).
+//		Node([]apstra.QEEAttribute{
+//			apstra.NodeTypeRedundancyGroup.QEEAttribute(),
+//			{Key: "name", Value: apstra.QEStringVal("n_redundancy_group")},
+//		})
+//
+//	var response struct {
+//		Items []struct {
+//			RedundancyGroup struct {
+//				Id    apstra.ObjectId `json:"id"`
+//				Label string          `json:"label"`
+//			} `json:"n_redundancy_group"`
+//		} `json:"items"`
+//	}
+//
+//	err := query.Do(ctx, &response)
+//	if err != nil {
+//		diags.AddError(fmt.Sprintf("failed querying for redundancy groups in rack %s", o.Id), err.Error())
+//		return
+//	}
+//
+//	// data structure to use when calling PatchNode
+//	var patch struct {
+//		Label string `json:"label"`
+//	}
+//
+//	// loop over each discovered redundancy group, set the label and hostname
+//	for _, item := range response.Items {
+//		patch.Label = strings.Replace(item.RedundancyGroup.Label, oldName, o.Name.ValueString(), 1)
+//		err := client.PatchNode(ctx, apstra.ObjectId(o.BlueprintId.ValueString()), item.RedundancyGroup.Id, &patch, nil)
+//		if err != nil {
+//			diags.AddError(fmt.Sprintf("failed to rename redundancy group %s in rack %s", item.RedundancyGroup.Id, o.Id), err.Error())
+//		}
+//	}
+//}
 
 func (o *Rack) GetName(ctx context.Context, client *apstra.Client) (string, error) {
 	// struct used to collect the rack node info
@@ -197,4 +314,222 @@ func (o *Rack) GetName(ctx context.Context, client *apstra.Client) (string, erro
 	}
 
 	return node.Label, nil
+}
+
+//	func (o *Rack) getPartOfRackElements(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) map[apstra.ObjectId]RackElement {
+//		query := new(apstra.PathQuery).
+//			SetClient(client).
+//			SetBlueprintId(apstra.ObjectId(o.BlueprintId.ValueString())).
+//			SetBlueprintType(apstra.BlueprintTypeStaging).
+//			Node([]apstra.QEEAttribute{{Key: "id", Value: apstra.QEStringVal(o.Id.ValueString())}}). // rack node
+//			In([]apstra.QEEAttribute{apstra.RelationshipTypePartOfRack.QEEAttribute()}).
+//			Node([]apstra.QEEAttribute{ // switch and redundancy group nodes
+//				//apstra.NodeTypeSystem.QEEAttribute(),
+//				//{Key: "system_type", Value: apstra.QEStringVal("switch")},
+//				{Key: "name", Value: apstra.QEStringVal("n_obj")},
+//			})
+//
+//		var response struct {
+//			Items []struct {
+//				Obj RackElement `json:"n_obj"`
+//			} `json:"items"`
+//		}
+//
+//		err := query.Do(ctx, &response)
+//		if err != nil {
+//			diags.AddError(fmt.Sprintf("failed querying for switches in rack %s", o.Id), err.Error())
+//			return nil
+//		}
+//
+//		result := make(map[apstra.ObjectId]RackElement, len(response.Items))
+//		for _, item := range response.Items {
+//			result[item.Obj.Id] = item.Obj
+//		}
+//
+//		return result
+//	}
+//
+//	func (o *Rack) getAllRackElements(ctx context.Context, switchIds []string, client *apstra.Client, diags *diag.Diagnostics) map[apstra.ObjectId]RackElement {
+//		partOfRackQuery := new(apstra.PathQuery).
+//			Node([]apstra.QEEAttribute{{Key: "id", Value: apstra.QEStringVal(o.Id.ValueString())}}). // rack node
+//			In([]apstra.QEEAttribute{apstra.RelationshipTypePartOfRack.QEEAttribute()}).
+//			Node([]apstra.QEEAttribute{{Key: "name", Value: apstra.QEStringVal("n_part_of_rack")}})
+//
+//		linkQuery := new(apstra.PathQuery).
+//			Node([]apstra.QEEAttribute{{Key: "name", Value: apstra.QEStringVal("n_part_of_rack")}}).
+//			Out([]apstra.QEEAttribute{apstra.RelationshipTypeHostedInterfaces.QEEAttribute()}).
+//			Node([]apstra.QEEAttribute{apstra.NodeTypeInterface.QEEAttribute()}).
+//			Out([]apstra.QEEAttribute{apstra.RelationshipTypeLink.QEEAttribute()}).
+//			Node([]apstra.QEEAttribute{
+//				apstra.NodeTypeLink.QEEAttribute(),
+//				{Key: "name", Value: apstra.QEStringVal("n_link")},
+//			})
+//
+//		serverQuery := new(apstra.PathQuery).
+//			Node([]apstra.QEEAttribute{{Key: "name", Value: apstra.QEStringVal("n_link")}}).
+//			In([]apstra.QEEAttribute{apstra.RelationshipTypeLink.QEEAttribute()}).
+//			Node([]apstra.QEEAttribute{apstra.NodeTypeInterface.QEEAttribute()}).
+//			In([]apstra.QEEAttribute{apstra.RelationshipTypeHostedInterfaces.QEEAttribute()}).
+//			Node([]apstra.QEEAttribute{
+//				apstra.NodeTypeSystem.QEEAttribute(),
+//				{Key: "system_type", Value: apstra.QEStringVal("server")},
+//				{Key: "external", Value: apstra.QEBoolVal(false)},
+//				{Key: "name", Value: apstra.QEStringVal("n_server")},
+//			})
+//
+//		query := new(apstra.MatchQuery).
+//			Match(partOfRackQuery).
+//			Optional(new(apstra.MatchQuery).
+//				Match(linkQuery).
+//				Optional(serverQuery))
+//
+//		qString := query.String()
+//		_ = qString
+//
+//		var result struct {
+//			Items []struct {
+//				PartOfRack *RackElement `json:"n_part_of_rack"`
+//				Link       *RackElement `json:"n_link"`
+//				Server     *RackElement `json:"n_server"`
+//			} `json:"items"`
+//		}
+//
+//		err := query.Do(ctx, &result)
+//		if err != nil {
+//			diags.AddError("failed querying for rack elements", err.Error())
+//			return nil
+//		}
+//
+// }
+//
+//	func (o *Rack) GetRackElementsIdsAndLabels(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) []RackElement {
+//		// partsOfRack are RackElements discovered using 'part_of_rack' graph relationship.
+//		// They include leaf switches, access switches, and leaf/access redundancy groups,
+//		// each of which need to be re-labeled to match the rack name.
+//		result := o.getPartOfRackElements(ctx, client, diags)
+//		if diags.HasError() {
+//			return nil
+//		}
+//
+//		// partOfRackIds are used for tracking down links and servers
+//		partOfRackIds := make([]string, len(result))
+//		i := 0
+//		for _, partOfRack := range result {
+//			partOfRackIds[i] = partOfRack.Id.String()
+//			i++
+//		}
+//
+//		// we want links from leaf/access systems (Ethernet and LAG) and from redundancy groups (MLAG)
+//		links := o.getLinkRackElements(ctx, switchIds, client, diags)
+//		if diags.HasError() {
+//			return nil
+//		}
+//
+//		maps.Copy(result, links) // add links to the result map
+//
+//		for id, link := range links {
+//
+//		}
+//
+//		for i := len(links) - 1; i >= 0; i-- {
+//			if !ids[links[i].Id] {
+//				// this is a new ID; add it to the list
+//				ids[links[i].Id] = true
+//				continue
+//			}
+//
+//			// this id has been seen previously; remove it from the slice
+//			links[i] = links[len(links)-1]
+//			links = links[:len(links)-1]
+//		}
+//
+//		response := make([]RackElement, len(rPartOfRack.Items))
+//		for i, item := range rPartOfRack.Items {
+//			response[i] = item.Obj
+//			ids[item.Obj.Id] = true
+//		}
+//
+//		for _, node := range response {
+//			if node.Type != "system" {
+//				continue // we're looking only for leaf/access at this stage
+//			}
+//
+//			qLink := new(apstra.PathQuery).
+//				SetClient(client).
+//				SetBlueprintId(apstra.ObjectId(o.BlueprintId.ValueString())).
+//				SetBlueprintType(apstra.BlueprintTypeStaging).
+//				Node([]apstra.QEEAttribute{{Key: "id", Value: apstra.QEStringVal(node.Id.String())}}).
+//				Node([]apstra.QEEAttribute{{Key: "id", Value: apstra.QEStringVal(node.Id.String())}}).
+//				Out([]apstra.QEEAttribute{apstra.RelationshipTypeHostedInterfaces.QEEAttribute()}).
+//				Node([]apstra.QEEAttribute{apstra.NodeTypeInterface.QEEAttribute()}).
+//				Out([]apstra.QEEAttribute{apstra.RelationshipTypeLink.QEEAttribute()}).
+//				Node([]apstra.QEEAttribute{
+//					apstra.NodeTypeLink.QEEAttribute(),
+//					{Key: "name", Value: apstra.QEStringVal("n_link")},
+//				})
+//
+//			var rLink struct {
+//				Items []struct {
+//					Link RackElement `json:"n_link"`
+//				} `json:"items"`
+//			}
+//
+//			err = qLink.Do(ctx, &rLink)
+//			if err != nil {
+//				diags.AddError(fmt.Sprintf("failed querying for links from node %s", node.Id), err.Error())
+//				return nil
+//			}
+//
+//			// add discovered links to the response
+//			for _, item := range rLink.Items {
+//				if ids[item.Link.Id] {
+//					continue
+//				}
+//
+//				response = append(response, item.Link)
+//				ids[item.Link.Id] = true
+//			}
+//
+//			qGeneric := qLink.
+//				In([]apstra.QEEAttribute{apstra.RelationshipTypeLink.QEEAttribute()}).
+//				Node([]apstra.QEEAttribute{apstra.NodeTypeInterface.QEEAttribute()}).
+//				In([]apstra.QEEAttribute{apstra.RelationshipTypeHostedInterfaces.QEEAttribute()}).
+//				Node([]apstra.QEEAttribute{
+//					apstra.NodeTypeSystem.QEEAttribute(),
+//					{Key: "system_type", Value: apstra.QEStringVal("server")},
+//					{Key: "role", Value: apstra.QEStringVal("generic")},
+//					{Key: "external", Value: apstra.QEBoolVal(false)},
+//					{Key: "name", Value: apstra.QEStringVal("n_generic")},
+//				})
+//
+//			var rGeneric struct {
+//				Items []struct {
+//					Link RackElement `json:"n_generic"`
+//				} `json:"items"`
+//			}
+//
+//			err = qLink.Do(ctx, &rGeneric)
+//			if err != nil {
+//				diags.AddError(fmt.Sprintf("failed querying for servers from node %s", node.Id), err.Error())
+//				return nil
+//			}
+//
+//			for _, item := range qResponse.Items {
+//				if ids[item.Id] {
+//					continue
+//				}
+//
+//				response = append(response, item)
+//				ids[item.Id] = true
+//			}
+//
+//		}
+//
+//		return response
+//	}
+type RackElement struct {
+	Id       apstra.ObjectId `json:"id"`
+	Type     string          `json:"type,omitempty"`
+	Label    string          `json:"label"`
+	Hostname *string         `json:"hostname,omitempty"`
 }

--- a/apstra/resource_datacenter_rack.go
+++ b/apstra/resource_datacenter_rack.go
@@ -85,7 +85,9 @@ func (o *resourceDatacenterRack) Create(ctx context.Context, req resource.Create
 	if plan.SystemNameOneShot.ValueBool() || plan.RackElementsNameOneShot.ValueBool() {
 		oldName, err = plan.GetName(ctx, bp.Client())
 		if err != nil {
-			resp.Diagnostics.AddError("failed to fetch rack name", err.Error())
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("failed to fetch apstra-selected name of just-created rack %s", plan.Id),
+				err.Error())
 			return
 		}
 	}

--- a/apstra/resource_datacenter_rack.go
+++ b/apstra/resource_datacenter_rack.go
@@ -62,46 +62,39 @@ func (o *resourceDatacenterRack) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	// create the rack and squirrel away the rack ID
+	// create the rack
 	id, err := bp.CreateRack(ctx, plan.Request())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create Datacenter Rack", err.Error())
 		return
 	}
-	plan.Id = types.StringValue(id.String())
 
-	// fetch the rack name chosen by Apstra
-	oldName, err := plan.GetName(ctx, bp.Client())
-	if err != nil {
-		resp.Diagnostics.AddError("failed to fetch rack name", err.Error())
-		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	// record the new rack ID and set tentative state
+	plan.Id = types.StringValue(id.String())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Name is optional. Did the user supply one?
-	if plan.Name.IsUnknown() {
-		// no user supplied name.
-		// save the apstra-generated name
-		plan.Name = types.StringValue(oldName)
-	} else {
-		// user has provided a name.
-		// set the rack name
-		plan.SetName(ctx, bp.Client(), &resp.Diagnostics)
-		if resp.Diagnostics.HasError() {
-			resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	// oldName is used to trigger one-shot rename of rack elements:
+	// - empty string: only the rack is re-named
+	// - non-empty string: the rack and elements within the rack are renamed
+	var oldName string
+
+	// did the user request one-shot rename of elements within the rack?
+	if plan.SystemNameOneShot.ValueBool() || plan.RackElementsNameOneShot.ValueBool() {
+		oldName, err = plan.GetName(ctx, bp.Client())
+		if err != nil {
+			resp.Diagnostics.AddError("failed to fetch rack name", err.Error())
 			return
 		}
+	}
 
-		// one-shot rename objects in the rack. "oldName" is used as the original
-		// value in a substring replace operation.
-		if plan.SystemNameOneShot.ValueBool() {
-			plan.SetSystemNames(ctx, bp.Client(), oldName, &resp.Diagnostics)
-			plan.SetRedundancyGroupNames(ctx, bp.Client(), oldName, &resp.Diagnostics)
-			if resp.Diagnostics.HasError() {
-				resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-				return
-			}
-		}
+	// set the rack name
+	plan.SetName(ctx, oldName, bp.Client(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+		return
 	}
 
 	//set the state.
@@ -135,7 +128,7 @@ func (o *resourceDatacenterRack) Read(ctx context.Context, req resource.ReadRequ
 			return
 		}
 
-		resp.Diagnostics.AddError("failed to fetch rack name", err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to fetch name of rack %s", state.Id), err.Error())
 		return
 	}
 
@@ -168,7 +161,7 @@ func (o *resourceDatacenterRack) Update(ctx context.Context, req resource.Update
 
 	// update the name if necessary
 	if !plan.Name.Equal(state.Name) {
-		plan.SetName(ctx, bp.Client(), &resp.Diagnostics)
+		plan.SetName(ctx, "", bp.Client(), &resp.Diagnostics)
 	}
 
 	// Set state

--- a/docs/resources/datacenter_rack.md
+++ b/docs/resources/datacenter_rack.md
@@ -29,13 +29,14 @@ resource "apstra_datacenter_rack" "r" {
 ### Required
 
 - `blueprint_id` (String) Apstra ID of the Blueprint where the Rack should be created.
+- `name` (String) Name of the Rack.
 - `rack_type_id` (String) ID of the Global Catalog Rack Type design object to use as a template for this Rack.
 
 ### Optional
 
-- `name` (String) Name of the Rack.
 - `pod_id` (String) Graph node ID of Pod (3-stage topology) where the new rack should be created. Required only in Pod-Based (5-stage) Blueprints.
-- `system_name_one_shot` (Boolean) Because this resource only manages the Rack, names of Systems defined within the Rack are not within this resource's control. When `system_name_one_shot` is `true` during initial Rack creation, Systems within the Rack will be renamed to match the rack's `name`. Subsequent modifications to the `name` attribute will not affect the names of those systems. It's a create-time one-shot operation.
+- `rack_elements_name_one_shot` (Boolean) Because this resource only manages the Rack, names of Systems and other embedded elements with names derived from the Rack name are not within this resource's control. When `true` during initial Rack creation, those elements will be renamed to match the `name` attribute. Subsequent changes to the `name` attribute will not affect those elements. It's a create-time operation only.
+- `system_name_one_shot` (Boolean, Deprecated) Because this resource only manages the Rack, names of Systems defined within the Rack are not within this resource's control. When `system_name_one_shot` is `true` during initial Rack creation, Systems within the Rack will be renamed to match the rack's `name`. Subsequent modifications to the `name` attribute will not affect the names of those systems. It's a create-time one-shot operation.
 
 ### Read-Only
 


### PR DESCRIPTION
First cut at `apstra_datacenter_rack` had the option to rename systems (leaf/access/generic) within a rack.

It turns out we missed other elements which should also have been renamed:
- links
- redundancy groups

Also, renaming was done by invoking the node patch API method for each rack element. This was slow.

This PR addresses those issues by using a different strategy to identify rack elements, using a new batch-mode node patching strategy to speed things up, and renaming the "one_shot" configuration boolean from `system_name_one_shot` to `rack_elements_name_one_shot` to better indicate the scope of the one shot renaming.

`system_name_one_shot` is still available for use, but marked as deprecated.

Known issue:

There's a logical link between subinterfaces of an ESI access switch pair. This link is not matched by the graph query used for re-labeling, so it retains the original name selected by Apstra. This link does not appear in the web UI, so it doesn't seem to be a problem.