### PR TITLE
WIP: Bug 579: Don't attempt to read/set loopback/asn on access switches

### DIFF
--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -3,6 +3,8 @@ package blueprint
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -15,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"strings"
 )
 
 type DeviceAllocation struct {
@@ -575,7 +576,6 @@ func (o *DeviceAllocation) deviceProfileNodeIdFromInterfaceMapCatalogId(ctx cont
 		})
 
 	err := query.Do(ctx, &response)
-
 	if err != nil {
 		if utils.IsApstra404(err) {
 			o.BlueprintId = types.StringNull()

--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -724,6 +724,9 @@ func (o *DeviceAllocation) GetSystemAttributes(ctx context.Context, bp *apstra.T
 		return
 	}
 
+	// copy the new DeployMode over to the old location
+	o.DeployMode = systemAttributes.DeployMode
+
 	var d diag.Diagnostics
 	o.SystemAttributes, d = types.ObjectValueFrom(ctx, systemAttributes.attrTypes(), systemAttributes)
 	diags.Append(d...)

--- a/apstra/blueprint/device_allocation_system_attributes.go
+++ b/apstra/blueprint/device_allocation_system_attributes.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
+	"net"
+	"regexp"
+	"strconv"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -17,10 +22,6 @@ import (
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"math"
-	"net"
-	"regexp"
-	"strconv"
 )
 
 type DeviceAllocationSystemAttributes struct {

--- a/apstra/blueprint/device_allocation_system_attributes.go
+++ b/apstra/blueprint/device_allocation_system_attributes.go
@@ -79,7 +79,8 @@ func (o DeviceAllocationSystemAttributes) ResourceAttributes() map[string]resour
 		},
 		"loopback_ipv6": resourceSchema.StringAttribute{
 			MarkdownDescription: "IPv6 address of loopback interface in CIDR notation, must use 128-bit mask. Setting " +
-				"loopback addresses is supported only for Spine and Leaf switches.",
+				"loopback addresses is supported only for Spine and Leaf switches. IPv6 must be enabled in the " +
+				"Blueprint to use this attribute.",
 			CustomType: cidrtypes.IPv6PrefixType{},
 			Optional:   true,
 			Computed:   true,

--- a/apstra/resource_datacenter_device_allocation.go
+++ b/apstra/resource_datacenter_device_allocation.go
@@ -4,20 +4,23 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"regexp"
 )
 
-var _ resource.ResourceWithConfigure = &resourceDeviceAllocation{}
-var _ resource.ResourceWithValidateConfig = &resourceDeviceAllocation{}
-var _ resourceWithSetBpClientFunc = &resourceDeviceAllocation{}
-var _ resourceWithSetBpLockFunc = &resourceDeviceAllocation{}
-var _ resourceWithSetExperimental = &resourceDeviceAllocation{}
+var (
+	_ resource.ResourceWithConfigure      = &resourceDeviceAllocation{}
+	_ resource.ResourceWithValidateConfig = &resourceDeviceAllocation{}
+	_ resourceWithSetBpClientFunc         = &resourceDeviceAllocation{}
+	_ resourceWithSetBpLockFunc           = &resourceDeviceAllocation{}
+	_ resourceWithSetExperimental         = &resourceDeviceAllocation{}
+)
 
 type resourceDeviceAllocation struct {
 	experimental    types.Bool

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -3,12 +3,13 @@ package tfapstra_test
 import (
 	"context"
 	"fmt"
+	"net"
+	"testing"
+
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/t aJuniper/apstra-go-sdk/apstra"
-	"net"
-	"testing"
 )
 
 const (
@@ -120,7 +121,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 					config: deviceAllocation{
 						blueprintId: bpClient.Id().String(),
 						nodeName:    "spine1",
-						//initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Spine",
+						// initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Spine",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
 					},
 					checks: []resource.TestCheckFunc{

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -21,7 +21,8 @@ resource "apstra_datacenter_device_allocation" "test" {
 }
 `
 
-	resourceDataCenterDeviceAllocationSystemAttributesHCL = `    {
+	resourceDataCenterDeviceAllocationSystemAttributesHCL = `
+    {
 		name          = %s
 		hostname      = %s
 		asn           = %s

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -3,9 +3,10 @@ package tfapstra_test
 import (
 	"context"
 	"fmt"
-	"github.com/Juniper/apstra-go-sdk/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
+	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/t aJuniper/apstra-go-sdk/apstra"
 	"net"
 	"testing"
 )
@@ -21,8 +22,7 @@ resource "apstra_datacenter_device_allocation" "test" {
 }
 `
 
-	resourceDataCenterDeviceAllocationSystemAttributesHCL = `
-    {
+	resourceDataCenterDeviceAllocationSystemAttributesHCL = ` {
 		name          = %s
 		hostname      = %s
 		asn           = %s
@@ -30,14 +30,13 @@ resource "apstra_datacenter_device_allocation" "test" {
 		loopback_ipv6 = %s
 		deploy_mode   = %s
 		tags          = %s
-    }
-`
+    }`
 )
 
 func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 	ctx := context.Background()
 
-	bpClient := testutils.BlueprintA(t, ctx)
+	bpClient := testutils.BlueprintC(t, ctx)
 
 	// set spine ASN pool
 	err := bpClient.SetResourceAllocation(ctx, &apstra.ResourceGroupAllocation{
@@ -66,7 +65,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 	type systemAttributes struct {
 		name         string
 		hostname     string
-		asn          int
+		asn          *int
 		loopbackIpv4 *net.IPNet
 		loopbackIpv6 *net.IPNet
 		deployMode   string
@@ -81,7 +80,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 		return fmt.Sprintf(resourceDataCenterDeviceAllocationSystemAttributesHCL,
 			stringOrNull(in.name),
 			stringOrNull(in.hostname),
-			intPtrOrNull(&in.asn),
+			intPtrOrNull(in.asn),
 			cidrOrNull(in.loopbackIpv4),
 			cidrOrNull(in.loopbackIpv6),
 			stringOrNull(in.deployMode),
@@ -119,13 +118,14 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 			steps: []testStep{
 				{
 					config: deviceAllocation{
-						blueprintId:           bpClient.Id().String(),
-						nodeName:              "spine1",
-						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Spine",
+						blueprintId: bpClient.Id().String(),
+						nodeName:    "spine1",
+						//initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Spine",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Spine"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "not_set"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "spine1"),
@@ -138,23 +138,22 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 					config: deviceAllocation{
 						blueprintId:           bpClient.Id().String(),
 						nodeName:              "spine1",
-						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Spine",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
 						systemAttributes: &systemAttributes{
 							name:     "SPINE1",
 							hostname: "spine1.test",
-							asn:      1,
+							asn:      utils.ToPtr(1),
 							loopbackIpv4: &net.IPNet{
 								IP:   net.IP{1, 1, 1, 1},
 								Mask: net.CIDRMask(32, 32),
 							},
-							loopbackIpv6: nil,
-							deployMode:   "ready",
-							tags:         []string{"one"},
+							deployMode: "ready",
+							tags:       []string{"one"},
 						},
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Spine"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "SPINE1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "spine1.test"),
@@ -169,23 +168,22 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 					config: deviceAllocation{
 						blueprintId:           bpClient.Id().String(),
 						nodeName:              "spine1",
-						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Spine",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
 						systemAttributes: &systemAttributes{
 							name:     "SPINE2",
 							hostname: "spine2.test",
-							asn:      2,
+							asn:      utils.ToPtr(2),
 							loopbackIpv4: &net.IPNet{
 								IP:   net.IP{2, 2, 2, 2},
 								Mask: net.CIDRMask(32, 32),
 							},
-							loopbackIpv6: nil,
-							deployMode:   "drain",
-							tags:         []string{"two", "2"},
+							deployMode: "drain",
+							tags:       []string{"two", "2"},
 						},
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Spine"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "SPINE2"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "spine2.test"),
@@ -195,6 +193,300 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "two"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "2"),
+					},
+				},
+			},
+		},
+		"leaf_start_minimal": {
+			steps: []testStep{
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_leaf1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "initial_interface_map_id", "Juniper_vQFX__AOS-7x10-Leaf"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Leaf"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeNone)),
+					},
+				},
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_leaf1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
+						systemAttributes: &systemAttributes{
+							name:         "leaf_start_minimal_name",
+							hostname:     "leafstartminimalhostname.com",
+							asn:          utils.ToPtr(1),
+							loopbackIpv4: &net.IPNet{IP: net.IP{1, 1, 1, 1}, Mask: net.CIDRMask(32, 32)},
+							deployMode:   "drain",
+							tags:         []string{"one", "1"},
+						},
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "initial_interface_map_id", "Juniper_vQFX__AOS-7x10-Leaf"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Leaf"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "leaf_start_minimal_name"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartminimalhostname.com"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
+						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
+						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
+					},
+				},
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_leaf1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "initial_interface_map_id", "Juniper_vQFX__AOS-7x10-Leaf"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Leaf"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "leaf_start_minimal_name"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartminimalhostname.com"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+					},
+				},
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_leaf1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
+						systemAttributes: &systemAttributes{
+							name: "l2_one_access_001_leaf1",
+						},
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "l2_one_access_001_leaf1"),
+					},
+				},
+			},
+		},
+		"leaf_start_maximal": {
+			steps: []testStep{
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_leaf1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
+						systemAttributes: &systemAttributes{
+							name:         "leaf_start_maximal_name",
+							hostname:     "leafstartmaximalhostname.com",
+							asn:          utils.ToPtr(1),
+							loopbackIpv4: &net.IPNet{IP: net.IP{1, 1, 1, 1}, Mask: net.CIDRMask(32, 32)},
+							deployMode:   "drain",
+							tags:         []string{"one", "1"},
+						},
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "initial_interface_map_id", "Juniper_vQFX__AOS-7x10-Leaf"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Leaf"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "leaf_start_maximal_name"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartmaximalhostname.com"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
+						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
+						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
+					},
+				},
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_leaf1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "initial_interface_map_id", "Juniper_vQFX__AOS-7x10-Leaf"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Leaf"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "leaf_start_maximal_name"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartmaximalhostname.com"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+					},
+				},
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_leaf1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
+						systemAttributes: &systemAttributes{
+							name: "l2_one_access_001_leaf1",
+						},
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "l2_one_access_001_leaf1"),
+					},
+				},
+			},
+		},
+		"access_start_minimal": {
+			steps: []testStep{
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_access1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "initial_interface_map_id", "Juniper_vQFX__AOS-8x10-1"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeNone)),
+					},
+				},
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_access1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
+						systemAttributes: &systemAttributes{
+							name:       "access_start_minimal_name",
+							hostname:   "accessstartminimalhostname.com",
+							deployMode: "drain",
+							tags:       []string{"one", "1"},
+						},
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "initial_interface_map_id", "Juniper_vQFX__AOS-8x10-1"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_minimal_name"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartminimalhostname.com"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
+						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
+						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
+					},
+				},
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_access1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "initial_interface_map_id", "Juniper_vQFX__AOS-8x10-1"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_minimal_name"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartminimalhostname.com"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+					},
+				},
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_access1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
+						systemAttributes: &systemAttributes{
+							name: "l2_one_access_001_access1",
+						},
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "l2_one_access_001_access1"),
+					},
+				},
+			},
+		},
+		"access_start_maximal": {
+			steps: []testStep{
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_access1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
+						systemAttributes: &systemAttributes{
+							name:       "access_start_maximal_name",
+							hostname:   "accessstartmaximalhostname.com",
+							deployMode: "drain",
+							tags:       []string{"one", "1"},
+						},
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "initial_interface_map_id", "Juniper_vQFX__AOS-8x10-1"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_maximal_name"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartmaximalhostname.com"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
+						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
+						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
+					},
+				},
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_access1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "initial_interface_map_id", "Juniper_vQFX__AOS-8x10-1"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_maximal_name"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartmaximalhostname.com"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+					},
+				},
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_access1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
+						systemAttributes: &systemAttributes{
+							name: "l2_one_access_001_access1",
+						},
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "l2_one_access_001_access1"),
 					},
 				},
 			},

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -6,10 +6,10 @@ import (
 	"net"
 	"testing"
 
+	"github.com/Juniper/apstra-go-sdk/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/t aJuniper/apstra-go-sdk/apstra"
 )
 
 const (

--- a/docs/resources/datacenter_device_allocation.md
+++ b/docs/resources/datacenter_device_allocation.md
@@ -105,7 +105,7 @@ Optional:
 - `deploy_mode` (String) Set the [deploy mode](https://www.juniper.net/documentation/us/en/software/apstra4.1/apstra-user-guide/topics/topic-map/datacenter-deploy-mode-set.html) of the associated fabric node.
 - `hostname` (String) Hostname of the System node.
 - `loopback_ipv4` (String) IPv4 address of loopback interface in CIDR notation, must use 32-bit mask. Setting loopback addresses is supported only for Spine and Leaf switches.
-- `loopback_ipv6` (String) IPv6 address of loopback interface in CIDR notation, must use 128-bit mask. Setting loopback addresses is supported only for Spine and Leaf switches.
+- `loopback_ipv6` (String) IPv6 address of loopback interface in CIDR notation, must use 128-bit mask. Setting loopback addresses is supported only for Spine and Leaf switches. IPv6 must be enabled in the Blueprint to use this attribute.
 - `name` (String) Web UI label for the system node.
 - `tags` (Set of String) Tag labels to be applied to the System node. If a Tag doesn't exist in the Blueprint it will be created automatically.
 

--- a/docs/resources/datacenter_device_allocation.md
+++ b/docs/resources/datacenter_device_allocation.md
@@ -101,11 +101,11 @@ Note that omitting a previously configured value (e.g. setting and then subseque
 
 Optional:
 
-- `asn` (Number) ASN of the system node.
+- `asn` (Number) ASN of the system node. Setting ASN is supported only for Spine and Leaf switches.
 - `deploy_mode` (String) Set the [deploy mode](https://www.juniper.net/documentation/us/en/software/apstra4.1/apstra-user-guide/topics/topic-map/datacenter-deploy-mode-set.html) of the associated fabric node.
 - `hostname` (String) Hostname of the System node.
-- `loopback_ipv4` (String) IPv4 address of loopback interface in CIDR notation, must use 32-bit mask.
-- `loopback_ipv6` (String) IPv6 address of loopback interface in CIDR notation, must use 128-bit mask.
+- `loopback_ipv4` (String) IPv4 address of loopback interface in CIDR notation, must use 32-bit mask. Setting loopback addresses is supported only for Spine and Leaf switches.
+- `loopback_ipv6` (String) IPv6 address of loopback interface in CIDR notation, must use 128-bit mask. Setting loopback addresses is supported only for Spine and Leaf switches.
 - `name` (String) Web UI label for the system node.
 - `tags` (Set of String) Tag labels to be applied to the System node. If a Tag doesn't exist in the Blueprint it will be created automatically.
 


### PR DESCRIPTION
The new `system_attributes` object in the `apstra_datacenter_device_allocation` resource assumes that systems have associated `domain` and `interface` (loopback 0) nodes.

This isn't necessarily true.

This PR ensures that when those nodes are missing, the values are set to `null` during `Read()`, and a sensible error is presented if the user defines attributes which we cannot set.

Closes #579