### PR TITLE
Fix `DeviceAllocationSystemAttributes.IsEmpty()`

### DIFF
--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -734,8 +734,8 @@ func (o *DeviceAllocation) SetSystemAttributes(ctx context.Context, state *Devic
 		return
 	}
 
-	planSA := new(DeviceAllocationSystemAttributes)
-	diags.Append(o.SystemAttributes.As(ctx, planSA, basetypes.ObjectAsOptions{})...)
+	var planSA DeviceAllocationSystemAttributes
+	diags.Append(o.SystemAttributes.As(ctx, &planSA, basetypes.ObjectAsOptions{})...)
 	if diags.HasError() {
 		return
 	}

--- a/apstra/blueprint/device_allocation_system_attributes.go
+++ b/apstra/blueprint/device_allocation_system_attributes.go
@@ -99,10 +99,12 @@ func (o DeviceAllocationSystemAttributes) ResourceAttributes() map[string]resour
 }
 
 func (o *DeviceAllocationSystemAttributes) IsEmpty() bool {
-	if //o.Asn.IsNull() &&
-	o.Name.IsNull() &&
+	if o.Asn.IsNull() &&
+		o.Name.IsNull() &&
 		o.Hostname.IsNull() &&
 		o.LoopbackIpv4.IsNull() &&
+		o.Tags.IsNull() &&
+		o.DeployMode.IsNull() &&
 		o.LoopbackIpv6.IsNull() {
 		return true
 	}

--- a/apstra/test_helpers_test.go
+++ b/apstra/test_helpers_test.go
@@ -73,6 +73,10 @@ func cidrOrNull(in *net.IPNet) string {
 }
 
 func stringSetOrNull(in []string) string {
+	if in == nil {
+		return "null"
+	}
+
 	sb := new(strings.Builder)
 	for i, s := range in {
 		if i == 0 {


### PR DESCRIPTION
This PR fixes a bug where the validation code would complain about `system_attributes` being empty when it's got values in it.

Closes #570