### PR TITLE
Bug #584: nil pointer dereference when creating `device_allocation` with empty tags

### DIFF
--- a/apstra/blueprint/device_allocation_system_attributes.go
+++ b/apstra/blueprint/device_allocation_system_attributes.go
@@ -429,8 +429,8 @@ func (o *DeviceAllocationSystemAttributes) setProperties(ctx context.Context, bp
 
 func (o *DeviceAllocationSystemAttributes) setTags(ctx context.Context, state *DeviceAllocationSystemAttributes, bp *apstra.TwoStageL3ClosClient, nodeId apstra.ObjectId, diags *diag.Diagnostics) {
 	// not a Computed value, so IsNull() will suffice
-	if o.Tags.IsNull() && len(state.Tags.Elements()) == 0 {
-		// tags not supplied by user indicates we intend to clear them
+	if len(o.Tags.Elements()) == 0 && (state == nil || len(state.Tags.Elements()) == 0) {
+		// user supplied no tags (requiring us to clear them), but state indicates no tags exist
 		return
 	}
 

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -492,6 +492,24 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 				},
 			},
 		},
+		"bug_584": {
+			steps: []testStep{
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_001_leaf1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
+						systemAttributes: &systemAttributes{
+							deployMode: "drain",
+						},
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
+					},
+				},
+			},
+		},
 	}
 
 	for tName, tCase := range testCases {


### PR DESCRIPTION
The following check exists to determine if we can bail early on setting tags because neither `o` (the plan) nor `state` indicate any tags (plan matches state):
```go
if o.Tags.IsNull() && len(state.Tags.Elements()) == 0 {}
```

It now looks like this:
```go
if len(o.Tags.Elements()) == 0 && (state == nil || len(state.Tags.Elements()) == 0) {}
```

`Create()` runs this code with no state object, so state is `nil`, leading to a nil pointer dereference at `state.Tags.Elements()`

Additionally, I changed `o.Tags.IsNull()` (no tags) to the more general `len(o.Tags.Elements()) == 0` (no tags, but works when `o.Tags` has a *known empty* value)

A test case for this crash was added.