### PR TITLE
Document generic system ASN behavior when auto-assigned by Apstra

### DIFF
--- a/apstra/blueprint/datacenter_generic_system.go
+++ b/apstra/blueprint/datacenter_generic_system.go
@@ -90,9 +90,11 @@ func (o DatacenterGenericSystem) ResourceAttributes() map[string]resourceSchema.
 			},
 		},
 		"asn": resourceSchema.Int64Attribute{
-			MarkdownDescription: "AS number of the Generic System",
-			Optional:            true,
-			Validators:          []validator.Int64{int64validator.Between(1, math.MaxUint32)},
+			MarkdownDescription: "AS number of the Generic System. Note that in some circumstances Apstra may assign " +
+				"an ASN to the generic system even when none is supplied via this attribute. The automatically" +
+				"assigned value will be overwritten by Terraform during a subsequent apply operation.",
+			Optional:   true,
+			Validators: []validator.Int64{int64validator.Between(1, math.MaxUint32)},
 		},
 		"loopback_ipv4": resourceSchema.StringAttribute{
 			MarkdownDescription: "IPv4 address of loopback interface in CIDR notation",

--- a/docs/resources/datacenter_generic_system.md
+++ b/docs/resources/datacenter_generic_system.md
@@ -83,7 +83,7 @@ resource "apstra_datacenter_generic_system" "example" {
 
 ### Optional
 
-- `asn` (Number) AS number of the Generic System
+- `asn` (Number) AS number of the Generic System. Note that in some circumstances Apstra may assign an ASN to the generic system even when none is supplied via this attribute. The automaticallyassigned value will be overwritten by Terraform during a subsequent apply operation.
 - `deploy_mode` (String) Set the Apstra Deploy Mode for this Generic System. Default: `deploy`
 - `external` (Boolean) Set `true` to create an External Generic System
 - `hostname` (String) System hostname.


### PR DESCRIPTION
Issue #442 suggested that the ASN should be marked as `Computed` and any Apstra-assigned value read into the Terraform state when omitted by the user.

It turns out this is more complicated of a problem than initially thought, and it's impossible during `Create()` to be confident we've read the correct value: Maybe Apstra is about to assign a value? How long should we wait?

Given that the ASN of a generic system is outside of Apstra's control, it is reasonable to expect provider users to be prescriptive here.

This PR
- documents the potential for state churn when Apstra is allowed to assign a value
- enhances an error message
- performs a defensive partial state commit (in case errors are encountered later)

Closes #442