### PR TITLE
735 review

### DIFF
--- a/apstra/blueprint/freeform_ra_group.go
+++ b/apstra/blueprint/freeform_ra_group.go
@@ -3,14 +3,12 @@ package blueprint
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -22,21 +20,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-//{
-//  "parent_id": "string",
-//  "label": "string",
-//  "tags": [
-//    "string"
-//  ],
-//  "data": {}
-//}
-
 type FreeformRaGroup struct {
-	BlueprintId types.String         `tfsdk:"blueprint_id"`
-	Id          types.String         `tfsdk:"id"`
-	Name        types.String         `tfsdk:"name"`
-	ParentId    types.String         `tfsdk:"parent_id"`
-	Tags        types.Set            `tfsdk:"tags"`
+	BlueprintId types.String `tfsdk:"blueprint_id"`
+	Id          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	ParentId    types.String `tfsdk:"parent_id"`
+	// Tags        types.Set            `tfsdk:"tags"`
 	Data        jsontypes.Normalized `tfsdk:"data"`
 	GeneratorId types.String         `tfsdk:"generator_id"`
 }
@@ -62,22 +51,21 @@ func (o FreeformRaGroup) DataSourceAttributes() map[string]dataSourceSchema.Attr
 			},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Populate this field to look up the Allocation Group by Name. Required when `id` is omitted.",
+			MarkdownDescription: "Populate this field to look up the Freeform Allocation Group by Name. Required when `id` is omitted.",
 			Optional:            true,
 			Computed:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"parent_id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "ID of the group node that is present as a parent of the current one in " +
-				"parent/children relationship." +
-				" If group is a top-level one, then 'parent_id' is equal to None/null.",
+			MarkdownDescription: "ID of the group node that is present as a parent of the current one in a " +
+				"parent/child relationship. If this is a top-level (root) node, then `parent_id` will be `null`.",
 			Computed: true,
 		},
-		"tags": dataSourceSchema.SetAttribute{
-			MarkdownDescription: "Set of Tag labels",
-			ElementType:         types.StringType,
-			Computed:            true,
-		},
+		//"tags": dataSourceSchema.SetAttribute{
+		//	MarkdownDescription: "Set of Tag labels",
+		//	ElementType:         types.StringType,
+		//	Computed:            true,
+		//},
 		"data": dataSourceSchema.StringAttribute{
 			MarkdownDescription: "Arbitrary key-value mapping that is useful in a context of this group. " +
 				"For example, you can store some VRF-related data there or add properties that are useful " +
@@ -86,7 +74,7 @@ func (o FreeformRaGroup) DataSourceAttributes() map[string]dataSourceSchema.Attr
 			CustomType: jsontypes.NormalizedType{},
 		},
 		"generator_id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "ID of the group generator that created the group.",
+			MarkdownDescription: "ID of the group generator that created the group, if any.",
 			Computed:            true,
 		},
 	}
@@ -109,59 +97,62 @@ func (o FreeformRaGroup) ResourceAttributes() map[string]resourceSchema.Attribut
 			MarkdownDescription: "Freeform Resource Allocation Group name as shown in the Web UI.",
 			Required:            true,
 			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9.-_]+$"), "name may consist only of the following characters : a-zA-Z0-9.-_")},
+				stringvalidator.RegexMatches(
+					regexp.MustCompile("^[a-zA-Z0-9.-_]+$"),
+					"name may consist only of the following characters : a-zA-Z0-9.-_"),
+			},
 		},
 		"parent_id": resourceSchema.StringAttribute{
-			MarkdownDescription: fmt.Sprintf("Type of the System. Must be one of `%s` or `%s`", apstra.SystemTypeInternal, apstra.SystemTypeExternal),
+			MarkdownDescription: "ID of the parent Freeform Resource Allocation Group, if this group is to be nested.",
 			Optional:            true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
-		"tags": resourceSchema.SetAttribute{
-			MarkdownDescription: "Set of Tag labels",
-			ElementType:         types.StringType,
-			Optional:            true,
-			Validators:          []validator.Set{setvalidator.SizeAtLeast(1)},
-		},
+		//"tags": resourceSchema.SetAttribute{
+		//	MarkdownDescription: "Set of Tag labels",
+		//	ElementType:         types.StringType,
+		//	Optional:            true,
+		//	Validators:          []validator.Set{setvalidator.SizeAtLeast(1)},
+		//},
 		"data": resourceSchema.StringAttribute{
-			MarkdownDescription: "Arbitrary key-value mapping that is useful in a context of this group. " +
-				"For example, you can store some VRF-related data there or add properties that are useful" +
-				" only in context of resource allocation, but not systems or interfaces. ",
+			MarkdownDescription: "Arbitrary JSON-encoded key-value mapping that is useful in a context of this " +
+				"group. For example, you can store some VRF-related data there or add properties that are useful " +
+				"only in context of resource allocation, but not systems or interfaces.",
 			Optional:   true,
 			Computed:   true,
 			Default:    stringdefault.StaticString("{}"),
 			CustomType: jsontypes.NormalizedType{},
 		},
 		"generator_id": resourceSchema.StringAttribute{
-			MarkdownDescription: "ID of the Generator that created Resource Allocation Group, " +
-				"always `null` because groups created with this resource were not generated.",
+			MarkdownDescription: "ID of the Generator that created Resource Allocation Group. " +
+				"Always `null` because groups created via resource declaration were not generated.",
 			Computed: true,
 		},
 	}
 }
 
-func (o *FreeformRaGroup) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.FreeformRaGroupData {
-	var tags []string
-	diags.Append(o.Tags.ElementsAs(ctx, &tags, false)...)
-	if diags.HasError() {
-		return nil
-	}
+func (o *FreeformRaGroup) Request(_ context.Context, _ *diag.Diagnostics) *apstra.FreeformRaGroupData {
+	//var tags []string
+	//diags.Append(o.Tags.ElementsAs(ctx, &tags, false)...)
+	//if diags.HasError() {
+	//	return nil
+	//}
 
 	return &apstra.FreeformRaGroupData{
-		ParentId:    (*apstra.ObjectId)(o.ParentId.ValueStringPointer()),
-		Label:       o.Name.ValueString(),
-		Tags:        tags,
+		ParentId: (*apstra.ObjectId)(o.ParentId.ValueStringPointer()),
+		Label:    o.Name.ValueString(),
+		// Tags:        tags,
 		Data:        json.RawMessage(o.Data.ValueString()),
 		GeneratorId: (*apstra.ObjectId)(o.GeneratorId.ValueStringPointer()),
 	}
 }
 
-func (o *FreeformRaGroup) LoadApiData(ctx context.Context, in *apstra.FreeformRaGroupData, diags *diag.Diagnostics) {
+func (o *FreeformRaGroup) LoadApiData(_ context.Context, in *apstra.FreeformRaGroupData, _ *diag.Diagnostics) {
 	o.Name = types.StringValue(in.Label)
 	if in.ParentId != nil {
 		o.ParentId = types.StringValue(string(*in.ParentId))
 	}
 
 	o.Data = jsontypes.NewNormalizedValue(string(in.Data))
-	o.Tags = utils.SetValueOrNull(ctx, types.StringType, in.Tags, diags) // safe to ignore diagnostic here
+	// o.Tags = utils.SetValueOrNull(ctx, types.StringType, in.Tags, diags) // safe to ignore diagnostic here
 	o.GeneratorId = types.StringPointerValue((*string)(in.GeneratorId))
 }

--- a/apstra/resource_freeform_ra_group.go
+++ b/apstra/resource_freeform_ra_group.go
@@ -73,7 +73,7 @@ func (o *resourceFreeformRaGroup) Create(ctx context.Context, req resource.Creat
 
 	id, err := bp.CreateRaGroup(ctx, request)
 	if err != nil {
-		resp.Diagnostics.AddError("error creating new Resource Allocation Group", err.Error())
+		resp.Diagnostics.AddError("error creating new Freeform Resource Allocation Group", err.Error())
 		return
 	}
 
@@ -160,7 +160,9 @@ func (o *resourceFreeformRaGroup) Update(ctx context.Context, req resource.Updat
 		resp.Diagnostics.AddError("error updating Freeform Resource Allocation Group", err.Error())
 		return
 	}
+
 	plan.GeneratorId = types.StringNull()
+
 	// set state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }

--- a/docs/data-sources/freeform_ra_group.md
+++ b/docs/data-sources/freeform_ra_group.md
@@ -21,7 +21,6 @@ At least one optional attribute is required.
 resource "apstra_freeform_ra_group" "test" {
   blueprint_id      = "freeform_blueprint-d8c1fabf"
   name              = "test_ra_group_fizz"
-  tags              = ["a", "b", "c"]
   data              =  jsonencode({
     foo   = "bar"
     clown = 2
@@ -46,11 +45,6 @@ output "test_ra_group_out" {value = data.apstra_freeform_ra_group.test}
 //  "id" = "98ubU5cuRj7WsT159L4"
 //  "name" = "test_ra_group_fizz"
 //  "parent_id" = tostring(null)
-//  "tags" = toset([
-//    "a",
-//    "b",
-//    "c",
-//  ])
 //}
 ```
 
@@ -64,11 +58,10 @@ output "test_ra_group_out" {value = data.apstra_freeform_ra_group.test}
 ### Optional
 
 - `id` (String) Populate this field to look up the Freeform Allocation Group by ID. Required when `name` is omitted.
-- `name` (String) Populate this field to look up the Allocation Group by Name. Required when `id` is omitted.
+- `name` (String) Populate this field to look up the Freeform Allocation Group by Name. Required when `id` is omitted.
 
 ### Read-Only
 
 - `data` (String) Arbitrary key-value mapping that is useful in a context of this group. For example, you can store some VRF-related data there or add properties that are useful only in context of resource allocation, but not systems or interfaces.
-- `generator_id` (String) ID of the group generator that created the group.
-- `parent_id` (String) ID of the group node that is present as a parent of the current one in parent/children relationship. If group is a top-level one, then 'parent_id' is equal to None/null.
-- `tags` (Set of String) Set of Tag labels
+- `generator_id` (String) ID of the group generator that created the group, if any.
+- `parent_id` (String) ID of the group node that is present as a parent of the current one in a parent/child relationship. If this is a top-level (root) node, then `parent_id` will be `null`.

--- a/docs/resources/freeform_ra_group.md
+++ b/docs/resources/freeform_ra_group.md
@@ -18,7 +18,6 @@ This resource creates a Resource Allocation Group in a Freeform Blueprint.
 resource "apstra_freeform_ra_group" "test" {
   blueprint_id      = "freeform_blueprint-d8c1fabf"
   name              = "test_ra_group_fizz"
-  tags              = ["a", "b", "c"]
   data              =  jsonencode({
     foo   = "bar"
     clown = 2
@@ -43,11 +42,6 @@ output "test_ra_out" {value = data.apstra_freeform_ra_group.test}
 //  "id" = "98ubU5cuRj7WsT159L4"
 //  "name" = "test_ra_group_fizz"
 //  "parent_id" = tostring(null)
-//  "tags" = toset([
-//    "a",
-//    "b",
-//    "c",
-//  ])
 //}
 ```
 
@@ -61,13 +55,12 @@ output "test_ra_out" {value = data.apstra_freeform_ra_group.test}
 
 ### Optional
 
-- `data` (String) Arbitrary key-value mapping that is useful in a context of this group. For example, you can store some VRF-related data there or add properties that are useful only in context of resource allocation, but not systems or interfaces.
-- `parent_id` (String) Type of the System. Must be one of `internal` or `external`
-- `tags` (Set of String) Set of Tag labels
+- `data` (String) Arbitrary JSON-encoded key-value mapping that is useful in a context of this group. For example, you can store some VRF-related data there or add properties that are useful only in context of resource allocation, but not systems or interfaces.
+- `parent_id` (String) ID of the parent Freeform Resource Allocation Group, if this group is to be nested.
 
 ### Read-Only
 
-- `generator_id` (String) ID of the Generator that created Resource Allocation Group, always `null` because groups created with this resource were not generated.
+- `generator_id` (String) ID of the Generator that created Resource Allocation Group. Always `null` because groups created via resource declaration were not generated.
 - `id` (String) ID of the Freeform Resource Allocation Group.
 
 

--- a/examples/data-sources/apstra_freeform_ra_group/example.tf
+++ b/examples/data-sources/apstra_freeform_ra_group/example.tf
@@ -3,7 +3,6 @@
 resource "apstra_freeform_ra_group" "test" {
   blueprint_id      = "freeform_blueprint-d8c1fabf"
   name              = "test_ra_group_fizz"
-  tags              = ["a", "b", "c"]
   data              =  jsonencode({
     foo   = "bar"
     clown = 2
@@ -28,10 +27,5 @@ output "test_ra_group_out" {value = data.apstra_freeform_ra_group.test}
 //  "id" = "98ubU5cuRj7WsT159L4"
 //  "name" = "test_ra_group_fizz"
 //  "parent_id" = tostring(null)
-//  "tags" = toset([
-//    "a",
-//    "b",
-//    "c",
-//  ])
 //}
 

--- a/examples/resources/apstra_freeform_ra_group/example.tf
+++ b/examples/resources/apstra_freeform_ra_group/example.tf
@@ -3,7 +3,6 @@
 resource "apstra_freeform_ra_group" "test" {
   blueprint_id      = "freeform_blueprint-d8c1fabf"
   name              = "test_ra_group_fizz"
-  tags              = ["a", "b", "c"]
   data              =  jsonencode({
     foo   = "bar"
     clown = 2
@@ -28,9 +27,4 @@ output "test_ra_out" {value = data.apstra_freeform_ra_group.test}
 //  "id" = "98ubU5cuRj7WsT159L4"
 //  "name" = "test_ra_group_fizz"
 //  "parent_id" = tostring(null)
-//  "tags" = toset([
-//    "a",
-//    "b",
-//    "c",
-//  ])
 //}


### PR DESCRIPTION
Minor string massaging here.

Biggest change: I ripped out `tags` because I don't see it in the web UI.

Also, we should chat about the name:
- `ra` vs. `resource_allocation`
- whether we want to mention `ra` at all... is this merely a "Resource Group" in the UI?

choosing between API attributes and Web UI presentation is tricky...