### PR TITLE
The `system_attributes` block in `apstra_datacenter_device_allocation` shouldn't attempt to clear apstra-chosen values

### DIFF
--- a/docs/resources/datacenter_device_allocation.md
+++ b/docs/resources/datacenter_device_allocation.md
@@ -86,7 +86,9 @@ resource "apstra_datacenter_device_allocation" "r" {
 - `deploy_mode` (String, Deprecated) Set the [deploy mode](https://www.juniper.net/documentation/us/en/software/apstra4.1/apstra-user-guide/topics/topic-map/datacenter-deploy-mode-set.html) of the associated fabric node.
 - `device_key` (String) Unique ID for a Managed Device, generally the serial number, used to assign a Managed Device to a fabric role.
 - `initial_interface_map_id` (String) Interface Maps link a Logical Device (fabric design element) to a Device Profile (description of a specific hardware model). The value of this field must be the graph node ID (bootstrapped from Global Catalog ID) of an Interface Map. A value is required when `device_key` is omitted, or when `device_key` is supplied, but does not provide enough information to automatically select an Interface Map. The ID is used only at resource creation (in the initial `apply` operation) and for replacement when the configuration is modified. Apstra flexible fabric expansion operations should not trigger state churn due to the current Interface Map ID being inconsistent with the configured value.
-- `system_attributes` (Attributes) Attributes which should be set on the pre-existing system node. (see [below for nested schema](#nestedatt--system_attributes))
+- `system_attributes` (Attributes) Attributes which should be set on the pre-existing system node may be configured here.
+
+Note that omitting a previously configured value (e.g. setting and then subsequently clearing `asn` from the configuration) will not cause the system to revert to an Apstra-assigned value. Omitting a configuration element says "I have no opinion about this value" to Terraform. There is no mechanism to revert to Apstra-assigned values for the attributes in this block. (see [below for nested schema](#nestedatt--system_attributes))
 
 ### Read-Only
 


### PR DESCRIPTION
There are seven levers in the `system_attributes` block:

- `name`
- `hostname`
- `asn`
- `deploy_mode`
- `loopback_ipv4`
- `loopback_ipv6`
- `tags`

Of these, only `tags` should be cleared when the value is omitted by the user. This is because we can't tell the difference between "former value; now null" and "never supplied by the user".

This PR handles those situations more gracefully, and is aligned with Terraform's position that "no value" == "no opinion". The inline documentation attempts to explain that fact.

Also, added some validation to ensure that loopback addresses are supplied with 32-bit or 128-bit masks.

Closes #571
Closes #574