### PR TITLE
Clear `GIT_SSH_COMMAND` environment variable when running `git` via `goreleaser` hooks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@
 before:
   hooks:
     - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || [ \"$RELEASE_TEST\" = \"1\" ] || (echo must be on branch main; false)"
-    - sh -c "[ \"$(git pull)\" = \"Already up to date.\" ] || [ \"$RELEASE_TEST\" = \"1\" ] || (echo not in sync with origin; false)"
+    - sh -c "[ \"$(env -u GIT_SSH_COMMAND git pull)\" = \"Already up to date.\" ] || [ \"$RELEASE_TEST\" = \"1\" ] || (echo not in sync with origin; false)"
     - make compliance
     - make docs
     - git update-index --refresh && git diff-index --quiet HEAD --


### PR DESCRIPTION
Closes #733