### PR TITLE
Bug #567 Add version constraints to link tags due to 4.1.1 limitation

### DIFF
--- a/apstra/api_versions/constraints.go
+++ b/apstra/api_versions/constraints.go
@@ -5,36 +5,38 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
-type attributeConstraint struct {
-	path        path.Path
-	constraints version.Constraints
+type AttributeConstraint struct {
+	Path        path.Path
+	Constraints version.Constraints
 }
 
-type otherConstraint struct {
-	message     string
-	constraints version.Constraints
+type OtherConstraint struct {
+	Message     string
+	Constraints version.Constraints
 }
 
 type Constraints struct {
-	attributeConstraints []attributeConstraint
-	otherConstraints     []otherConstraint
+	attributeConstraints []AttributeConstraint
+	otherConstraints     []OtherConstraint
 }
 
 // AddAttributeConstraints should be used to add version constraints imposed by
 // the presence of an attribute or attribute value in the configuration.
-func (o *Constraints) AddAttributeConstraints(path path.Path, constraints version.Constraints) {
-	o.attributeConstraints = append(o.attributeConstraints, attributeConstraint{
-		path:        path,
-		constraints: constraints,
-	})
+func (o *Constraints) AddAttributeConstraints(in AttributeConstraint) {
+	o.attributeConstraints = append(o.attributeConstraints, in)
 }
 
-// AddConstraints should be used to add non-attribute-value-based version
+// AddOtherConstraints should be used to add non-attribute-value-based version
 // constraints, like those imposed by the absence of an attribute in the
 // configuration.
-func (o *Constraints) AddConstraints(message string, constraints version.Constraints) {
-	o.otherConstraints = append(o.otherConstraints, otherConstraint{
-		message:     message,
-		constraints: constraints,
-	})
+func (o *Constraints) AddOtherConstraints(in OtherConstraint) {
+	o.otherConstraints = append(o.otherConstraints, in)
+}
+
+func (o *Constraints) AttributeConstraints() []AttributeConstraint {
+	return o.attributeConstraints
+}
+
+func (o *Constraints) OtherConstraints() []OtherConstraint {
+	return o.otherConstraints
 }

--- a/apstra/api_versions/validate.go
+++ b/apstra/api_versions/validate.go
@@ -22,20 +22,20 @@ func ValidateConstraints(_ context.Context, req ValidateConstraintsRequest) diag
 	var response diag.Diagnostics
 
 	for _, constraint := range req.Constraints.attributeConstraints {
-		if !constraint.constraints.Check(req.Version) { // un-met version constraint?
+		if !constraint.Constraints.Check(req.Version) { // un-met version constraint?
 			response.AddAttributeError(
-				constraint.path,
+				constraint.Path,
 				fmt.Sprintf(errSummary, req.Version),
-				fmt.Sprintf(errAttributeDetail, constraint.constraints),
+				fmt.Sprintf(errAttributeDetail, constraint.Constraints),
 			)
 		}
 	}
 
 	for _, constraint := range req.Constraints.otherConstraints {
-		if !constraint.constraints.Check(req.Version) {
+		if !constraint.Constraints.Check(req.Version) {
 			response.AddError(
 				fmt.Sprintf(errSummary, req.Version),
-				fmt.Sprintf(errOtherDetail, constraint.message, constraint.constraints),
+				fmt.Sprintf(errOtherDetail, constraint.Message, constraint.Constraints),
 			)
 		}
 	}

--- a/apstra/blueprint/blueprint.go
+++ b/apstra/blueprint/blueprint.go
@@ -492,15 +492,19 @@ func (o Blueprint) VersionConstraints() apiversions.Constraints {
 
 	if utils.Known(o.FabricAddressing) {
 		response.AddAttributeConstraints(
-			path.Root("fabric_addressing"),
-			version.MustConstraints(version.NewConstraint(">="+apiversions.Apstra411)),
+			apiversions.AttributeConstraint{
+				Path:        path.Root("fabric_addressing"),
+				Constraints: version.MustConstraints(version.NewConstraint(">=" + apiversions.Apstra411)),
+			},
 		)
 	}
 
 	if utils.Known(o.FabricMtu) {
 		response.AddAttributeConstraints(
-			path.Root("fabric_mtu"),
-			version.MustConstraints(version.NewConstraint(">="+apiversions.Apstra420)),
+			apiversions.AttributeConstraint{
+				Path:        path.Root("fabric_mtu"),
+				Constraints: version.MustConstraints(version.NewConstraint(">=" + apiversions.Apstra420)),
+			},
 		)
 	}
 

--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -922,8 +922,10 @@ func (o DatacenterVirtualNetwork) VersionConstraints() apiversions.Constraints {
 
 	if utils.Known(o.L3Mtu) {
 		response.AddAttributeConstraints(
-			path.Root("l3_mtu"),
-			version.MustConstraints(version.NewConstraint(">="+apiversions.Apstra420)),
+			apiversions.AttributeConstraint{
+				Path:        path.Root("l3_mtu"),
+				Constraints: version.MustConstraints(version.NewConstraint(">=" + apiversions.Apstra420)),
+			},
 		)
 	}
 

--- a/apstra/connectivity_template/ip_link.go
+++ b/apstra/connectivity_template/ip_link.go
@@ -198,8 +198,10 @@ func (o IpLink) VersionConstraints() apiversions.Constraints {
 
 	if !o.L3Mtu.IsNull() {
 		response.AddAttributeConstraints(
-			path.Root("l3_mtu"),
-			version.MustConstraints(version.NewConstraint(">="+apiversions.Apstra420)),
+			apiversions.AttributeConstraint{
+				Path:        path.Root("l3_mtu"),
+				Constraints: version.MustConstraints(version.NewConstraint(">=" + apiversions.Apstra420)),
+			},
 		)
 	}
 

--- a/apstra/design/template_rack_based.go
+++ b/apstra/design/template_rack_based.go
@@ -295,8 +295,10 @@ func (o TemplateRackBased) VersionConstraints() apiversions.Constraints {
 
 	if !o.FabricAddressing.IsNull() {
 		response.AddAttributeConstraints(
-			path.Root("fabric_link_addressing"),
-			version.MustConstraints(version.NewConstraint(apiversions.Apstra410)),
+			apiversions.AttributeConstraint{
+				Path:        path.Root("fabric_link_addressing"),
+				Constraints: version.MustConstraints(version.NewConstraint(apiversions.Apstra410)),
+			},
 		)
 	}
 

--- a/docs/resources/datacenter_generic_system.md
+++ b/docs/resources/datacenter_generic_system.md
@@ -79,7 +79,7 @@ resource "apstra_datacenter_generic_system" "example" {
 ### Required
 
 - `blueprint_id` (String) Apstra Blueprint ID.
-- `links` (Attributes Set) Generic System link details (see [below for nested schema](#nestedatt--links))
+- `links` (Attributes Set) Generic System link details. Note that tagging Links requires Apstra 4.1.2 or newer. (see [below for nested schema](#nestedatt--links))
 
 ### Optional
 


### PR DESCRIPTION
Apstra versions earlier than 4.1.2 do not return link tags in GET `/api/blueprints/<id>/experience/web/cabling-map`, leading to state churn when tags are included: We never find them in `Read()`, so we always think they need to be added.

This PR adds a config constraints feature which complains when generic system link tags are used with Apstra < 4.1.2

Making recursive `VersionConstraints` calls required making some existing objects and methods public, so there's a bit of refactoring there as well.

Closes #567