### PR TITLE
Use rosetta for security policy protocol strings

### DIFF
--- a/apstra/blueprint/datacenter_security_policy_rule.go
+++ b/apstra/blueprint/datacenter_security_policy_rule.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"strings"
 )
 
 type DatacenterSecurityPolicyRule struct {
@@ -49,7 +51,7 @@ func (o DatacenterSecurityPolicyRule) DataSourceAttributes() map[string]dataSour
 			Computed:            true,
 		},
 		"protocol": dataSourceSchema.StringAttribute{
-			MarkdownDescription: fmt.Sprintf("Security Policy Rule Protocol; one of: %s", apstra.PolicyRuleProtocols),
+			MarkdownDescription: fmt.Sprintf("Security Policy Rule Protocol; one of: %s", strings.ToLower(fmt.Sprint(apstra.PolicyRuleProtocols))),
 			Computed:            true,
 		},
 		"action": dataSourceSchema.StringAttribute{
@@ -58,8 +60,10 @@ func (o DatacenterSecurityPolicyRule) DataSourceAttributes() map[string]dataSour
 		},
 		"source_ports": dataSourceSchema.SetNestedAttribute{
 			MarkdownDescription: fmt.Sprintf("Set of TCP/UDP source ports matched by this rule. A `null` "+
-				"set matches any port. Applies only when `protocol` is %s or %s.",
-				apstra.PolicyRuleProtocolTcp, apstra.PolicyRuleProtocolUdp),
+				"set matches any port. Applies only when `protocol` is `%s` or `%s`.",
+				utils.StringersToFriendlyString(apstra.PolicyRuleProtocolTcp),
+				utils.StringersToFriendlyString(apstra.PolicyRuleProtocolUdp),
+			),
 			Computed: true,
 			NestedObject: dataSourceSchema.NestedAttributeObject{
 				Attributes: DatacenterSecurityPolicyRulePortRange{}.DataSourceAttributes(),
@@ -67,8 +71,10 @@ func (o DatacenterSecurityPolicyRule) DataSourceAttributes() map[string]dataSour
 		},
 		"destination_ports": dataSourceSchema.SetNestedAttribute{
 			MarkdownDescription: fmt.Sprintf("Set of TCP/UDP destination ports matched by this rule. A `null` "+
-				"set matches any port. Applies only when `protocol` is %s or %s.",
-				apstra.PolicyRuleProtocolTcp, apstra.PolicyRuleProtocolUdp),
+				"set matches any port. Applies only when `protocol` is `%s` or `%s`.",
+				utils.StringersToFriendlyString(apstra.PolicyRuleProtocolTcp),
+				utils.StringersToFriendlyString(apstra.PolicyRuleProtocolUdp),
+			),
 			Computed: true,
 			NestedObject: dataSourceSchema.NestedAttributeObject{
 				Attributes: DatacenterSecurityPolicyRulePortRange{}.DataSourceAttributes(),
@@ -142,7 +148,7 @@ func (o *DatacenterSecurityPolicyRule) loadApiData(ctx context.Context, in *apst
 
 	o.Name = types.StringValue(in.Label)
 	o.Description = types.StringValue(in.Description)
-	o.Protocol = types.StringValue(in.Protocol.Value)
+	o.Protocol = types.StringValue(utils.StringersToFriendlyString(in.Protocol))
 	o.Action = types.StringValue(in.Action.Value)
 	o.SrcPorts = newDatacenterPolicyRulePortRangeSet(ctx, in.SrcPort, diags)
 	o.DstPorts = newDatacenterPolicyRulePortRangeSet(ctx, in.DstPort, diags)

--- a/apstra/data_source_datacenter_security_policy_test.go
+++ b/apstra/data_source_datacenter_security_policy_test.go
@@ -181,22 +181,22 @@ func TestDatacenterSecurityPolicy(t *testing.T) {
 
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.name", "name_0"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.description", "description_0"),
-				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.protocol", "ICMP"),
+				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.protocol", "icmp"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.action", "deny"),
 
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.1.name", "name_1"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.1.description", "description_1"),
-				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.1.protocol", "IP"),
+				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.1.protocol", "ip"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.1.action", "deny_log"),
 
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.2.name", "name_2"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.2.description", "description_2"),
-				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.2.protocol", "TCP"),
+				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.2.protocol", "tcp"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.2.action", "permit_log"),
 
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.3.name", "name_3"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.3.description", "description_3"),
-				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.3.protocol", "TCP"),
+				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.3.protocol", "tcp"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.3.action", "permit_log"),
 
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.3.source_ports.#", "3"),
@@ -234,7 +234,7 @@ func TestDatacenterSecurityPolicy(t *testing.T) {
 
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.name", "ssh_established"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.description", "ssh established"),
-				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.protocol", "TCP"),
+				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.protocol", "tcp"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.action", "permit_log"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.established", "true"),
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "rules.0.source_ports.#", "1"),

--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -57,6 +57,8 @@ func StringersToFriendlyString(in ...fmt.Stringer) string {
 		return nodeDeployModeToFriendlyString(in0)
 	case apstra.OverlayControlProtocol:
 		return overlayControlProtocolToFriendlyString(in0)
+	case apstra.PolicyRuleProtocol:
+		return policyRuleProtocolToFriendlyString(in0)
 	case apstra.RefDesign:
 		return refDesignToFriendlyString(in0)
 	case apstra.ResourceGroupName:
@@ -91,6 +93,8 @@ func ApiStringerFromFriendlyString(target StringerWithFromString, in ...string) 
 		return nodeDeployModeFromFriendlyString(target, in...)
 	case *apstra.OverlayControlProtocol:
 		return overlayControlProtocolFromFriendlyString(target, in...)
+	case *apstra.PolicyRuleProtocol:
+		return policyRuleProtocolFromFriendlyString(target, in[0])
 	case *apstra.RefDesign:
 		return refDesignFromFriendlyString(target, in...)
 	case *apstra.ResourceGroupName:
@@ -182,6 +186,10 @@ func overlayControlProtocolToFriendlyString(in apstra.OverlayControlProtocol) st
 	}
 
 	return in.String()
+}
+
+func policyRuleProtocolToFriendlyString(in apstra.PolicyRuleProtocol) string {
+	return strings.ToLower(in.String())
 }
 
 func refDesignToFriendlyString(in apstra.RefDesign) string {
@@ -306,6 +314,15 @@ func overlayControlProtocolFromFriendlyString(target *apstra.OverlayControlProto
 		return target.FromString(in[0])
 	}
 
+	return nil
+}
+
+func policyRuleProtocolFromFriendlyString(target *apstra.PolicyRuleProtocol, s string) error {
+	t := apstra.PolicyRuleProtocols.Parse(strings.ToUpper(s))
+	if t == nil {
+		return fmt.Errorf("cannot parse PolicyRuleProtocol %q", s)
+	}
+	target.Value = t.Value
 	return nil
 }
 

--- a/apstra/utils/rosetta_test.go
+++ b/apstra/utils/rosetta_test.go
@@ -40,6 +40,11 @@ func TestRosetta(t *testing.T) {
 		{string: "static", stringers: []fmt.Stringer{apstra.OverlayControlProtocolNone}},
 		{string: "evpn", stringers: []fmt.Stringer{apstra.OverlayControlProtocolEvpn}},
 
+		{string: "icmp", stringers: []fmt.Stringer{apstra.PolicyRuleProtocolIcmp}},
+		{string: "ip", stringers: []fmt.Stringer{apstra.PolicyRuleProtocolIp}},
+		{string: "tcp", stringers: []fmt.Stringer{apstra.PolicyRuleProtocolTcp}},
+		{string: "udp", stringers: []fmt.Stringer{apstra.PolicyRuleProtocolUdp}},
+
 		{string: "datacenter", stringers: []fmt.Stringer{apstra.RefDesignTwoStageL3Clos}},
 		{string: "freeform", stringers: []fmt.Stringer{apstra.RefDesignFreeform}},
 
@@ -72,6 +77,9 @@ func TestRosetta(t *testing.T) {
 			target = &x
 		case apstra.OverlayControlProtocol:
 			x := apstra.OverlayControlProtocol(-1)
+			target = &x
+		case apstra.PolicyRuleProtocol:
+			x := apstra.PolicyRuleProtocol{}
 			target = &x
 		case apstra.RefDesign:
 			x := apstra.RefDesign(-1)

--- a/docs/data-sources/datacenter_security_policy.md
+++ b/docs/data-sources/datacenter_security_policy.md
@@ -59,12 +59,12 @@ Read-Only:
 
 - `action` (String) Security Policy Rule Action; one of: deny, deny_log, permit, permit_log
 - `description` (String) Security Policy Rule Description.
-- `destination_ports` (Attributes Set) Set of TCP/UDP destination ports matched by this rule. A `null` set matches any port. Applies only when `protocol` is TCP or UDP. (see [below for nested schema](#nestedatt--rules--destination_ports))
+- `destination_ports` (Attributes Set) Set of TCP/UDP destination ports matched by this rule. A `null` set matches any port. Applies only when `protocol` is `tcp` or `udp`. (see [below for nested schema](#nestedatt--rules--destination_ports))
 - `established` (Boolean) When `true`, the rendered rule will use the NOS `established` or `tcp-established` keyword/feature for TCP access control list entries.
 - `id` (String) Security Policy Rule ID.
 - `name` (String) Security Policy Rule Name.
-- `protocol` (String) Security Policy Rule Protocol; one of: ICMP, IP, TCP, UDP
-- `source_ports` (Attributes Set) Set of TCP/UDP source ports matched by this rule. A `null` set matches any port. Applies only when `protocol` is TCP or UDP. (see [below for nested schema](#nestedatt--rules--source_ports))
+- `protocol` (String) Security Policy Rule Protocol; one of: icmp, ip, tcp, udp
+- `source_ports` (Attributes Set) Set of TCP/UDP source ports matched by this rule. A `null` set matches any port. Applies only when `protocol` is `tcp` or `udp`. (see [below for nested schema](#nestedatt--rules--source_ports))
 
 <a id="nestedatt--rules--destination_ports"></a>
 ### Nested Schema for `rules.destination_ports`


### PR DESCRIPTION
This PR uses the new rosetta capability for enum types to swap API strings `ICMP`, `IP`, `TCP`, `UDP` for `icmp`, `ip`, `tcp`, and `udp`