### PR TITLE
Rename `ip_links_ids` attribute to `ip_link_ids`

### DIFF
--- a/apstra/blueprint/connectivity_template_assignments.go
+++ b/apstra/blueprint/connectivity_template_assignments.go
@@ -22,7 +22,7 @@ type ConnectivityTemplateAssignments struct {
 	ConnectivityTemplateId types.String `tfsdk:"connectivity_template_id"`
 	ApplicationPointIds    types.Set    `tfsdk:"application_point_ids"`
 	FetchIpLinkIds         types.Bool   `tfsdk:"fetch_ip_link_ids"`
-	IpLinkIds              types.Map    `tfsdk:"ip_links_ids"`
+	IpLinkIds              types.Map    `tfsdk:"ip_link_ids"`
 }
 
 func (o ConnectivityTemplateAssignments) ResourceAttributes() map[string]resourceSchema.Attribute {
@@ -55,7 +55,7 @@ func (o ConnectivityTemplateAssignments) ResourceAttributes() map[string]resourc
 				"is not needed.",
 			Optional: true,
 		},
-		"ip_links_ids": resourceSchema.MapAttribute{
+		"ip_link_ids": resourceSchema.MapAttribute{
 			MarkdownDescription: "New Logical Links are created when Connectivity Templates containing *IP Link* " +
 				"primitives are attached to a switch interface. These logical links may or may not be VLAN-tagged. " +
 				"This attribute is a two-dimensional map. The outer map is keyed by Application Point ID. The inner " +

--- a/apstra/blueprint/connectivity_templates_assignment.go
+++ b/apstra/blueprint/connectivity_templates_assignment.go
@@ -23,7 +23,7 @@ type ConnectivityTemplatesAssignment struct {
 	ConnectivityTemplateIds types.Set    `tfsdk:"connectivity_template_ids"`
 	ApplicationPointId      types.String `tfsdk:"application_point_id"`
 	FetchIpLinkIds          types.Bool   `tfsdk:"fetch_ip_link_ids"`
-	IpLinkIds               types.Map    `tfsdk:"ip_links_ids"`
+	IpLinkIds               types.Map    `tfsdk:"ip_link_ids"`
 }
 
 func (o ConnectivityTemplatesAssignment) ResourceAttributes() map[string]resourceSchema.Attribute {
@@ -56,7 +56,7 @@ func (o ConnectivityTemplatesAssignment) ResourceAttributes() map[string]resourc
 				"is not needed.",
 			Optional: true,
 		},
-		"ip_links_ids": resourceSchema.MapAttribute{
+		"ip_link_ids": resourceSchema.MapAttribute{
 			MarkdownDescription: "New Logical Links are created when Connectivity Templates containing *IP Link* " +
 				"primitives are attached to a switch interface. These logical links may or may not be VLAN-tagged. " +
 				"This attribute is a two-dimensional map. The outer map is keyed by Connectivity Template ID. The inner " +

--- a/docs/resources/datacenter_connectivity_template_assignment.md
+++ b/docs/resources/datacenter_connectivity_template_assignment.md
@@ -53,7 +53,7 @@ resource "apstra_datacenter_connectivity_template_assignment" "a" {
 
 ### Read-Only
 
-- `ip_links_ids` (Map of Map of String) New Logical Links are created when Connectivity Templates containing *IP Link* primitives are attached to a switch interface. These logical links may or may not be VLAN-tagged. This attribute is a two-dimensional map. The outer map is keyed by Connectivity Template ID. The inner map is keyed by VLAN number. Untagged Logical Links are represented in the inner map by key `0`.
+- `ip_link_ids` (Map of Map of String) New Logical Links are created when Connectivity Templates containing *IP Link* primitives are attached to a switch interface. These logical links may or may not be VLAN-tagged. This attribute is a two-dimensional map. The outer map is keyed by Connectivity Template ID. The inner map is keyed by VLAN number. Untagged Logical Links are represented in the inner map by key `0`.
 **Note:** requires `fetch_iplink_ids = true`
 
 

--- a/docs/resources/datacenter_connectivity_template_assignments.md
+++ b/docs/resources/datacenter_connectivity_template_assignments.md
@@ -51,7 +51,7 @@ resource "apstra_datacenter_connectivity_template_assignments" "a" {
 
 ### Read-Only
 
-- `ip_links_ids` (Map of Map of String) New Logical Links are created when Connectivity Templates containing *IP Link* primitives are attached to a switch interface. These logical links may or may not be VLAN-tagged. This attribute is a two-dimensional map. The outer map is keyed by Application Point ID. The inner map is keyed by VLAN number. Untagged Logical Links are represented in the inner map by key `0`.
+- `ip_link_ids` (Map of Map of String) New Logical Links are created when Connectivity Templates containing *IP Link* primitives are attached to a switch interface. These logical links may or may not be VLAN-tagged. This attribute is a two-dimensional map. The outer map is keyed by Application Point ID. The inner map is keyed by VLAN number. Untagged Logical Links are represented in the inner map by key `0`.
 **Note:** requires `fetch_iplink_ids = true`
 
 

--- a/docs/resources/datacenter_connectivity_templates_assignment.md
+++ b/docs/resources/datacenter_connectivity_templates_assignment.md
@@ -47,7 +47,7 @@ resource "apstra_datacenter_connectivity_template_assignment" "a" {
 
 ### Read-Only
 
-- `ip_links_ids` (Map of Map of String) New Logical Links are created when Connectivity Templates containing *IP Link* primitives are attached to a switch interface. These logical links may or may not be VLAN-tagged. This attribute is a two-dimensional map. The outer map is keyed by Connectivity Template ID. The inner map is keyed by VLAN number. Untagged Logical Links are represented in the inner map by key `0`.
+- `ip_link_ids` (Map of Map of String) New Logical Links are created when Connectivity Templates containing *IP Link* primitives are attached to a switch interface. These logical links may or may not be VLAN-tagged. This attribute is a two-dimensional map. The outer map is keyed by Connectivity Template ID. The inner map is keyed by VLAN number. Untagged Logical Links are represented in the inner map by key `0`.
 **Note:** requires `fetch_iplink_ids = true`
 
 


### PR DESCRIPTION
All three connectivity template assignment resources recently sprouted a new `ip_links_ids` read-only attribute:

- `apstra_datacenter_connectivity_template_assignment`
- `apstra_datacenter_connectivity_templates_assignment`
- `apstra_datacenter_connectivity_template_assignments`

Not until I got around to using it did I notice the clunky attribute name. It's better as `ip_link_ids`.