### PR TITLE
Fix documentation errors in `apstra_datacenter_security_policy` data source and resource

### DIFF
--- a/apstra/blueprint/datacenter_security_policy.go
+++ b/apstra/blueprint/datacenter_security_policy.go
@@ -173,9 +173,8 @@ func (o DatacenterSecurityPolicy) ResourceAttributes() map[string]resourceSchema
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"rules": resourceSchema.ListNestedAttribute{
-			MarkdownDescription: "Not currently supported for use in a filter. Do you need this? Let us know by " +
-				"[opening an issue](https://github.com/Juniper/terraform-provider-apstra/issues/new)!",
-			Optional: true,
+			MarkdownDescription: "Ordered list of policy rules.",
+			Optional:            true,
 			NestedObject: resourceSchema.NestedAttributeObject{
 				Attributes: DatacenterSecurityPolicyRule{}.ResourceAttributes(),
 			},

--- a/apstra/data_source_datacenter_security_policy.go
+++ b/apstra/data_source_datacenter_security_policy.go
@@ -27,7 +27,7 @@ func (o *dataSourceDatacenterSecurityPolicy) Configure(ctx context.Context, req 
 
 func (o *dataSourceDatacenterSecurityPolicy) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: docCategoryRefDesignAny + "This data source provides details of a specific Security " +
+		MarkdownDescription: docCategoryDatacenter + "This data source provides details of a specific Security " +
 			"Policy within a Datacenter Blueprint.\n\nAt least one optional attribute is required.",
 		Attributes: blueprint.DatacenterSecurityPolicy{}.DataSourceAttributes(),
 	}

--- a/docs/data-sources/datacenter_security_policy.md
+++ b/docs/data-sources/datacenter_security_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "apstra_datacenter_security_policy Data Source - terraform-provider-apstra"
-subcategory: "Reference Design: Shared"
+subcategory: "Reference Design: Datacenter"
 description: |-
   This data source provides details of a specific Security Policy within a Datacenter Blueprint.
   At least one optional attribute is required.

--- a/docs/resources/datacenter_security_policy.md
+++ b/docs/resources/datacenter_security_policy.md
@@ -100,7 +100,7 @@ resource "apstra_datacenter_security_policy" "server_traffic" {
 - `description` (String) Security Policy description, as seen in the Web UI.
 - `destination_application_point_id` (String) Graph node ID of the destination Application Point (Virtual Network ID, Routing Zone ID, etc...)
 - `enabled` (Boolean) Indicates whether the Security Policy is enabled. Default value: `true`
-- `rules` (Attributes List) Not currently supported for use in a filter. Do you need this? Let us know by [opening an issue](https://github.com/Juniper/terraform-provider-apstra/issues/new)! (see [below for nested schema](#nestedatt--rules))
+- `rules` (Attributes List) Ordered list of policy rules. (see [below for nested schema](#nestedatt--rules))
 - `source_application_point_id` (String) Graph node ID of the source Application Point (Virtual Network ID, Routing Zone ID, etc...)
 - `tags` (Set of String) Set of Tags. All tags supplied here are used to match the Security Policy, but a matching Security Policy may have additional tags not enumerated in this set.
 


### PR DESCRIPTION
Documentation for `apstra_datacenter_security_policy ` data source rendered in wrong registry category.

`s/docCategoryRefDesignAny/docCategoryDatacenter/`

`MarkdownDescription` for resource `apstra_datacenter_security_policy`'s `rules` attribute was copied from the data source filters context.