### PR TITLE
Fix 404 handling for an easier developer experience

### DIFF
--- a/apstra/data_source_datacenter_external_gateway.go
+++ b/apstra/data_source_datacenter_external_gateway.go
@@ -51,7 +51,23 @@ func (o *dataSourceDatacenterExternalGateway) Read(ctx context.Context, req data
 		return
 	}
 
-	config.Read(ctx, bp, &resp.Diagnostics)
+	err = config.Read(ctx, bp, &resp.Diagnostics)
+	if err != nil {
+		if utils.IsApstra404(err) {
+			switch config.Id.IsNull() {
+			case true:
+				resp.Diagnostics.AddError(
+					"External Gateway not found",
+					fmt.Sprintf("Blueprint %q External Gateway with Name %s not found", bp.Id(), config.Name))
+			case false:
+				resp.Diagnostics.AddError(
+					"External Gateway not found",
+					fmt.Sprintf("Blueprint %q External Gateway with ID %s not found", bp.Id(), config.Id))
+			}
+			return
+		}
+		resp.Diagnostics.AddError("Failed to fetch External Gateway", err.Error())
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/apstra/resource_datacenter_external_gateway.go
+++ b/apstra/resource_datacenter_external_gateway.go
@@ -77,7 +77,17 @@ func (o *resourceDatacenterExternalGateway) ImportState(ctx context.Context, req
 		return
 	}
 
-	state.Read(ctx, bp, &resp.Diagnostics)
+	err = state.Read(ctx, bp, &resp.Diagnostics)
+	if err != nil {
+		if utils.IsApstra404(err) {
+			resp.Diagnostics.AddError(
+				"External Gateway not found",
+				fmt.Sprintf("Blueprint %q External Gateway with ID %s not found", bp.Id(), state.Id))
+			return
+		}
+		resp.Diagnostics.AddError("Failed to fetch External Gateway", err.Error())
+		return
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -125,7 +135,10 @@ func (o *resourceDatacenterExternalGateway) Create(ctx context.Context, req reso
 	}
 
 	plan.Id = types.StringValue(id.String())
-	plan.Read(ctx, bp, &resp.Diagnostics)
+	err = plan.Read(ctx, bp, &resp.Diagnostics)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to fetch just created External Gateway", err.Error())
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -152,7 +165,14 @@ func (o *resourceDatacenterExternalGateway) Read(ctx context.Context, req resour
 		return
 	}
 
-	state.Read(ctx, bp, &resp.Diagnostics)
+	err = state.Read(ctx, bp, &resp.Diagnostics)
+	if err != nil {
+		if utils.IsApstra404(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Failed to fetch External Gateway", err.Error())
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -195,7 +215,10 @@ func (o *resourceDatacenterExternalGateway) Update(ctx context.Context, req reso
 		return
 	}
 
-	plan.Read(ctx, bp, &resp.Diagnostics)
+	err = plan.Read(ctx, bp, &resp.Diagnostics)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to fetch just updated External Gateway", err.Error())
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
This PR fixes a problem introduced by moving `Read()` logic out of resource/datasource methods and into a method on the model struct (prompted by code re-use for supporting resource import).

Prior to this change, 404 handling was performed in the new `<model>.Read()` method.

The problem with this approach is that some callers of `<model>.Read()` want to produce a diagnostic event in the case of 404, while others want to trigger resource re-creation.

The `<model>.Read()` now returns `error` allowing various callers to handle 404s however is appropriate for their logic.

Closes #507