### PR TITLE
Add checks for `unknown` values to `ValidateConfig()` methods

### DIFF
--- a/apstra/data_source_datacenter_ct_bgp_peering_generic_system.go
+++ b/apstra/data_source_datacenter_ct_bgp_peering_generic_system.go
@@ -33,6 +33,10 @@ func (o *dataSourceDatacenterCtBgpPeeringGenericSystem) ValidateConfig(ctx conte
 		return
 	}
 
+	if config.Ipv4AddressingType.IsUnknown() || config.Ipv6AddressingType.IsUnknown() {
+		return //cannot validate until both values are known
+	}
+
 	v4NoneString := apstra.CtPrimitiveIPv4ProtocolSessionAddressingNone.String() // "none"
 	v6NoneString := apstra.CtPrimitiveIPv6ProtocolSessionAddressingNone.String() // "none"
 

--- a/apstra/data_source_datacenter_ct_dynamic_bgp_peering.go
+++ b/apstra/data_source_datacenter_ct_dynamic_bgp_peering.go
@@ -32,6 +32,10 @@ func (o *dataSourceDatacenterCtDynamicBgpPeering) ValidateConfig(ctx context.Con
 		return
 	}
 
+	if config.Ipv4Enabled.IsUnknown() || config.Ipv6Enabled.IsUnknown() {
+		return // cannot validate while either value is unknown
+	}
+
 	if !config.Ipv4Enabled.ValueBool() && !config.Ipv6Enabled.ValueBool() {
 		resp.Diagnostics.AddError("Invalid Attribute Combination", "At least one attribute "+
 			"out of 'ipv4_enabled' and 'ipv6_enabled' must be `true`")

--- a/apstra/design/logical_device_panel.go
+++ b/apstra/design/logical_device_panel.go
@@ -173,6 +173,10 @@ func (o *LogicalDevicePanel) Validate(ctx context.Context, i int, diags *diag.Di
 	// count up the ports in each port group
 	var panelPortsByPortGroup int64
 	for _, portGroup := range portGroups {
+		if portGroup.PortCount.IsUnknown() {
+			return // cannot validate with any unknown port count
+		}
+
 		panelPortsByPortGroup = panelPortsByPortGroup + portGroup.PortCount.ValueInt64()
 	}
 

--- a/apstra/design/template_pod_based.go
+++ b/apstra/design/template_pod_based.go
@@ -238,6 +238,10 @@ func (o *TemplatePodBased) CopyWriteOnlyElements(ctx context.Context, src *Templ
 func (o TemplatePodBased) VersionConstraints() apiversions.Constraints {
 	var response apiversions.Constraints
 
+	if o.FabricAddressing.IsUnknown() {
+		return apiversions.Constraints{} // cannot validate
+	}
+
 	if !o.FabricAddressing.IsNull() {
 		response.AddAttributeConstraints(
 			apiversions.AttributeConstraint{

--- a/apstra/design/template_rack_based.go
+++ b/apstra/design/template_rack_based.go
@@ -365,6 +365,10 @@ func (o *TemplateRackBased) CopyWriteOnlyElements(ctx context.Context, src *Temp
 func (o TemplateRackBased) VersionConstraints() apiversions.Constraints {
 	var response apiversions.Constraints
 
+	if o.FabricAddressing.IsUnknown() {
+		return apiversions.Constraints{} // cannot validate
+	}
+
 	if !o.FabricAddressing.IsNull() {
 		response.AddAttributeConstraints(
 			apiversions.AttributeConstraint{

--- a/apstra/resource_configlet.go
+++ b/apstra/resource_configlet.go
@@ -93,6 +93,10 @@ func (o *resourceConfiglet) ValidateConfig(ctx context.Context, req resource.Val
 
 	// validate each generator
 	for i, generator := range generators {
+		if generator.ConfigStyle.IsUnknown() || generator.Section.IsUnknown() {
+			continue // cannot validate with unknown value
+		}
+
 		// extract the platform/config_style from the generator object as an SDK iota type
 		var platform apstra.PlatformOS
 		err := platform.FromString(generator.ConfigStyle.ValueString())

--- a/apstra/resource_interface_map.go
+++ b/apstra/resource_interface_map.go
@@ -112,6 +112,10 @@ func (o *resourceInterfaceMap) ValidateConfig(ctx context.Context, req resource.
 	logicalDevicePorts := make(map[string]struct{})
 
 	for _, configInterface := range configInterfaces {
+		if configInterface.PhysicalInterfaceName.IsUnknown() || configInterface.LogicalDevicePort.IsUnknown() {
+			continue // cannot validate
+		}
+
 		physicalInterfaceName := configInterface.PhysicalInterfaceName.ValueString()
 		logicalDevicePortName := configInterface.LogicalDevicePort.ValueString()
 

--- a/apstra/resource_logical_device.go
+++ b/apstra/resource_logical_device.go
@@ -45,6 +45,7 @@ func (o *resourceLogicalDevice) ValidateConfig(ctx context.Context, req resource
 	if config.Panels.IsUnknown() {
 		return // cannot validate unknown panels
 	}
+
 	panels := config.GetPanels(ctx, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return

--- a/apstra/resource_modular_device_profile.go
+++ b/apstra/resource_modular_device_profile.go
@@ -29,6 +29,10 @@ func (o *resourceModularDeviceProfile) ValidateConfig(ctx context.Context, req r
 		return
 	}
 
+	if config.LineCardProfileIds.IsUnknown() {
+		return //cannot validate
+	}
+
 	for key := range config.LineCardProfileIds.Elements() {
 		_, err := strconv.ParseUint(key, 10, 64)
 		if err != nil {


### PR DESCRIPTION
Attribute values configured like this can never be unknown:

```tf
resource "foo" "x" {
  always_lowercase_string = "hello"
}
```

...But attribute values based on as-yet-unknown values (perhaps those `computed` later) are another story:

```tf
resource "foo" "x" {
  always_lowercase_string = thing_with_upercase_computed_values.x.an_uppercase_string
}
```

Resources which implement `ResourceWithValidateConfig` cannot check the value for case because it won't be known when `ValidateConfig()` is first run.

Attempts to evaluate these attributes will result in the zero value for those types until a future point when the value is calculated. There's little point in trying to validate them in these cases. Worse, the (temporary) zero value might fail validation.

This PR adds escape hatches for the validation routines where `unknown` values might have had validation attempted.

Closes #124