### PR TITLE
Improve time complexity of `apstra_datacenter_generic_system` link updates

### DIFF
--- a/apstra/blueprint/datacenter_generic_system_link.go
+++ b/apstra/blueprint/datacenter_generic_system_link.go
@@ -195,56 +195,6 @@ func (o *DatacenterGenericSystemLink) updateTransformId(ctx context.Context, sta
 	}
 }
 
-//// updateParams checks/updates the following link parameters.
-//// - transform ID
-//// - group label
-//// - LAG mode
-//// - tags
-//// Because the DatacenterGenericSystemLink object doesn't know the link ID,
-//// the ID of the link's graph node is passed as a function argument.
-//func (o *DatacenterGenericSystemLink) updateParams(ctx context.Context, id apstra.ObjectId, state *DatacenterGenericSystemLink, client *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) {
-//	// set the transform ID if it has changed
-//	if !o.TargetSwitchIfTransformId.Equal(state.TargetSwitchIfTransformId) {
-//		err := client.SetTransformIdByIfName(ctx, apstra.ObjectId(o.TargetSwitchId.ValueString()),
-//			o.TargetSwitchIfName.ValueString(), int(o.TargetSwitchIfTransformId.ValueInt64()))
-//		if err != nil {
-//			var ace apstra.ClientErr
-//			if errors.As(err, &ace) && ace.Type() == apstra.ErrCannotChangeTransform {
-//				diags.AddWarning("could not change interface transform", err.Error())
-//			} else {
-//				diags.AddError("failed to set interface transform", err.Error())
-//				return
-//			}
-//		}
-//	}
-//
-//	// set the tags, lag mode and group label if any have changed
-//	if !o.Tags.Equal(state.Tags) || !o.LagMode.Equal(state.LagMode) || !o.GroupLabel.Equal(state.GroupLabel) {
-//		var tags []string
-//		diags.Append(o.Tags.ElementsAs(ctx, &tags, false)...)
-//		if tags == nil {
-//			tags = []string{} // convert nil -> empty slice to clear tags
-//		}
-//
-//		var lagMode apstra.RackLinkLagMode
-//		err := lagMode.FromString(o.LagMode.ValueString())
-//		if err != nil {
-//			diags.AddError(fmt.Sprintf("failed to parse lag mode %s", o.LagMode), err.Error())
-//			return
-//		}
-//
-//		// set lag params + tag set
-//		err = client.SetLinkLagParams(ctx, &apstra.SetLinkLagParamsRequest{id: apstra.LinkLagParams{
-//			GroupLabel: o.GroupLabel.ValueString(),
-//			LagMode:    lagMode,
-//			Tags:       tags,
-//		}})
-//		if err != nil {
-//			diags.AddError(fmt.Sprintf("failed to set link %s LAG parameters", id), err.Error())
-//		}
-//	}
-//}
-
 func (o *DatacenterGenericSystemLink) versionConstraintsAsGenericSystemLink(_ context.Context, path path.Path, _ *diag.Diagnostics) apiversions.Constraints {
 	var result apiversions.Constraints
 


### PR DESCRIPTION
Rather than asking each link object to update its own parameters (`DatacenterGenericSystemLink.updateParams()`), we now collect the link parameter request object from each link (`DatacenterGenericSystemLink.lagParams()`) and then submit the changes to each link in a single request.

Closes #596