### PR TITLE
Bug 582: Sort rack elements when generating rack request

### DIFF
--- a/apstra/design/rack_type.go
+++ b/apstra/design/rack_type.go
@@ -456,18 +456,18 @@ func (o *RackType) genericSystems(ctx context.Context, diags *diag.Diagnostics) 
 	return genericSystems
 }
 
-func (o *RackType) genericSystemByName(ctx context.Context, requested string, diags *diag.Diagnostics) *GenericSystem {
-	genericSystems := o.genericSystems(ctx, diags)
-	if diags.HasError() {
-		return nil
-	}
-
-	if gs, ok := genericSystems[requested]; ok {
-		return &gs
-	}
-
-	return nil
-}
+//func (o *RackType) genericSystemByName(ctx context.Context, requested string, diags *diag.Diagnostics) *GenericSystem {
+//	genericSystems := o.genericSystems(ctx, diags)
+//	if diags.HasError() {
+//		return nil
+//	}
+//
+//	if gs, ok := genericSystems[requested]; ok {
+//		return &gs
+//	}
+//
+//	return nil
+//}
 
 // CopyWriteOnlyElements copies elements (IDs of nested design API objects)
 // from 'src' (plan or state - something which knows these facts) into 'o' a

--- a/apstra/design/rack_type_link.go
+++ b/apstra/design/rack_type_link.go
@@ -194,8 +194,8 @@ func (o *RackLink) Request(ctx context.Context, path path.Path, rack *RackType, 
 		}
 	}
 
-	leaf := rack.GetLeafSwitchByName(ctx, o.TargetSwitchName.ValueString(), diags)
-	access := rack.GetAccessSwitchByName(ctx, o.TargetSwitchName.ValueString(), diags)
+	leaf := rack.leafSwitchByName(ctx, o.TargetSwitchName.ValueString(), diags)
+	access := rack.accessSwitchByName(ctx, o.TargetSwitchName.ValueString(), diags)
 	if leaf == nil && access == nil {
 		diags.AddAttributeError(path, errInvalidConfig,
 			fmt.Sprintf("target switch %q not found in rack type %q", o.TargetSwitchName.ValueString(), rack.Id))


### PR DESCRIPTION
We keep track of system rack elements (leaf/access/generic/) in a map keyed by name.

The Apstra API keeps track of them as a list, and discards the name when scaffolding the rack into a blueprint.

Losing both the name/label and the map key makes it impossible to predict which leaf is which when the new rack appears in the blueprint.

This PR sorts the leaf / access / generic devices by label when creating them in the design API, making the result predictable.

Additionally a set of `Get<thing>()` functions have been renamed to just `<thing>()` because they're just spitting out the contents of the receiver. There's no "get" feature in these methods. Additionally, they've been made private. One of the methods wasn't used (this became obvious when it was made private), so it's been "removed" via comment.

Closes #582