### PR TITLE
Introduce test helper pattern

### DIFF
--- a/apstra/resource_datacenter_generic_system_test.go
+++ b/apstra/resource_datacenter_generic_system_test.go
@@ -2,10 +2,10 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
+	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"net"
 	"strconv"
@@ -45,20 +45,9 @@ resource "apstra_datacenter_generic_system" "test" {
 func TestResourceDatacenterGenericSystem_A(t *testing.T) {
 	ctx := context.Background()
 
-	bpClient, bpDelete, err := testutils.BlueprintF(ctx)
-	if err != nil {
-		t.Fatal(errors.Join(err, bpDelete(ctx)))
-	}
-	defer func() {
-		err = bpDelete(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-	}()
+	bpClient := testutils.BlueprintF(t, ctx)
 
-	// enable IPv6
-	ipv6Enabled := true
-	err = bpClient.SetFabricAddressingPolicy(ctx, &apstra.TwoStageL3ClosFabricAddressingPolicy{Ipv6Enabled: &ipv6Enabled})
+	err := bpClient.SetFabricAddressingPolicy(ctx, &apstra.TwoStageL3ClosFabricAddressingPolicy{Ipv6Enabled: utils.ToPtr(true)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -308,6 +308,9 @@ func BlueprintF(t testing.TB, ctx context.Context) *apstra.TwoStageL3ClosClient 
 	t.Helper()
 
 	client, err := GetTestClient(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	template := TemplateE(t, ctx)
 

--- a/apstra/utils/diagnostics.go
+++ b/apstra/utils/diagnostics.go
@@ -1,8 +1,9 @@
 package utils
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
 const diagnosticWrapperDefaultSeparator = ", "

--- a/apstra/utils/helpers.go
+++ b/apstra/utils/helpers.go
@@ -11,3 +11,7 @@ func (o Stringer) String() string {
 func NewStringer(s string) Stringer {
 	return Stringer{s: s}
 }
+
+func ToPtr[A any](a A) *A {
+	return &a
+}


### PR DESCRIPTION
This PR makes use of the `testing.TB` interface and the `testing.Helper()` and `testing.Cleanup()` functions in a single example of our existing test helper functions.

Previously we had a brittle stack of `defer`red functions. This is how you're supposed to do it, I guess.

The rules, as I understand them:

- each test helper function (like the ones that create a blueprint playground in which a test can run) must take `t testing.TB` as their first argument
- these helper functions can now interrupt testing by invoking `t.Fatal()` rather than returning an error
- to avoid `t.Fatal()` indicating a failure inside the helper, they invoke `t.Helper()` to flag themselves as helper functions
- cleanup actions no longer need to be handled by a returned `cleanup` function, but by `t.Cleanup()`, which is executed automatically at the end of the test

It's a much cleaner pattern.

This PR only covers one use case in an attempt to make this first example easily digestible for review. I'll do the rest in a separate PR.