### PR TITLE
Ensure that `device_allocation` resource clears tags in `Delete()`

### DIFF
--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -728,7 +728,7 @@ func (o *DeviceAllocation) GetSystemAttributes(ctx context.Context, bp *apstra.T
 	o.DeployMode = systemAttributes.DeployMode
 
 	var d diag.Diagnostics
-	o.SystemAttributes, d = types.ObjectValueFrom(ctx, systemAttributes.attrTypes(), systemAttributes)
+	o.SystemAttributes, d = types.ObjectValueFrom(ctx, systemAttributes.AttrTypes(), systemAttributes)
 	diags.Append(d...)
 }
 

--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -373,8 +373,7 @@ func (o *DeviceAllocation) SetInterfaceMap(ctx context.Context, bp *apstra.TwoSt
 func (o *DeviceAllocation) SetNodeSystemId(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) {
 	var deviceKeyPtr *string
 	if !o.DeviceKey.IsNull() {
-		dk := o.DeviceKey.ValueString()
-		deviceKeyPtr = &dk
+		deviceKeyPtr = utils.ToPtr(o.DeviceKey.ValueString())
 	}
 
 	patch := &struct {
@@ -383,15 +382,13 @@ func (o *DeviceAllocation) SetNodeSystemId(ctx context.Context, client *apstra.C
 		SystemId: deviceKeyPtr,
 	}
 
-	nodeId := apstra.ObjectId(o.NodeId.ValueString())
-	blueprintId := apstra.ObjectId(o.BlueprintId.ValueString())
-	err := client.PatchNode(ctx, blueprintId, nodeId, &patch, nil)
+	err := client.PatchNode(ctx, apstra.ObjectId(o.BlueprintId.ValueString()), apstra.ObjectId(o.NodeId.ValueString()), &patch, nil)
 	if err != nil {
 		if utils.IsApstra404(err) {
 			o.BlueprintId = types.StringNull()
 			return
 		}
-		diags.AddError(fmt.Sprintf("failed to (re)assign system_id for node '%s'", nodeId), err.Error())
+		diags.AddError(fmt.Sprintf("failed to (re)assign system_id for node '%s'", apstra.ObjectId(o.NodeId.ValueString())), err.Error())
 	}
 }
 

--- a/apstra/blueprint/device_allocation_system_attributes.go
+++ b/apstra/blueprint/device_allocation_system_attributes.go
@@ -34,7 +34,7 @@ type DeviceAllocationSystemAttributes struct {
 	DeployMode   types.String         `tfsdk:"deploy_mode"`
 }
 
-func (o DeviceAllocationSystemAttributes) attrTypes() map[string]attr.Type {
+func (o DeviceAllocationSystemAttributes) AttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"name":          types.StringType,
 		"hostname":      types.StringType,

--- a/apstra/resource_datacenter_device_allocation.go
+++ b/apstra/resource_datacenter_device_allocation.go
@@ -353,10 +353,13 @@ func (o *resourceDeviceAllocation) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	state.InitialInterfaceMapId = types.StringNull()
-	state.SetInterfaceMap(ctx, bp, &resp.Diagnostics)
+	plan := state                                                                                      // clone the state into a "destroy plan"
+	plan.SystemAttributes = types.ObjectNull(blueprint.DeviceAllocationSystemAttributes{}.AttrTypes()) // no tags
+	plan.InitialInterfaceMapId = types.StringNull()                                                    // 'null' triggers clearing the interface map
+	plan.DeviceKey = types.StringNull()                                                                // 'null' triggers clearing the system_id
 
-	state.DeviceKey = types.StringNull() // 'null' triggers clearing the 'system_id' field.
+	plan.SetSystemAttributes(ctx, &state, bp, &resp.Diagnostics)
+	state.SetInterfaceMap(ctx, bp, &resp.Diagnostics)
 	state.SetNodeSystemId(ctx, bp.Client(), &resp.Diagnostics)
 }
 

--- a/apstra/resource_datacenter_device_allocation.go
+++ b/apstra/resource_datacenter_device_allocation.go
@@ -354,13 +354,13 @@ func (o *resourceDeviceAllocation) Delete(ctx context.Context, req resource.Dele
 	}
 
 	plan := state                                                                                      // clone the state into a "destroy plan"
-	plan.SystemAttributes = types.ObjectNull(blueprint.DeviceAllocationSystemAttributes{}.AttrTypes()) // no tags
+	plan.SystemAttributes = types.ObjectNull(blueprint.DeviceAllocationSystemAttributes{}.AttrTypes()) // clear out SA so it has no tags (other details irrelevant)
 	plan.InitialInterfaceMapId = types.StringNull()                                                    // 'null' triggers clearing the interface map
 	plan.DeviceKey = types.StringNull()                                                                // 'null' triggers clearing the system_id
 
-	plan.SetSystemAttributes(ctx, &state, bp, &resp.Diagnostics)
-	state.SetInterfaceMap(ctx, bp, &resp.Diagnostics)
-	state.SetNodeSystemId(ctx, bp.Client(), &resp.Diagnostics)
+	plan.SetSystemAttributes(ctx, &state, bp, &resp.Diagnostics) // wipes out tags only
+	plan.SetInterfaceMap(ctx, bp, &resp.Diagnostics)             // clear the interface map association
+	plan.SetNodeSystemId(ctx, bp.Client(), &resp.Diagnostics)    // clear the system_id (managed device ID) from the system node
 }
 
 func (o *resourceDeviceAllocation) setBpClientFunc(f func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)) {


### PR DESCRIPTION
Deleting an instance of the `apstra_datacenter_device_allocation` resource merely un-links the system node from the specified interface map (and possibly managed device) node.

It doesn't currently clean up any of the other changes it may have effected via the `system_attributes` resource.

This PR ensures that `tags` are cleared from the system node if the state indicates we'd previously set some tags.