### PR TITLE
Feat/623 Include 3rd party licenses in release bundle

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,8 @@
 #
 before:
   hooks:
-    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || [ "$RELEASE_TEST" -eq 1 ] || (echo must be on branch main; false)"
-    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || [ "$RELEASE_TEST" -eq 1 ] || (echo not in sync with origin; false)"
+    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || [ \"$RELEASE_TEST\" -eq 1 ] || (echo must be on branch main; false)"
+    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || [ \"$RELEASE_TEST\" -eq 1 ] || (echo not in sync with origin; false)"
     - make compliance
     - make docs
     - git update-index --refresh && git diff-index --quiet HEAD --

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,8 @@
 #
 before:
   hooks:
-    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || [ \"$RELEASE_TEST\" -eq 1 ] || (echo must be on branch main; false)"
-    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || [ \"$RELEASE_TEST\" -eq 1 ] || (echo not in sync with origin; false)"
+    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || [ \"$RELEASE_TEST\" = \"1\" ] || (echo must be on branch main; false)"
+    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || [ \"$RELEASE_TEST\" = \"1\" ] || (echo not in sync with origin; false)"
     - make compliance
     - make docs
     - git update-index --refresh && git diff-index --quiet HEAD --

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,10 +4,10 @@
 before:
   hooks:
     - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
-    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
+#    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
     - make compliance
     - make docs
-    - git update-index --refresh && git diff-index --quiet HEAD --
+#    - git update-index --refresh && git diff-index --quiet HEAD --
 builds:
 - env:
     # goreleaser does not work with CGO, it could also complicate
@@ -36,6 +36,10 @@ builds:
 archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  files:
+    - LICENSE
+    - README.md
+    - Third_Party_Code/NOTICES.md
 checksum:
   extra_files:
     - glob: 'terraform-registry-manifest.json'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@
 #
 before:
   hooks:
-    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
+#    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
 #    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
     - make compliance
     - make docs

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,8 @@
 #
 before:
   hooks:
-    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || [ "$RELEASE_TEST -eq 1 ] || (echo must be on branch main; false)"
-    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || [ "$RELEASE_TEST -eq 1 ] || (echo not in sync with origin; false)"
+    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || [ "$RELEASE_TEST" -eq 1 ] || (echo must be on branch main; false)"
+    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || [ "$RELEASE_TEST" -eq 1 ] || (echo not in sync with origin; false)"
     - make compliance
     - make docs
     - git update-index --refresh && git diff-index --quiet HEAD --

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,11 +3,11 @@
 #
 before:
   hooks:
-#    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
-#    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
+    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
+    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
     - make compliance
     - make docs
-#    - git update-index --refresh && git diff-index --quiet HEAD --
+    - git update-index --refresh && git diff-index --quiet HEAD --
 builds:
 - env:
     # goreleaser does not work with CGO, it could also complicate

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,8 @@
 #
 before:
   hooks:
-    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || (echo must be on branch main; false)"
-    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || (echo not in sync with origin; false)"
+    - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || [ "$RELEASE_TEST -eq 1 ] || (echo must be on branch main; false)"
+    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || [ "$RELEASE_TEST -eq 1 ] || (echo not in sync with origin; false)"
     - make compliance
     - make docs
     - git update-index --refresh && git diff-index --quiet HEAD --


### PR DESCRIPTION
This PR changes the list of files included in the release from the default set, to an enumerated set which includes the previous files plus the `Third_Party_Code/NOTICES.md`.

It also adds a testing switch to the `goreleaser` process (needed in building this PR, and likely useful going forward).

Closes #623