### PR TITLE
Bug #609 - fix handling of deprecated attribute

### DIFF
--- a/apstra/blueprint/device_allocation_system_attributes.go
+++ b/apstra/blueprint/device_allocation_system_attributes.go
@@ -36,9 +36,9 @@ type DeviceAllocationSystemAttributes struct {
 
 func (o DeviceAllocationSystemAttributes) AttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
+		"asn":           types.Int64Type,
 		"name":          types.StringType,
 		"hostname":      types.StringType,
-		"asn":           types.Int64Type,
 		"loopback_ipv4": cidrtypes.IPv4PrefixType{},
 		"loopback_ipv6": cidrtypes.IPv6PrefixType{},
 		"tags":          types.SetType{ElemType: types.StringType},

--- a/apstra/resource_datacenter_device_allocation.go
+++ b/apstra/resource_datacenter_device_allocation.go
@@ -126,7 +126,10 @@ func (o *resourceDeviceAllocation) Create(ctx context.Context, req resource.Crea
 	// Deprecated attribute in use?
 	if utils.Known(plan.DeployMode) {
 		// validators ensure that system_attributes object has been omitted. instantiate a fresh one and copy the deploy mode in there
-		sa, d := types.ObjectValueFrom(ctx, blueprint.DeviceAllocationSystemAttributes{}.AttrTypes(), basetypes.ObjectAsOptions{})
+		sa, d := types.ObjectValueFrom(ctx, blueprint.DeviceAllocationSystemAttributes{}.AttrTypes(), blueprint.DeviceAllocationSystemAttributes{
+			DeployMode: plan.DeployMode,
+			Tags:       types.SetNull(types.StringType),
+		})
 		resp.Diagnostics.Append(d...)
 		if resp.Diagnostics.HasError() {
 			return

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -19,6 +19,7 @@ resource "apstra_datacenter_device_allocation" "test" {
 	blueprint_id             = %q
 	node_name                = %q
 	initial_interface_map_id = %q
+    deploy_mode              = %s
 	system_attributes        = %s
 }
 `
@@ -94,6 +95,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 		nodeName              string
 		initialInterfaceMapId string
 		systemAttributes      *systemAttributes
+		deployMode            string
 	}
 
 	renderDeviceAllocation := func(in deviceAllocation) string {
@@ -101,6 +103,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 			in.blueprintId,
 			in.nodeName,
 			in.initialInterfaceMapId,
+			stringOrNull(in.deployMode),
 			renderSystemAttributes(in.systemAttributes),
 		)
 	}
@@ -526,6 +529,21 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(apstra.NodeDeployModeDrain)),
+					},
+				},
+			},
+		},
+		"bug_609_deprecated_option": {
+			steps: []testStep{
+				{
+					config: deviceAllocation{
+						blueprintId:           bpClient.Id().String(),
+						nodeName:              "l2_one_access_003_leaf1",
+						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
+						deployMode:            "drain",
+					},
+					checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 					},
 				},
 			},


### PR DESCRIPTION
The special handing for use of the deprecated `deploy_mode` attribute wasn't set up correctly.

There was a bug in initializing a new `system_attributes` object where we copy the deprecated attribute.

This PR:
- sorts some map entries (aesthetics)
- fixes intialization of the `system_attributes` object
- includes a test case which (would have) triggered this bug

Closes #609