### PR TITLE
Introduce version constraint based configuration validation

### DIFF
--- a/apstra/api_versions/constraints.go
+++ b/apstra/api_versions/constraints.go
@@ -1,0 +1,40 @@
+package apiversions
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+type attributeConstraints struct {
+	path        path.Path
+	constraints version.Constraints
+}
+
+type otherConstraint struct {
+	message     string
+	constraints version.Constraints
+}
+
+type Constraints struct {
+	attributeConstraints []attributeConstraints
+	otherConstraints     []otherConstraint
+}
+
+// AddAttributeConstraints should be used to add version constraints imposed by
+// the presence of an attribute or attribute value in the configuration.
+func (o *Constraints) AddAttributeConstraints(path path.Path, constraints version.Constraints) {
+	o.attributeConstraints = append(o.attributeConstraints, attributeConstraints{
+		path:        path,
+		constraints: constraints,
+	})
+}
+
+// AddConstraints should be used to add non-attribute-value-based version
+// constraints, like those imposed by the absence of an attribute in the
+// configuration.
+func (o *Constraints) AddConstraints(message string, constraints version.Constraints) {
+	o.otherConstraints = append(o.otherConstraints, otherConstraint{
+		message:     message,
+		constraints: constraints,
+	})
+}

--- a/apstra/api_versions/constraints.go
+++ b/apstra/api_versions/constraints.go
@@ -5,7 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
-type attributeConstraints struct {
+type attributeConstraint struct {
 	path        path.Path
 	constraints version.Constraints
 }
@@ -16,14 +16,14 @@ type otherConstraint struct {
 }
 
 type Constraints struct {
-	attributeConstraints []attributeConstraints
+	attributeConstraints []attributeConstraint
 	otherConstraints     []otherConstraint
 }
 
 // AddAttributeConstraints should be used to add version constraints imposed by
 // the presence of an attribute or attribute value in the configuration.
 func (o *Constraints) AddAttributeConstraints(path path.Path, constraints version.Constraints) {
-	o.attributeConstraints = append(o.attributeConstraints, attributeConstraints{
+	o.attributeConstraints = append(o.attributeConstraints, attributeConstraint{
 		path:        path,
 		constraints: constraints,
 	})

--- a/apstra/api_versions/validate.go
+++ b/apstra/api_versions/validate.go
@@ -1,0 +1,44 @@
+package apiversions
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+const (
+	errSummary         = "Configuration not compatible with Apstra %s"
+	errAttributeDetail = "This configuration requires Apstra %s"
+	errOtherDetail     = "%s\nThis configuration requires Apstra %s"
+)
+
+type ValidateConstraintsRequest struct {
+	Version     *version.Version
+	Constraints Constraints
+}
+
+func ValidateConstraints(_ context.Context, req ValidateConstraintsRequest) diag.Diagnostics {
+	var response diag.Diagnostics
+
+	for _, constraint := range req.Constraints.attributeConstraints {
+		if !constraint.constraints.Check(req.Version) { // un-met version constraint?
+			response.AddAttributeError(
+				constraint.path,
+				fmt.Sprintf(errSummary, req.Version),
+				fmt.Sprintf(errAttributeDetail, constraint.constraints),
+			)
+		}
+	}
+
+	for _, constraint := range req.Constraints.otherConstraints {
+		if !constraint.constraints.Check(req.Version) {
+			response.AddError(
+				fmt.Sprintf(errSummary, req.Version),
+				fmt.Sprintf(errOtherDetail, constraint.message, constraint.constraints),
+			)
+		}
+	}
+
+	return response
+}

--- a/apstra/api_versions/versions.go
+++ b/apstra/api_versions/versions.go
@@ -1,0 +1,11 @@
+package apiversions
+
+// the idea with these constants is that all references to an Apstra release
+// track back to this file. When support for an old release is dropped, these
+// constants should help track down code relevant to those versions.
+const (
+	Apstra410 = "4.1.0"
+	Apstra411 = "4.1.1"
+	Apstra412 = "4.1.2"
+	Apstra420 = "4.2.0"
+)

--- a/apstra/design/template_rack_based.go
+++ b/apstra/design/template_rack_based.go
@@ -6,8 +6,6 @@ import (
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	apiversions "github.com/Juniper/terraform-provider-apstra/apstra/api_versions"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/apstra_validator"
-	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
-	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"

--- a/apstra/resource_template_rack_based.go
+++ b/apstra/resource_template_rack_based.go
@@ -218,10 +218,3 @@ func (o *resourceTemplateRackBased) Delete(ctx context.Context, req resource.Del
 		return
 	}
 }
-
-func (o *resourceTemplateRackBased) apiVersion() (*version.Version, error) {
-	if o.client == nil {
-		return nil, nil
-	}
-	return version.NewVersion(o.client.ApiVersion())
-}

--- a/apstra/resource_template_rack_based.go
+++ b/apstra/resource_template_rack_based.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	apiversions "github.com/Juniper/terraform-provider-apstra/apstra/api_versions"
 	"github.com/Juniper/terraform-provider-apstra/apstra/design"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -15,12 +15,9 @@ import (
 
 var _ resource.ResourceWithConfigure = &resourceTemplateRackBased{}
 var _ resource.ResourceWithValidateConfig = &resourceTemplateRackBased{}
-var _ versionValidator = &resourceTemplateRackBased{}
 
 type resourceTemplateRackBased struct {
-	client           *apstra.Client
-	minClientVersion *version.Version
-	maxClientVersion *version.Version
+	client *apstra.Client
 }
 
 func (o *resourceTemplateRackBased) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -46,43 +43,38 @@ func (o *resourceTemplateRackBased) ValidateConfig(ctx context.Context, req reso
 		return
 	}
 
-	// validate the configuration
-	config.Validate(ctx, &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	// config-only validation begins here (there is none)
 
-	// Set the min/max API versions required by the client. These elements set within 'o'
-	// do not persist after ValidateConfig exits even though 'o' is a pointer receiver.
-	o.minClientVersion, o.maxClientVersion = config.MinMaxApiVersions(ctx, &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
+	// cannot proceed to config + api version validation without a client
 	if o.client == nil {
-		// Bail here because we can't validate config's API version needs if the client doesn't exist.
-		// This method should be called again (after the provider's Configure() method) with a non-nil
-		// client pointer.
 		return
 	}
 
-	// validate version compatibility between the API server and the configuration's min/max needs.
-	o.checkVersion(ctx, &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
+	// config + api version validation begins here
+
+	// get the api version from the client
+	apiVersion, err := version.NewVersion(o.client.ApiVersion())
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("cannot parse API version %q", o.client.ApiVersion()), err.Error())
 		return
 	}
+
+	// validate the configuration
+	resp.Diagnostics.Append(
+		apiversions.ValidateConstraints(
+			ctx,
+			apiversions.ValidateConstraintsRequest{
+				Version:     apiVersion,
+				Constraints: config.VersionConstraints(),
+			},
+		)...,
+	)
 }
 
 func (o *resourceTemplateRackBased) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// retrieve values from plan
 	var plan design.TemplateRackBased
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// check compatibility of config against API version
-	plan.CheckCompatibility(ctx, o.client, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -108,7 +100,7 @@ func (o *resourceTemplateRackBased) Create(ctx context.Context, req resource.Cre
 	}
 
 	// parse the API response into a state object
-	state := design.TemplateRackBased{}
+	var state design.TemplateRackBased
 	state.Id = types.StringValue(string(id))
 	state.LoadApiData(ctx, api.Data, &resp.Diagnostics)
 
@@ -161,12 +153,6 @@ func (o *resourceTemplateRackBased) Update(ctx context.Context, req resource.Upd
 	// retrieve values from plan
 	var plan design.TemplateRackBased
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// check compatibility of config against API version
-	plan.CheckCompatibility(ctx, o.client, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -238,16 +224,4 @@ func (o *resourceTemplateRackBased) apiVersion() (*version.Version, error) {
 		return nil, nil
 	}
 	return version.NewVersion(o.client.ApiVersion())
-}
-
-func (o *resourceTemplateRackBased) cfgVersionMin() (*version.Version, error) {
-	return o.minClientVersion, nil
-}
-
-func (o *resourceTemplateRackBased) cfgVersionMax() (*version.Version, error) {
-	return o.maxClientVersion, nil
-}
-
-func (o *resourceTemplateRackBased) checkVersion(ctx context.Context, diags *diag.Diagnostics) {
-	checkVersionCompatibility(ctx, o, diags)
 }


### PR DESCRIPTION
Version Constraints from the `hashicorp/versions` package facilitate expressions of version requirements like "4.1.0" and ">4.0, <= 4.2.0".

This PR converts a single resource (`apstra_template_rack_based`) to use new constraints-based tooling to express Apstra API version requirements, and methods for validating those requirements and reporting errors to the user.

Also, unrelated to version validation, the `TemplateRackBased .Validate()` method has been removed. This method ensures that no duplicate rack types appear in `rack_type_infos`. Checking for that error made sense at some point in the past when `rack_type_infos` were expressed as a set or list, but was mooted when the input structure was refactored into a map keyed by rack type.