### PR TITLE
Bugfix: #525 State churn in `apstra_template_rack_based` when generic system has 2 or more links

### DIFF
--- a/apstra/design/rack_type_generic_system.go
+++ b/apstra/design/rack_type_generic_system.go
@@ -173,7 +173,7 @@ func (o GenericSystem) ResourceAttributesNested() map[string]resourceSchema.Attr
 			MarkdownDescription: "Each Generic System is required to have at least one Link to a Leaf Switch or Access Switch.",
 			Computed:            true,
 			NestedObject: resourceSchema.NestedAttributeObject{
-				Attributes: RackLink{}.ResourceAttributes(),
+				Attributes: RackLink{}.ResourceAttributesNested(),
 			},
 		},
 		"tag_ids": resourceSchema.SetAttribute{

--- a/docs/resources/template_rack_based.md
+++ b/docs/resources/template_rack_based.md
@@ -196,21 +196,15 @@ Read-Only:
 <a id="nestedatt--rack_infos--rack_type--generic_systems--links"></a>
 ### Nested Schema for `rack_infos.rack_type.generic_systems.tags`
 
-Required:
-
-- `speed` (String) Speed of this Link.
-- `target_switch_name` (String) The `name` of the switch in this Rack Type to which this Link connects.
-
-Optional:
+Read-Only:
 
 - `lag_mode` (String) LAG negotiation mode of the Link.
 - `links_per_switch` (Number) Number of Links to each switch.
+- `speed` (String) Speed of this Link.
 - `switch_peer` (String) For non-lAG connections to redundant switch pairs, this field selects the target switch.
-- `tag_ids` (Set of String) Set of Tag IDs to be applied to this Link
-
-Read-Only:
-
+- `tag_ids` (Set of String) IDs will always be `<null>` in nested contexts.
 - `tags` (Attributes Set) Set of Tags (Name + Description) applied to this Link (see [below for nested schema](#nestedatt--rack_infos--rack_type--generic_systems--tags--tags))
+- `target_switch_name` (String) The `name` of the switch in this Rack Type to which this Link connects.
 
 <a id="nestedatt--rack_infos--rack_type--generic_systems--tags--tags"></a>
 ### Nested Schema for `rack_infos.rack_type.generic_systems.tags.tags`


### PR DESCRIPTION
Issue caught with [new acceptance tests](https://github.com/Juniper/terraform-provider-apstra/pull/524/files#diff-176b6d677841e3c681cc484223810986a018ca57de080e11c17958b247f93089) introduced in #524.

Closes #525