### PR TITLE
WIP: Bug/527: `apstra_template_rack_based` resource `fabric_link_addressing` attribute must be "Computed"

### DIFF
--- a/apstra/api_versions/constraints.go
+++ b/apstra/api_versions/constraints.go
@@ -1,0 +1,40 @@
+package apiversions
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+type attributeConstraints struct {
+	path        path.Path
+	constraints version.Constraints
+}
+
+type otherConstraint struct {
+	message     string
+	constraints version.Constraints
+}
+
+type Constraints struct {
+	attributeConstraints []attributeConstraints
+	otherConstraints     []otherConstraint
+}
+
+// AddAttributeConstraints should be used to add version constraints imposed by
+// the presence of an attribute or attribute value in the configuration.
+func (o *Constraints) AddAttributeConstraints(path path.Path, constraints version.Constraints) {
+	o.attributeConstraints = append(o.attributeConstraints, attributeConstraints{
+		path:        path,
+		constraints: constraints,
+	})
+}
+
+// AddConstraints should be used to add non-attribute-value-based version
+// constraints, like those imposed by the absence of an attribute in the
+// configuration.
+func (o *Constraints) AddConstraints(message string, constraints version.Constraints) {
+	o.otherConstraints = append(o.otherConstraints, otherConstraint{
+		message:     message,
+		constraints: constraints,
+	})
+}

--- a/apstra/api_versions/validate.go
+++ b/apstra/api_versions/validate.go
@@ -1,0 +1,44 @@
+package apiversions
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+const (
+	errSummary         = "Configuration not valid with Apstra %s"
+	errAttributeDetail = "This configuration requires Apstra %s"
+	errOtherDetail     = "%s\nThis configuration requires Apstra %s"
+)
+
+type ValidateConstraintsRequest struct {
+	Version     *version.Version
+	Constraints Constraints
+}
+
+func ValidateConstraints(_ context.Context, req ValidateConstraintsRequest) diag.Diagnostics {
+	var response diag.Diagnostics
+
+	for _, constraint := range req.Constraints.attributeConstraints {
+		if !constraint.constraints.Check(req.Version) { // un-met version constraint?
+			response.AddAttributeError(
+				constraint.path,
+				fmt.Sprintf(errSummary, req.Version),
+				fmt.Sprintf(errAttributeDetail, constraint.constraints),
+			)
+		}
+	}
+
+	for _, constraint := range req.Constraints.otherConstraints {
+		if !constraint.constraints.Check(req.Version) {
+			response.AddError(
+				fmt.Sprintf(errSummary, req.Version),
+				fmt.Sprintf(errOtherDetail, constraint.message, constraint.constraints),
+			)
+		}
+	}
+
+	return response
+}

--- a/apstra/design/template_rack_based.go
+++ b/apstra/design/template_rack_based.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
-	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
+	apiversions "github.com/Juniper/terraform-provider-apstra/apstra/api_versions"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -118,6 +117,7 @@ func (o TemplateRackBased) ResourceAttributes() map[string]resourceSchema.Attrib
 			MarkdownDescription: "Fabric addressing scheme for Spine/Leaf links. Required for " +
 				"Apstra <= 4.1.0, not supported by Apstra >= 4.1.1.",
 			Optional: true,
+			Computed: true,
 		},
 		"rack_infos": resourceSchema.MapNestedAttribute{
 			MarkdownDescription: "Map of Rack Type info (count + details)",
@@ -184,7 +184,7 @@ func (o *TemplateRackBased) Request(ctx context.Context, diags *diag.Diagnostics
 	}
 
 	var fabricAddressingPolicy *apstra.TemplateFabricAddressingPolicy410Only
-	if !o.FabricAddressing.IsNull() {
+	if utils.Known(o.FabricAddressing) {
 		var addressingScheme apstra.AddressingScheme
 		err = addressingScheme.FromString(o.FabricAddressing.ValueString())
 		if err != nil {
@@ -223,29 +223,6 @@ func (o *TemplateRackBased) Request(ctx context.Context, diags *diag.Diagnostics
 	}
 }
 
-func (o *TemplateRackBased) Validate(ctx context.Context, diags *diag.Diagnostics) {
-	if o.RackInfos.IsUnknown() {
-		return
-	}
-
-	rackInfoMap := make(map[string]TemplateRackInfo, len(o.RackInfos.Elements()))
-	d := o.RackInfos.ElementsAs(ctx, &rackInfoMap, false)
-	diags.Append(d...)
-	if diags.HasError() {
-		return
-	}
-
-	idMap := make(map[string]struct{}, len(rackInfoMap))
-	for key := range rackInfoMap {
-		if _, ok := idMap[key]; ok {
-			diags.AddAttributeError(path.Root("rack_infos").AtMapKey(key), errInvalidConfig,
-				fmt.Sprintf("rack type id %q used multiple times", key))
-			return
-		}
-		idMap[key] = struct{}{}
-	}
-}
-
 func (o *TemplateRackBased) LoadApiData(ctx context.Context, in *apstra.TemplateRackBasedData, diags *diag.Diagnostics) {
 	if in == nil {
 		diags.AddError(errProviderBug, "attempt to load TemplateRackBased from nil source")
@@ -274,22 +251,6 @@ func (o *TemplateRackBased) LoadApiData(ctx context.Context, in *apstra.Template
 	o.FabricAddressing = fabricAddressing
 }
 
-func (o *TemplateRackBased) MinMaxApiVersions(_ context.Context, diags *diag.Diagnostics) (*version.Version, *version.Version) {
-	var minVer, maxVer *version.Version
-	var err error
-	if o.FabricAddressing.IsNull() {
-		minVer, err = version.NewVersion("4.1.1")
-	} else {
-		maxVer, err = version.NewVersion("4.1.0")
-	}
-	if err != nil {
-		diags.AddError(errProviderBug,
-			fmt.Sprintf("error parsing min/max version - %s", err.Error()))
-	}
-
-	return minVer, maxVer
-}
-
 func (o *TemplateRackBased) CopyWriteOnlyElements(ctx context.Context, src *TemplateRackBased, diags *diag.Diagnostics) {
 	var srcSpine, dstSpine *Spine
 
@@ -312,12 +273,15 @@ func (o *TemplateRackBased) CopyWriteOnlyElements(ctx context.Context, src *Temp
 	o.Spine = utils.ObjectValueOrNull(ctx, Spine{}.AttrTypes(), dstSpine, diags)
 }
 
-func (o TemplateRackBased) CheckCompatibility(_ context.Context, client *apstra.Client, diags *diag.Diagnostics) {
-	if compatibility.TemplateFabricAddressingRequiredVersions(client.ApiVersion()) && o.FabricAddressing.IsNull() {
-		diags.AddAttributeError(
+func (o TemplateRackBased) VersionConstrains() apiversions.Constraints {
+	var response apiversions.Constraints
+
+	if !o.FabricAddressing.IsNull() {
+		response.AddAttributeConstraints(
 			path.Root("fabric_link_addressing"),
-			constants.ErrApiCompatibility,
-			"`fabric_link_addressing` required with Apstra "+client.ApiVersion(),
+			version.MustConstraints(version.NewConstraint("4.1.0")),
 		)
 	}
+
+	return response
 }

--- a/apstra/design/template_rack_based.go
+++ b/apstra/design/template_rack_based.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	apiversions "github.com/Juniper/terraform-provider-apstra/apstra/api_versions"
+	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/apstra_validator"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -118,6 +119,21 @@ func (o TemplateRackBased) ResourceAttributes() map[string]resourceSchema.Attrib
 				"Apstra <= 4.1.0, not supported by Apstra >= 4.1.1.",
 			Optional: true,
 			Computed: true,
+			Validators: []validator.String{
+				stringvalidator.OneOf(
+					apstra.AddressingSchemeIp4.String(),
+					apstra.AddressingSchemeIp46.String(),
+					apstra.AddressingSchemeIp6.String(),
+				),
+				apstravalidator.WhenValueIsString(
+					types.StringValue(apstra.AddressingSchemeIp6.String()),
+					apstravalidator.ValueAtMustBeString(
+						path.MatchRelative().AtParent().AtName("overlay_control_protocol"),
+						types.StringValue(OverlayControlProtocolStatic),
+						false,
+					),
+				),
+			},
 		},
 		"rack_infos": resourceSchema.MapNestedAttribute{
 			MarkdownDescription: "Map of Rack Type info (count + details)",


### PR DESCRIPTION
Added `Computed` flag to schema for `fabric_link_addressing` attribute. #527

Added schema validation to ensure valid string at `fabric_link_addressing` attribute.

Added schema validation to prevent use of `ipv6` at `fabric_link_addressing` when `overlay_control_protocol` has value `evpn`. #528