### PR TITLE
#670 Fix potential nil pointer dereference

### DIFF
--- a/apstra/blueprint/datacenter_generic_system_link.go
+++ b/apstra/blueprint/datacenter_generic_system_link.go
@@ -118,7 +118,7 @@ func (o *DatacenterGenericSystemLink) loadApiData(ctx context.Context, in *apstr
 	switchEndpoint := in.OppositeEndpointBySystemId(genericSystemId)
 
 	o.TargetSwitchId = types.StringValue(switchEndpoint.System.Id.String())
-	o.TargetSwitchIfName = types.StringValue(*switchEndpoint.Interface.IfName)
+	o.TargetSwitchIfName = types.StringPointerValue(switchEndpoint.Interface.IfName)
 	o.GroupLabel = types.StringValue(in.GroupLabel)
 	o.LagMode = utils.StringValueOrNull(ctx, switchEndpoint.Interface.LagMode.String(), diags)
 	o.Tags = utils.SetValueOrNull(ctx, types.StringType, in.TagLabels, diags)


### PR DESCRIPTION
Prior to this change, we didn't handle the case of a nil link endpoint correctly. Not sure why the API is responding with a `nil` value here - maybe related to un-assigned interface map?

In any case, this PR should improve things a bit.