### PR TITLE
Revert 0c1fac8; Upgrade terraform-plugin-testing

### DIFF
--- a/Third_Party_Code/NOTICES.md
+++ b/Third_Party_Code/NOTICES.md
@@ -4404,8 +4404,8 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
 ## github.com/hashicorp/terraform-plugin-testing/helper/acctest
 
 * Name: github.com/hashicorp/terraform-plugin-testing/helper/acctest
-* Version: v1.2.0
-* License: [MPL-2.0](https://github.com/hashicorp/terraform-plugin-testing/blob/v1.2.0/LICENSE)
+* Version: v1.5.1
+* License: [MPL-2.0](https://github.com/hashicorp/terraform-plugin-testing/blob/v1.5.1/LICENSE)
 
 ```
 Copyright (c) 2014 HashiCorp, Inc.

--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -19,12 +19,12 @@ import (
 )
 
 type DeviceAllocation struct {
-	NodeId                types.String `tfsdk:"id"`                       // computed
 	BlueprintId           types.String `tfsdk:"blueprint_id"`             // required
 	NodeName              types.String `tfsdk:"node_name"`                // required
 	DeviceKey             types.String `tfsdk:"device_key"`               // optional
 	InitialInterfaceMapId types.String `tfsdk:"initial_interface_map_id"` // computed + optional
 	InterfaceMapName      types.String `tfsdk:"interface_map_name"`       // computed
+	NodeId                types.String `tfsdk:"node_id"`                  // computed
 	DeviceProfileNodeId   types.String `tfsdk:"device_profile_node_id"`   // computed
 	DeployMode            types.String `tfsdk:"deploy_mode"`              // optional
 	SystemAttributes      types.Object `tfsdk:"system_attributes"`        // optional
@@ -81,7 +81,7 @@ func (o DeviceAllocation) ResourceAttributes() map[string]resourceSchema.Attribu
 			Computed:      true,
 			PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 		},
-		"id": resourceSchema.StringAttribute{
+		"node_id": resourceSchema.StringAttribute{
 			MarkdownDescription: "Graph node ID of the fabric node to which we're allocating " +
 				"an Interface Map (and possibly a Managed Device.)",
 			Computed: true,

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -133,7 +133,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Spine",
 					},
 					checks: []resource.TestCheckFunc{
-						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Spine"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "not_set"),
@@ -162,7 +162,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						},
 					},
 					checks: []resource.TestCheckFunc{
-						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Spine"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "SPINE1"),
@@ -193,7 +193,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						},
 					},
 					checks: []resource.TestCheckFunc{
-						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Spine"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "SPINE2"),

--- a/docs/resources/datacenter_device_allocation.md
+++ b/docs/resources/datacenter_device_allocation.md
@@ -93,8 +93,8 @@ Note that omitting a previously configured value (e.g. setting and then subseque
 ### Read-Only
 
 - `device_profile_node_id` (String) Device Profiles specify attributes of specific hardware models.
-- `id` (String) Graph node ID of the fabric node to which we're allocating an Interface Map (and possibly a Managed Device.)
 - `interface_map_name` (String) The Interface Map Name is recorded only at creation time toaid in detection of changes to the Interface Map made outside of Terraform.
+- `node_id` (String) Graph node ID of the fabric node to which we're allocating an Interface Map (and possibly a Managed Device.)
 
 <a id="nestedatt--system_attributes"></a>
 ### Nested Schema for `system_attributes`

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-nettypes v0.1.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.21.0
-	github.com/hashicorp/terraform-plugin-testing v1.2.0
+	github.com/hashicorp/terraform-plugin-testing v1.5.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/orsinium-labs/enum v1.3.0
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a

--- a/go.sum
+++ b/go.sum
@@ -691,8 +691,8 @@ github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9T
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0 h1:wcOKYwPI9IorAJEBLzgclh3xVolO7ZorYd6U1vnok14=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0/go.mod h1:qH/34G25Ugdj5FcM95cSoXzUgIbgfhVLXCcEcYaMwq8=
-github.com/hashicorp/terraform-plugin-testing v1.2.0 h1:pASRAe6BOZFO4xSGQr9WzitXit0nrQAYDk8ziuRfn9E=
-github.com/hashicorp/terraform-plugin-testing v1.2.0/go.mod h1:+8bp3O7xUb1UtBcdknrGdVRIuTw4b62TYSIgXHqlyew=
+github.com/hashicorp/terraform-plugin-testing v1.5.1 h1:T4aQh9JAhmWo4+t1A7x+rnxAJHCDIYW9kXyo4sVO92c=
+github.com/hashicorp/terraform-plugin-testing v1.5.1/go.mod h1:dg8clO6K59rZ8w9EshBmDp1CxTIPu3yA4iaDpX1h5u0=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=


### PR DESCRIPTION
With v0.51.0, the `node_id` attribute in the `apstra_datacenter_device_allocation` resource was renamed to `id`.

This change was made to accommodate a quirk of `terraform-plugin-testing` which assumed that all resources and data sources must have an `id` field (that's the behavior of the old plugin SDKv2).

An unfortunate side-effect of the renaming was that it became impossible to upgrade because we assume that an existing resource will always have a value here, but a state file written by an earlier version was storing the value under the wrong name.

This PR reverts the misguided renaming and upgrades `terraform-plugin-testing` to v1.5.1 which has lifted the `id` requirement.

v0.51.0 was introduced only about 72 hours ago, and was available only over a long US weekend, so it seems like the blast radius (likely involved state files) is pretty low.

Closes #577