### PR TITLE
Improve device allocation / system attributes logic

### DIFF
--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -723,6 +723,13 @@ func (o DeviceAllocation) EnsureSystemIsSwitch(ctx context.Context, bp *apstra.T
 
 func (o *DeviceAllocation) GetSystemAttributes(ctx context.Context, bp *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) {
 	var systemAttributes DeviceAllocationSystemAttributes
+	if !o.SystemAttributes.IsUnknown() {
+		diags.Append(o.SystemAttributes.As(ctx, &systemAttributes, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return
+		}
+	}
+
 	systemAttributes.Get(ctx, bp, o.NodeId, diags)
 	if diags.HasError() {
 		return

--- a/apstra/resource_datacenter_device_allocation.go
+++ b/apstra/resource_datacenter_device_allocation.go
@@ -2,9 +2,10 @@ package tfapstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
@@ -122,24 +123,13 @@ func (o *resourceDeviceAllocation) Create(ctx context.Context, req resource.Crea
 		}
 	}
 
-	switch {
-	case plan.DeployMode.IsNull(): // not expected with Optional+Computed, nothing to do here
-	case plan.DeployMode.IsUnknown(): // config is null, get the Computed value
-		deployMode, err := utils.GetNodeDeployMode(ctx, bp, plan.NodeId.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("failed to fetch node deploy mode", err.Error())
+	if utils.Known(plan.DeployMode) {
+		sa, d := types.ObjectValueFrom(ctx, blueprint.DeviceAllocationSystemAttributes{}.AttrTypes(), basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
 			return
 		}
-		plan.DeployMode = types.StringValue(deployMode)
-	default: // value provided via config
-		err = utils.SetNodeDeployMode(ctx, bp, plan.NodeId.ValueString(), plan.DeployMode.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("failed while setting node deploy mode", err.Error())
-			return
-		}
-	}
-	if resp.Diagnostics.HasError() {
-		return
+		plan.SystemAttributes = sa
 	}
 
 	// set system attributes
@@ -207,16 +197,6 @@ func (o *resourceDeviceAllocation) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	deployMode, err := utils.GetNodeDeployMode(ctx, bp, state.NodeId.ValueString())
-	if err != nil {
-		var ace apstra.ClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
-			resp.State.RemoveResource(ctx)
-			return
-		}
-	}
-	state.DeployMode = types.StringValue(deployMode)
-
 	state.GetInterfaceMapName(ctx, bp.Client(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
@@ -241,10 +221,19 @@ func (o *resourceDeviceAllocation) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	// InterfaceMapName must be immutable in order to be useful in detecting FFE modifications
-	state.InterfaceMapName = types.StringValue(previousInterfaceMapName.ValueString())
+	state.InterfaceMapName = previousInterfaceMapName
 
-	// read any apstra-assigned values
+	// read all apstra-assigned values; blow away existing values to ensure all values are read
+	state.SystemAttributes = types.ObjectUnknown(blueprint.DeviceAllocationSystemAttributes{}.AttrTypes())
 	state.GetSystemAttributes(ctx, bp, &resp.Diagnostics)
+
+	// copy the deploy mode to the deprecated root-level attribute
+	var sa blueprint.DeviceAllocationSystemAttributes
+	resp.Diagnostics.Append(state.SystemAttributes.As(ctx, &sa, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.DeployMode = sa.DeployMode
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -288,28 +277,6 @@ func (o *resourceDeviceAllocation) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	switch {
-	case plan.DeployMode.IsNull(): // not expected with Optional+Computed, nothing to do here
-	case plan.DeployMode.IsUnknown(): // config is null, get the Computed value
-		deployMode, err := utils.GetNodeDeployMode(ctx, bp, plan.NodeId.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("failed reading node deploy mode", err.Error())
-			return
-		}
-
-		plan.DeployMode = types.StringValue(deployMode)
-	default: // value provided via config
-		err := utils.SetNodeDeployMode(ctx, bp, plan.NodeId.ValueString(), plan.DeployMode.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("failed setting node deploy mode", err.Error())
-			return
-		}
-	}
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	state.DeployMode = plan.DeployMode
-
 	if !plan.DeviceKey.Equal(state.DeviceKey) {
 		// device key has changed
 		state.DeviceKey = plan.DeviceKey // copy user input directly from plan
@@ -325,11 +292,23 @@ func (o *resourceDeviceAllocation) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	// copy the planned system attributes into the state
+	// read back any apstra-assigned attributes
+	plan.GetSystemAttributes(ctx, bp, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// read and save any apstra-assigned values
+	plan.GetSystemAttributes(ctx, bp, &resp.Diagnostics)
 	state.SystemAttributes = plan.SystemAttributes
 
-	// read any apstra-assigned values
-	state.GetSystemAttributes(ctx, bp, &resp.Diagnostics)
+	// copy the deploy mode to the deprecated root-level attribute
+	var sa blueprint.DeviceAllocationSystemAttributes
+	resp.Diagnostics.Append(state.SystemAttributes.As(ctx, &sa, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.DeployMode = sa.DeployMode
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/apstra/resource_datacenter_device_allocation.go
+++ b/apstra/resource_datacenter_device_allocation.go
@@ -123,7 +123,9 @@ func (o *resourceDeviceAllocation) Create(ctx context.Context, req resource.Crea
 		}
 	}
 
+	// Deprecated attribute in use?
 	if utils.Known(plan.DeployMode) {
+		// validators ensure that system_attributes object has been omitted. instantiate a fresh one and copy the deploy mode in there
 		sa, d := types.ObjectValueFrom(ctx, blueprint.DeviceAllocationSystemAttributes{}.AttrTypes(), basetypes.ObjectAsOptions{})
 		resp.Diagnostics.Append(d...)
 		if resp.Diagnostics.HasError() {
@@ -266,6 +268,17 @@ func (o *resourceDeviceAllocation) Update(ctx context.Context, req resource.Upda
 		if resp.Diagnostics.HasError() {
 			return
 		}
+	}
+
+	// Deprecated attribute in use?
+	if utils.Known(plan.DeployMode) {
+		// validators ensure that system_attributes object has been omitted. instantiate a fresh one and copy the deploy mode in there
+		sa, d := types.ObjectValueFrom(ctx, blueprint.DeviceAllocationSystemAttributes{}.AttrTypes(), basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		plan.SystemAttributes = sa
 	}
 
 	// Lock the blueprint mutex.

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -119,15 +119,15 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 			steps: []testStep{
 				{
 					config: deviceAllocation{
-						blueprintId: bpClient.Id().String(),
-						nodeName:    "spine1",
-						// initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Spine",
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "spine1",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", "not_set"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "not_set"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "spine1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "spine1"),
@@ -148,7 +148,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 								IP:   net.IP{1, 1, 1, 1},
 								Mask: net.CIDRMask(32, 32),
 							},
-							deployMode: "ready",
+							deployMode: utils.StringersToFriendlyString(apstra.NodeDeployModeReady),
 							tags:       []string{"one"},
 						},
 					},
@@ -156,11 +156,12 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeReady)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "SPINE1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "spine1.test"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "ready"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeReady)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "1"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
 					},
@@ -178,7 +179,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 								IP:   net.IP{2, 2, 2, 2},
 								Mask: net.CIDRMask(32, 32),
 							},
-							deployMode: "drain",
+							deployMode: utils.StringersToFriendlyString(apstra.NodeDeployModeDrain),
 							tags:       []string{"two", "2"},
 						},
 					},
@@ -186,11 +187,12 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "SPINE2"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "spine2.test"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "2"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "2.2.2.2/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "two"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "2"),
@@ -213,6 +215,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeNone)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeNone)),
 					},
 				},
 				{
@@ -225,7 +228,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 							hostname:     "leafstartminimalhostname.com",
 							asn:          utils.ToPtr(1),
 							loopbackIpv4: &net.IPNet{IP: net.IP{1, 1, 1, 1}, Mask: net.CIDRMask(32, 32)},
-							deployMode:   "drain",
+							deployMode:   utils.StringersToFriendlyString(apstra.NodeDeployModeDrain),
 							tags:         []string{"one", "1"},
 						},
 					},
@@ -240,7 +243,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartminimalhostname.com"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
@@ -263,7 +266,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartminimalhostname.com"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 					},
 				},
 				{
@@ -287,14 +290,14 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 				{
 					config: deviceAllocation{
 						blueprintId:           bpClient.Id().String(),
-						nodeName:              "l2_one_access_001_leaf1",
+						nodeName:              "l2_one_access_002_leaf1",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
 						systemAttributes: &systemAttributes{
 							name:         "leaf_start_maximal_name",
 							hostname:     "leafstartmaximalhostname.com",
 							asn:          utils.ToPtr(1),
 							loopbackIpv4: &net.IPNet{IP: net.IP{1, 1, 1, 1}, Mask: net.CIDRMask(32, 32)},
-							deployMode:   "drain",
+							deployMode:   utils.StringersToFriendlyString(apstra.NodeDeployModeDrain),
 							tags:         []string{"one", "1"},
 						},
 					},
@@ -309,7 +312,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartmaximalhostname.com"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
@@ -318,7 +321,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 				{
 					config: deviceAllocation{
 						blueprintId:           bpClient.Id().String(),
-						nodeName:              "l2_one_access_001_leaf1",
+						nodeName:              "l2_one_access_002_leaf1",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
 					},
 					checks: []resource.TestCheckFunc{
@@ -332,21 +335,21 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartmaximalhostname.com"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 					},
 				},
 				{
 					config: deviceAllocation{
 						blueprintId:           bpClient.Id().String(),
-						nodeName:              "l2_one_access_001_leaf1",
+						nodeName:              "l2_one_access_002_leaf1",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
 						systemAttributes: &systemAttributes{
-							name: "l2_one_access_001_leaf1",
+							name: "l2_one_access_002_leaf1",
 						},
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "l2_one_access_001_leaf1"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "l2_one_access_002_leaf1"),
 					},
 				},
 			},
@@ -366,6 +369,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeNone)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeNone)),
 					},
 				},
 				{
@@ -376,7 +380,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						systemAttributes: &systemAttributes{
 							name:       "access_start_minimal_name",
 							hostname:   "accessstartminimalhostname.com",
-							deployMode: "drain",
+							deployMode: utils.StringersToFriendlyString(apstra.NodeDeployModeDrain),
 							tags:       []string{"one", "1"},
 						},
 					},
@@ -389,7 +393,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_minimal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartminimalhostname.com"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
@@ -410,7 +414,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_minimal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartminimalhostname.com"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 					},
 				},
 				{
@@ -434,12 +438,12 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 				{
 					config: deviceAllocation{
 						blueprintId:           bpClient.Id().String(),
-						nodeName:              "l2_one_access_001_access1",
+						nodeName:              "l2_one_access_002_access1",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
 						systemAttributes: &systemAttributes{
 							name:       "access_start_maximal_name",
 							hostname:   "accessstartmaximalhostname.com",
-							deployMode: "drain",
+							deployMode: utils.StringersToFriendlyString(apstra.NodeDeployModeDrain),
 							tags:       []string{"one", "1"},
 						},
 					},
@@ -452,7 +456,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_maximal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartmaximalhostname.com"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
@@ -461,7 +465,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 				{
 					config: deviceAllocation{
 						blueprintId:           bpClient.Id().String(),
-						nodeName:              "l2_one_access_001_access1",
+						nodeName:              "l2_one_access_002_access1",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
 					},
 					checks: []resource.TestCheckFunc{
@@ -473,21 +477,21 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_maximal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartmaximalhostname.com"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", "drain"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 					},
 				},
 				{
 					config: deviceAllocation{
 						blueprintId:           bpClient.Id().String(),
-						nodeName:              "l2_one_access_001_access1",
+						nodeName:              "l2_one_access_002_access1",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-8x10-1",
 						systemAttributes: &systemAttributes{
-							name: "l2_one_access_001_access1",
+							name: "l2_one_access_002_access1",
 						},
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "l2_one_access_001_access1"),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "l2_one_access_002_access1"),
 					},
 				},
 			},
@@ -497,15 +501,31 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 				{
 					config: deviceAllocation{
 						blueprintId:           bpClient.Id().String(),
-						nodeName:              "l2_one_access_001_leaf1",
+						nodeName:              "l2_one_access_002_leaf1",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
 						systemAttributes: &systemAttributes{
-							deployMode: "drain",
+							deployMode: utils.StringersToFriendlyString(apstra.NodeDeployModeNone),
+						},
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeNone)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeNone)),
+					},
+				},
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_002_leaf1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
+						systemAttributes: &systemAttributes{
+							deployMode: utils.StringersToFriendlyString(apstra.NodeDeployModeDrain),
 						},
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 					},
 				},
 			},

--- a/apstra/test_utils/test_utils.go
+++ b/apstra/test_utils/test_utils.go
@@ -12,9 +12,13 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 )
 
-const testConfigFile = "../.testconfig.hcl"
+const (
+	testConfigFile = "../.testconfig.hcl"
+	timeout        = 60 * time.Second // probably should be added to env vars and to test hcl file
+)
 
 var sharedClient *apstra.Client
 var testClientMutex sync.Mutex
@@ -42,6 +46,7 @@ func GetTestClient(t testing.TB, ctx context.Context) *apstra.Client {
 			t.Fatal(err)
 		}
 
+		clientCfg.Timeout = timeout
 		clientCfg.Experimental = true
 		clientCfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
 


### PR DESCRIPTION
Customer reported a problem #587 where tags set by the resource don't appear in the final state committed by the resource code (probably in `Create()`, maybe in `Update()`).

This PR attempts to address the possibility of reading "in process" data from the API by ensuring that we only fetch/save API elements which can't be known in advance: Those not given by the user.

In addition, the old logic which fetches/sets the deprecated top-level `deploy_mode` attribute has been replaced with copying from the `system_attributes` object.

Finally, I did a review to ensure that we're running `deploy_mode` through the rosetta mechanism because `""` (API) is the same as `"not_set"` (Terraform / Web UI).

Tests were also improved so that various test cases make changes to different system nodes so they're less likely to interfere with each other.

Closes #587