### PR TITLE
Resource `apstra_datacenter_blueprint`: clear ipv6 flag when creating blueprint

### DIFF
--- a/apstra/blueprint/blueprint.go
+++ b/apstra/blueprint/blueprint.go
@@ -766,11 +766,19 @@ func (o *Blueprint) LoadFabricSettings(ctx context.Context, settings *apstra.Fab
 }
 
 func (o *Blueprint) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.CreateBlueprintFromTemplateRequest {
+	fabricSettings := o.FabricSettings(ctx, diags)
+	if diags.HasError() {
+		return nil
+	}
+
+	// IPv6 cannot be enabled as part of blueprint creation
+	fabricSettings.Ipv6Enabled = nil
+
 	result := apstra.CreateBlueprintFromTemplateRequest{
 		RefDesign:      apstra.RefDesignTwoStageL3Clos,
 		Label:          o.Name.ValueString(),
 		TemplateId:     apstra.ObjectId(o.TemplateId.ValueString()),
-		FabricSettings: o.FabricSettings(ctx, diags),
+		FabricSettings: fabricSettings,
 	}
 
 	if utils.Known(o.FabricAddressing) {

--- a/apstra/resource_datacenter_blueprint.go
+++ b/apstra/resource_datacenter_blueprint.go
@@ -126,14 +126,6 @@ func (o *resourceDatacenterBlueprint) Create(ctx context.Context, req resource.C
 	// Apstra 4.2.1 allows us to set *some* fabric settings as part of blueprint creation.
 	// Depending on what's in the plan, we might not need to invoke SetFabricSettings().
 	if !apiversions.Ge421.Check(apiVersion) || plan.Ipv6Applications.ValueBool() {
-		// did we really need to lock the blueprint here? nothing else knows it exists yet.
-		//// Lock the blueprint mutex.
-		//err = o.lockFunc(ctx, id.String())
-		//if err != nil {
-		//	resp.Diagnostics.AddError("failed locking blueprint mutex", err.Error())
-		//	return
-		//}
-
 		// Set the fabric settings
 		plan.SetFabricSettings(ctx, bp, nil, &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
@@ -145,6 +137,7 @@ func (o *resourceDatacenterBlueprint) Create(ctx context.Context, req resource.C
 	apiData, err := o.client.GetBlueprintStatus(ctx, id)
 	if err != nil {
 		resp.Diagnostics.AddError("error retrieving Datacenter Blueprint after creation", err.Error())
+		return
 	}
 
 	// Load blueprint status

--- a/apstra/resource_datacenter_blueprint_test.go
+++ b/apstra/resource_datacenter_blueprint_test.go
@@ -1530,12 +1530,32 @@ func TestResourceDatacenterBlueprint(t *testing.T) {
 				},
 			},
 		},
+		"evpn_start_with_ipv6": {
+			testCase: resource.TestCase{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: renderConfig(config{
+							name:             "esv6AV_0_" + rs,
+							templateId:       "L2_Virtual_EVPN",
+							ipv6Applications: utils.ToPtr(true),
+						}),
+						Check: resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+							resource.TestCheckResourceAttrSet("apstra_datacenter_blueprint.test", "id"),
+							resource.TestCheckResourceAttr("apstra_datacenter_blueprint.test", "name", "esv6AV_0_"+rs),
+							resource.TestCheckResourceAttr("apstra_datacenter_blueprint.test", "template_id", "L2_Virtual_EVPN"),
+							resource.TestCheckResourceAttr("apstra_datacenter_blueprint.test", "ipv6_applications", "true"),
+						}...),
+					},
+				},
+			},
+		},
 	}
 
 	for tName, tCase := range testCases {
 		tName, tCase := tName, tCase
 		t.Run(tName, func(t *testing.T) {
-			t.Parallel()
+			//t.Parallel()
 			if !tCase.apiVersionConstraints.Check(apiVersion) {
 				t.Skipf("API version %s does not satisfy version constraints(%s) of test %q",
 					apiVersion, tCase.apiVersionConstraints, tName)


### PR DESCRIPTION
This PR clears the `Ipv6Enabled` flag from the `FabricSettings` object in a blueprint creation request because the flag (which would be ignored by the API) provokes an SDK error.

The flag is set in a post-creation operation (no change here).

Added a test for this condition to the test cases.

Closes #655