### PR TITLE
`device_allocation` resource: check if the target is switch or server in`Update()`

### DIFF
--- a/apstra/blueprint/device_allocation_system_attributes.go
+++ b/apstra/blueprint/device_allocation_system_attributes.go
@@ -428,7 +428,6 @@ func (o *DeviceAllocationSystemAttributes) setProperties(ctx context.Context, bp
 }
 
 func (o *DeviceAllocationSystemAttributes) setTags(ctx context.Context, state *DeviceAllocationSystemAttributes, bp *apstra.TwoStageL3ClosClient, nodeId apstra.ObjectId, diags *diag.Diagnostics) {
-	// not a Computed value, so IsNull() will suffice
 	if len(o.Tags.Elements()) == 0 && (state == nil || len(state.Tags.Elements()) == 0) {
 		// user supplied no tags (requiring us to clear them), but state indicates no tags exist
 		return

--- a/apstra/resource_datacenter_device_allocation.go
+++ b/apstra/resource_datacenter_device_allocation.go
@@ -79,7 +79,7 @@ func (o *resourceDeviceAllocation) Create(ctx context.Context, req resource.Crea
 
 	// if the user gave us system attributes, make sure that we're pointed at a switch
 	if !plan.SystemAttributes.IsUnknown() {
-		plan.EnsureSystemIsSwitchBeforeCreate(ctx, bp, &resp.Diagnostics)
+		plan.EnsureSystemIsSwitch(ctx, bp, o.experimental.ValueBool(), &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -269,6 +269,14 @@ func (o *resourceDeviceAllocation) Update(ctx context.Context, req resource.Upda
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create blueprint client", err.Error())
 		return
+	}
+
+	// if the user gave us system attributes, make sure that we're pointed at a switch
+	if !plan.SystemAttributes.IsUnknown() {
+		state.EnsureSystemIsSwitch(ctx, bp, o.experimental.ValueBool(), &resp.Diagnostics) // use state for node_id
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Lock the blueprint mutex.


### PR DESCRIPTION
The `EnsureSystemIsSwitchBeforeCreate()` function gets called to ensure that the target system is a switch (not generic) before a `device_allocation` resource with `system_attributes` is allowed to `Create()`.

That is because servers have different methods for handling ASN and Loopback addressing then switches, and we've only implemented the switch bits.

The problem comes up if a user adds `system_attributes` after initial create.

We need to do the same check in `Update()`.

This PR renames `EnsureSystemIsSwitchBeforeCreate()` to `EnsureSystemIsSwitch()` and modifies its check to use either the `NodeName` attribute (during initial `Create()`) or `NodeId` (during `Update()`) as appropriate.