### PR TITLE
Add `l3_mtu` attribute to `apstra_datacenter_virtual_network` resource

### DIFF
--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -808,8 +808,9 @@ func (o *DatacenterVirtualNetwork) CompatibilityCheckAsResource(_ context.Contex
 		return
 	}
 
-	if !o.L3Mtu.IsNull() && compatibility.MinVerForVnL3Mtu().GreaterThan(apstraVersion) {
+	if utils.Known(o.L3Mtu) && compatibility.MinVerForVnL3Mtu().GreaterThan(apstraVersion) {
 		diags.AddAttributeError(path.Root("l3_mtu"), errApiCompatibility,
-			"The `l3_mtu` attribute is applicable to Apstra %s and later only.")
+			fmt.Sprintf("The `l3_mtu` attribute is applicable to Apstra %s and later only.",
+				compatibility.MinVerForVnL3Mtu().Original()))
 	}
 }

--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/apstra_validator"
+	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/design"
 	"github.com/Juniper/terraform-provider-apstra/apstra/resources"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -46,6 +48,7 @@ type DatacenterVirtualNetwork struct {
 	IPv6GatewayEnabled      types.Bool   `tfsdk:"ipv6_virtual_gateway_enabled"`
 	IPv4Gateway             types.String `tfsdk:"ipv4_virtual_gateway"`
 	IPv6Gateway             types.String `tfsdk:"ipv6_virtual_gateway"`
+	L3Mtu                   types.Int64  `tfsdk:"l3_mtu"`
 }
 
 func (o DatacenterVirtualNetwork) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
@@ -146,6 +149,11 @@ func (o DatacenterVirtualNetwork) DataSourceAttributes() map[string]dataSourceSc
 				"for mechanisms which rely on string matching.",
 			Computed: true,
 		},
+		"l3_mtu": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "L3 MTU used by the L3 switch interfaces participating in this Virtual Network. " +
+				"Requires Apstra 4.2 or later.",
+			Computed: true,
+		},
 	}
 }
 
@@ -240,6 +248,11 @@ func (o DatacenterVirtualNetwork) DataSourceFilterAttributes() map[string]dataSo
 				"for mechanisms which rely on string matching.",
 			Optional:   true,
 			Validators: []validator.String{apstravalidator.ParseIp(false, true)},
+		},
+		"l3_mtu": dataSourceSchema.Int64Attribute{
+			MarkdownDescription: "L3 MTU used by the L3 switch interfaces participating in this Virtual Network. " +
+				"Requires Apstra 4.2 or later.",
+			Optional: true,
 		},
 	}
 }
@@ -468,6 +481,15 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 					true, true),
 			},
 		},
+		"l3_mtu": resourceSchema.Int64Attribute{
+			MarkdownDescription: "L3 MTU used by the L3 switch interfaces participating in this Virtual Network",
+			Optional:            true,
+			Computed:            true,
+			Validators: []validator.Int64{
+				int64validator.Between(1280, 9216),
+				apstravalidator.MustBeEvenOrOdd(true),
+			},
+		},
 	}
 }
 
@@ -538,12 +560,19 @@ func (o *DatacenterVirtualNetwork) Request(ctx context.Context, diags *diag.Diag
 		ipv6Gateway = net.ParseIP(o.IPv6Gateway.ValueString())
 	}
 
+	var l3Mtu *int
+	if utils.Known(o.L3Mtu) {
+		i := int(o.L3Mtu.ValueInt64())
+		l3Mtu = &i
+	}
+
 	return &apstra.VirtualNetworkData{
 		DhcpService:               apstra.DhcpServiceEnabled(o.DhcpServiceEnabled.ValueBool()),
 		Ipv4Enabled:               o.IPv4ConnectivityEnabled.ValueBool(),
 		Ipv4Subnet:                ipv4Subnet,
 		Ipv6Enabled:               o.IPv6ConnectivityEnabled.ValueBool(),
 		Ipv6Subnet:                ipv6Subnet,
+		L3Mtu:                     l3Mtu,
 		Label:                     o.Name.ValueString(),
 		ReservedVlanId:            reservedVlanId,
 		RouteTarget:               "",
@@ -609,6 +638,7 @@ func (o *DatacenterVirtualNetwork) LoadApiData(ctx context.Context, in *apstra.V
 	o.IPv6GatewayEnabled = types.BoolValue(in.VirtualGatewayIpv6Enabled)
 	o.IPv4Gateway = utils.StringValueOrNull(ctx, virtualGatewayIpv4, diags)
 	o.IPv6Gateway = utils.StringValueOrNull(ctx, virtualGatewayIpv6, diags)
+	o.L3Mtu = utils.Int64ValueOrNull(ctx, in.L3Mtu, diags)
 }
 
 func (o *DatacenterVirtualNetwork) Query(vnResultName string) apstra.QEQuery {
@@ -690,6 +720,13 @@ func (o *DatacenterVirtualNetwork) Query(vnResultName string) apstra.QEQuery {
 		})
 	}
 
+	if !o.L3Mtu.IsNull() {
+		nodeAttributes = append(nodeAttributes, apstra.QEEAttribute{
+			Key:   "l3_mtu",
+			Value: apstra.QEIntVal(o.L3Mtu.ValueInt64()),
+		})
+	}
+
 	// not handling ipv6 gateway as a string match because of '::' expansion weirdness
 	//if !o.IPv6Gateway.IsNull() { nope! }
 
@@ -744,4 +781,34 @@ func (o *DatacenterVirtualNetwork) Ipv6Gateway(_ context.Context, _ path.Path, _
 	}
 
 	return net.ParseIP(o.IPv6Gateway.ValueString())
+}
+
+func (o *DatacenterVirtualNetwork) CompatibilityCheckAsFilter(_ context.Context, path path.Path, client *apstra.Client, diags *diag.Diagnostics) {
+	apstraVersion, err := version.NewVersion(client.ApiVersion())
+	if err != nil {
+		diags.AddError(fmt.Sprintf("failed parsing Apstra API version %q", apstraVersion), err.Error())
+		return
+	}
+
+	if !o.L3Mtu.IsNull() && compatibility.MinVerForVnL3Mtu().GreaterThan(apstraVersion) {
+		diags.AddAttributeWarning(
+			path.AtName("l3_mtu"),
+			errApiCompatibility,
+			fmt.Sprintf("The `l3_mtu` attribute is applicable to Apstra %s and later only.\n\n"+
+				"Using `l3_mtu` with Apstra %s will cause this filter to match zero Virtual Networks.",
+				compatibility.MinVerForVnL3Mtu().Original(), apstraVersion))
+	}
+}
+
+func (o *DatacenterVirtualNetwork) CompatibilityCheckAsResource(_ context.Context, client *apstra.Client, diags *diag.Diagnostics) {
+	apstraVersion, err := version.NewVersion(client.ApiVersion())
+	if err != nil {
+		diags.AddError(fmt.Sprintf("failed parsing Apstra API version %q", apstraVersion), err.Error())
+		return
+	}
+
+	if !o.L3Mtu.IsNull() && compatibility.MinVerForVnL3Mtu().GreaterThan(apstraVersion) {
+		diags.AddAttributeError(path.Root("l3_mtu"), errApiCompatibility,
+			"The `l3_mtu` attribute is applicable to Apstra %s and later only.")
+	}
 }

--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -150,7 +150,7 @@ func (o DatacenterVirtualNetwork) DataSourceAttributes() map[string]dataSourceSc
 			Computed: true,
 		},
 		"l3_mtu": dataSourceSchema.Int64Attribute{
-			MarkdownDescription: "L3 MTU used by the L3 switch interfaces participating in this Virtual Network. " +
+			MarkdownDescription: "L3 MTU used by the L3 switch interfaces participating in the Virtual Network. " +
 				"Requires Apstra 4.2 or later.",
 			Computed: true,
 		},
@@ -250,7 +250,7 @@ func (o DatacenterVirtualNetwork) DataSourceFilterAttributes() map[string]dataSo
 			Validators: []validator.String{apstravalidator.ParseIp(false, true)},
 		},
 		"l3_mtu": dataSourceSchema.Int64Attribute{
-			MarkdownDescription: "L3 MTU used by the L3 switch interfaces participating in this Virtual Network. " +
+			MarkdownDescription: "L3 MTU used by the L3 switch interfaces participating in the Virtual Network. " +
 				"Requires Apstra 4.2 or later.",
 			Optional: true,
 		},
@@ -482,9 +482,10 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 			},
 		},
 		"l3_mtu": resourceSchema.Int64Attribute{
-			MarkdownDescription: "L3 MTU used by the L3 switch interfaces participating in this Virtual Network",
-			Optional:            true,
-			Computed:            true,
+			MarkdownDescription: "L3 MTU used by the L3 switch interfaces participating in the Virtual Network. " +
+				"Requires Apstra 4.2 or later.",
+			Optional: true,
+			Computed: true,
 			Validators: []validator.Int64{
 				int64validator.Between(1280, 9216),
 				apstravalidator.MustBeEvenOrOdd(true),

--- a/apstra/compatibility/api_versions.go
+++ b/apstra/compatibility/api_versions.go
@@ -2,8 +2,18 @@ package compatibility
 
 import (
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/hashicorp/go-version"
 	"strings"
 )
+
+const (
+	minVerForVnL3Mtu = "4.2.0"
+)
+
+func MinVerForVnL3Mtu() *version.Version {
+	v, _ := version.NewVersion(minVerForVnL3Mtu) // this will not error
+	return v
+}
 
 func SupportedApiVersions() []string {
 	us := []string{

--- a/apstra/resource_datacenter_virtual_network.go
+++ b/apstra/resource_datacenter_virtual_network.go
@@ -188,6 +188,12 @@ func (o *resourceDatacenterVirtualNetwork) Create(ctx context.Context, req resou
 		return
 	}
 
+	// check the configuration against the apstra api version
+	plan.CompatibilityCheckAsResource(ctx, bp.Client(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Lock the blueprint mutex.
 	err = o.lockFunc(ctx, plan.BlueprintId.ValueString())
 	if err != nil {
@@ -323,6 +329,12 @@ func (o *resourceDatacenterVirtualNetwork) Update(ctx context.Context, req resou
 	bp, err := o.getBpClientFunc(ctx, plan.BlueprintId.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
+		return
+	}
+
+	// check the configuration against the apstra api version
+	plan.CompatibilityCheckAsResource(ctx, bp.Client(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/apstra/resource_datacenter_virtual_network_test.go
+++ b/apstra/resource_datacenter_virtual_network_test.go
@@ -71,14 +71,6 @@ func TestAccDatacenterVirtualNetwork_A(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// l2_one_access_001_leaf1	l2_one_access_001_access1
-	// l2_one_access_002_leaf1	l2_one_access_002_access1
-	// l2_one_access_003_leaf1	l2_one_access_002_access1
-	// l2_esi_acs_dual_001_leaf1	l2_esi_acs_dual_001_access1
-	// l2_esi_acs_dual_001_leaf2	l2_esi_acs_dual_001_access2
-	// l2_esi_acs_dual_002_leaf1	l2_esi_acs_dual_002_access1	l2_esi_acs_dual_002_access_pair1
-	// l2_esi_acs_dual_002_leaf2	l2_esi_acs_dual_002_access2
-
 	labelToNodeId := make(map[string]string)
 	for k, v := range systemNodesResponse.Nodes {
 		labelToNodeId[v.Label] = k

--- a/docs/data-sources/datacenter_virtual_network.md
+++ b/docs/data-sources/datacenter_virtual_network.md
@@ -53,6 +53,7 @@ locals {
 - `ipv6_subnet` (String) IPv6 subnet associated with the Virtual Network. Note that this attribute will not appear in the `graph_query` output because IPv6 zero compression rules are problematic for mechanisms which rely on string matching.
 - `ipv6_virtual_gateway` (String) Specifies the IPv6 virtual gateway address within the Virtual Network. Note that this attribute will not appear in the `graph_query` output because IPv6 zero compression rules are problematic for mechanisms which rely on string matching.
 - `ipv6_virtual_gateway_enabled` (Boolean) Controls and indicates whether the IPv6 gateway within the Virtual Network is enabled.
+- `l3_mtu` (Number) L3 MTU used by the L3 switch interfaces participating in the Virtual Network. Requires Apstra 4.2 or later.
 - `reserve_vlan` (Boolean) For use only with `vxlan` type Virtual networks when all `bindings` use the same VLAN ID. This option reserves the VLAN fabric-wide, even on switches to which the Virtual Network has not yet been deployed.
 - `routing_zone_id` (String) Routing Zone ID (only applies when `type == vxlan`
 - `type` (String) Virtual Network Type

--- a/docs/data-sources/datacenter_virtual_networks.md
+++ b/docs/data-sources/datacenter_virtual_networks.md
@@ -73,6 +73,7 @@ Optional:
 - `ipv6_subnet` (String) IPv6 subnet associated with the Virtual Network. Note that this attribute will not appear in the `graph_query` output because IPv6 zero compression rules are problematic for mechanisms which rely on string matching.
 - `ipv6_virtual_gateway` (String) Specifies the IPv6 virtual gateway address within the Virtual Network. Note that this attribute will not appear in the `graph_query` output because IPv6 zero compression rules are problematic for mechanisms which rely on string matching.
 - `ipv6_virtual_gateway_enabled` (Boolean) Controls and indicates whether the IPv6 gateway within the Virtual Network is enabled.
+- `l3_mtu` (Number) L3 MTU used by the L3 switch interfaces participating in the Virtual Network. Requires Apstra 4.2 or later.
 - `name` (String) Virtual Network Name
 - `reserve_vlan` (Boolean) For use only with `vxlan` type Virtual networks when all `bindings` use the same VLAN ID. This option reserves the VLAN fabric-wide, even on switches to which the Virtual Network has not yet been deployed.
 - `routing_zone_id` (String) Routing Zone ID (required when `type == vxlan`)
@@ -105,6 +106,7 @@ Optional:
 - `ipv6_subnet` (String) IPv6 subnet associated with the Virtual Network. Note that this attribute will not appear in the `graph_query` output because IPv6 zero compression rules are problematic for mechanisms which rely on string matching.
 - `ipv6_virtual_gateway` (String) Specifies the IPv6 virtual gateway address within the Virtual Network. Note that this attribute will not appear in the `graph_query` output because IPv6 zero compression rules are problematic for mechanisms which rely on string matching.
 - `ipv6_virtual_gateway_enabled` (Boolean) Controls and indicates whether the IPv6 gateway within the Virtual Network is enabled.
+- `l3_mtu` (Number) L3 MTU used by the L3 switch interfaces participating in the Virtual Network. Requires Apstra 4.2 or later.
 - `name` (String) Virtual Network Name
 - `reserve_vlan` (Boolean) For use only with `vxlan` type Virtual networks when all `bindings` use the same VLAN ID. This option reserves the VLAN fabric-wide, even on switches to which the Virtual Network has not yet been deployed.
 - `routing_zone_id` (String) Routing Zone ID (required when `type == vxlan`)

--- a/docs/resources/datacenter_virtual_network.md
+++ b/docs/resources/datacenter_virtual_network.md
@@ -65,6 +65,7 @@ resource "apstra_datacenter_virtual_network" "test" {
 - `ipv6_subnet` (String) IPv6 subnet associated with the Virtual Network. When not specified, a prefix from within the IPv6 Resource Pool assigned to the `virtual_network_svi_subnets_ipv6` role will be automatically assigned by Apstra.
 - `ipv6_virtual_gateway` (String) Specifies the IPv6 virtual gateway address within the Virtual Network. The configured value must be a valid IPv6 host address configured value within range specified by `ipv6_subnet`
 - `ipv6_virtual_gateway_enabled` (Boolean) Controls and indicates whether the IPv6 gateway within the Virtual Network is enabled. Requires `ipv6_connectivity_enabled` to be `true`
+- `l3_mtu` (Number) L3 MTU used by the L3 switch interfaces participating in the Virtual Network. Requires Apstra 4.2 or later.
 - `reserve_vlan` (Boolean) For use only with `vxlan` type Virtual networks when all `bindings` use the same VLAN ID. This option reserves the VLAN fabric-wide, even on switches to which the Virtual Network has not yet been deployed. The only accepted values is `true`.
 - `routing_zone_id` (String) Routing Zone ID (required when `type == vxlan`
 - `type` (String) Virtual Network Type

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20231229161545-ca8623cc9aa4
+	github.com/Juniper/apstra-go-sdk v0.0.0-20240104231850-cd09357bdbab
 	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20231229161545-ca8623cc9aa4 h1:dX4lC5iVj1pGLMK/+8HRBbUHlK2TNoS4FVHvdgw96HY=
-github.com/Juniper/apstra-go-sdk v0.0.0-20231229161545-ca8623cc9aa4/go.mod h1:jTSCBZBFRT5o3UZku3eO1mHA7BxBrDn498QT27IPQJ8=
+github.com/Juniper/apstra-go-sdk v0.0.0-20240104231850-cd09357bdbab h1:YgGfZhkL5gdXJp7iefksT6NNMnerkTZ2jW5ehYm6hZ0=
+github.com/Juniper/apstra-go-sdk v0.0.0-20240104231850-cd09357bdbab/go.mod h1:jTSCBZBFRT5o3UZku3eO1mHA7BxBrDn498QT27IPQJ8=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=


### PR DESCRIPTION
This PR adds the following element to the `DatacenterVirtualNetwork` terraform model struct:

```go
L3Mtu types.Int64 `tfsdk:"l3_mtu"`
```

That new struct element introduces the `l3_mtu` attribute to each of these:
- `apstra_datacenter_virtual_network` resource
- `apstra_datacenter_virtual_network` data source
- `apstra_datacenter_virtual_networks` data source (as a filter) 

Control of L3 MTU via `/api/blueprints/{blueprint_id}/virtual-networks` and `/api/blueprints/{blueprint_id}/virtual-networks/{vn_id}` is only supported in Apstra 4.2.0 and later. The following table outlines the expected terraform behavior in each scenario:

| Apstra version | use case | behavior | notes |
| --- | --- | --- | --- |
| <4.2.0 | resource `apstra_datacenter_virtual_network` | computed optional | error in apply phase when configured value not `null`; always computes to `null` |
| <4.2.0 | data `apstra_datacenter_virtual_network` | computed | always `null` |
| <4.2.0 | data `apstra_datacenter_virtual_networks` (used as filter) | optional | warn that filter will never match when not `null` |
| >=4.2.0 | resource `apstra_datacenter_virtual_network` | computed optional | sets and computes normally |
| >=4.2.0 | data `apstra_datacenter_virtual_network` | computed | always reports VN attribute value |
| >=4.2.0 | data `apstra_datacenter_virtual_networks` (used as filter) | optional | filters VNs via graph query |

Closes #499