### PR TITLE
Bugfix #527 and #528 in `apstra_template_rack_based` resource

### DIFF
--- a/apstra/design/template_rack_based.go
+++ b/apstra/design/template_rack_based.go
@@ -118,6 +118,7 @@ func (o TemplateRackBased) ResourceAttributes() map[string]resourceSchema.Attrib
 			MarkdownDescription: "Fabric addressing scheme for Spine/Leaf links. Required for " +
 				"Apstra <= 4.1.0, not supported by Apstra >= 4.1.1.",
 			Optional: true,
+			Computed: true,
 		},
 		"rack_infos": resourceSchema.MapNestedAttribute{
 			MarkdownDescription: "Map of Rack Type info (count + details)",

--- a/apstra/design/template_rack_based.go
+++ b/apstra/design/template_rack_based.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/apstra_validator"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -119,6 +120,21 @@ func (o TemplateRackBased) ResourceAttributes() map[string]resourceSchema.Attrib
 				"Apstra <= 4.1.0, not supported by Apstra >= 4.1.1.",
 			Optional: true,
 			Computed: true,
+			Validators: []validator.String{
+				stringvalidator.OneOf(
+					apstra.AddressingSchemeIp4.String(),
+					apstra.AddressingSchemeIp46.String(),
+					apstra.AddressingSchemeIp6.String(),
+				),
+				apstravalidator.WhenValueIsString(
+					types.StringValue(apstra.AddressingSchemeIp6.String()),
+					apstravalidator.ValueAtMustBeString(
+						path.MatchRelative().AtParent().AtName("overlay_control_protocol"),
+						types.StringValue(OverlayControlProtocolStatic),
+						false,
+					),
+				),
+			},
 		},
 		"rack_infos": resourceSchema.MapNestedAttribute{
 			MarkdownDescription: "Map of Rack Type info (count + details)",

--- a/apstra/design/template_rack_based.go
+++ b/apstra/design/template_rack_based.go
@@ -201,7 +201,7 @@ func (o *TemplateRackBased) Request(ctx context.Context, diags *diag.Diagnostics
 	}
 
 	var fabricAddressingPolicy *apstra.TemplateFabricAddressingPolicy410Only
-	if !o.FabricAddressing.IsNull() {
+	if utils.Known(o.FabricAddressing) {
 		var addressingScheme apstra.AddressingScheme
 		err = addressingScheme.FromString(o.FabricAddressing.ValueString())
 		if err != nil {


### PR DESCRIPTION
Closes #527  - `fabric_link_addressing` attribute for Apstra 4.1.0 must be `Computed`
Closes #528 - validation for `fabric_link_addressing` attribute