### PR TITLE
Missing `return` in rosetta leads to sending friendly string to API

### DIFF
--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -247,6 +247,7 @@ func overlayControlProtocolFromFriendlyString(target *apstra.OverlayControlProto
 	switch in[0] {
 	case overlayControlProtocolStatic:
 		*target = apstra.OverlayControlProtocolNone
+		return nil
 	}
 
 	return target.FromString(in[0])


### PR DESCRIPTION
closes #635 