### PR TITLE
Task/749 **BREAKING CHANGE** - Change IPv6 role strings in `apstra_datacenter_resource_pool_allocation` resource

### DIFF
--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -29,9 +29,9 @@ const (
 
 	// search for todos with 'enable_rosetta_for_pools_with_leading_ipv6' to enable rosetta for these items.
 	// total 18 occurences between this file and the test file
-	// resourceGroupNameSpineLeafLinkIpv6       = "spine_leaf_link_ips_ipv6"       // todo: enable_rosetta_for_pools_with_leading_ipv6
-	// resourceGroupNameSpineSuperspineLinkIpv6 = "spine_superspine_link_ips_ipv6" // todo: enable_rosetta_for_pools_with_leading_ipv6
-	// resourceGroupNameToGenericLinkIpv6       = "to_generic_link_ips_ipv6"       // todo: enable_rosetta_for_pools_with_leading_ipv6
+	resourceGroupNameSpineLeafLinkIpv6       = "spine_leaf_link_ips_ipv6"
+	resourceGroupNameSpineSuperspineLinkIpv6 = "spine_superspine_link_ips_ipv6"
+	resourceGroupNameToGenericLinkIpv6       = "to_generic_link_ips_ipv6"
 
 	interfaceNumberingIpv4TypeNone = "none"
 	interfaceNumberingIpv6TypeNone = "none"
@@ -217,12 +217,12 @@ func resourceGroupNameToFriendlyString(in apstra.ResourceGroupName) string {
 		return resourceGroupNameLeafL3PeerLinksIpv6
 	case apstra.ResourceGroupNameVxlanVnIds:
 		return resourceGroupNameVxlanVnIds
-		// case apstra.ResourceGroupNameSpineLeafIp6: //       todo: enable_rosetta_for_pools_with_leading_ipv6
-		//	return resourceGroupNameSpineLeafLinkIpv6 //       todo: enable_rosetta_for_pools_with_leading_ipv6
-		// case apstra.ResourceGroupNameSuperspineSpineIp6: // todo: enable_rosetta_for_pools_with_leading_ipv6
-		//	return resourceGroupNameSpineSuperspineLinkIpv6 // todo: enable_rosetta_for_pools_with_leading_ipv6
-		// case apstra.ResourceGroupNameToGenericLinkIpv6: //  todo: enable_rosetta_for_pools_with_leading_ipv6
-		//	return resourceGroupNameToGenericLinkIpv6 //       todo: enable_rosetta_for_pools_with_leading_ipv6
+	case apstra.ResourceGroupNameSpineLeafIp6:
+		return resourceGroupNameSpineLeafLinkIpv6
+	case apstra.ResourceGroupNameSuperspineSpineIp6:
+		return resourceGroupNameSpineSuperspineLinkIpv6
+	case apstra.ResourceGroupNameToGenericLinkIpv6:
+		return resourceGroupNameToGenericLinkIpv6
 	}
 
 	return in.String()
@@ -372,12 +372,12 @@ func resourceGroupNameFromFriendlyString(target *apstra.ResourceGroupName, in ..
 		*target = apstra.ResourceGroupNameLeafL3PeerLinkLinkIp6
 	case resourceGroupNameVxlanVnIds:
 		*target = apstra.ResourceGroupNameVxlanVnIds
-	// case resourceGroupNameSpineLeafLinkIpv6: //              todo: enable_rosetta_for_pools_with_leading_ipv6
-	//	*target = apstra.ResourceGroupNameSpineLeafIp6 //       todo: enable_rosetta_for_pools_with_leading_ipv6
-	// case resourceGroupNameSpineSuperspineLinkIpv6: //        todo: enable_rosetta_for_pools_with_leading_ipv6
-	//	*target = apstra.ResourceGroupNameSuperspineSpineIp6 // todo: enable_rosetta_for_pools_with_leading_ipv6
-	// case resourceGroupNameToGenericLinkIpv6: //              todo: enable_rosetta_for_pools_with_leading_ipv6
-	//	*target = apstra.ResourceGroupNameToGenericLinkIpv6 //  todo: enable_rosetta_for_pools_with_leading_ipv6
+	case resourceGroupNameSpineLeafLinkIpv6:
+		*target = apstra.ResourceGroupNameSpineLeafIp6
+	case resourceGroupNameSpineSuperspineLinkIpv6:
+		*target = apstra.ResourceGroupNameSuperspineSpineIp6
+	case resourceGroupNameToGenericLinkIpv6:
+		*target = apstra.ResourceGroupNameToGenericLinkIpv6
 	default:
 		return target.FromString(in[0])
 	}

--- a/apstra/utils/rosetta_test.go
+++ b/apstra/utils/rosetta_test.go
@@ -42,9 +42,9 @@ func TestRosetta(t *testing.T) {
 		{string: "leaf_l3_peer_links", stringers: []fmt.Stringer{apstra.ResourceGroupNameLeafL3PeerLinkLinkIp4}},
 		{string: "leaf_l3_peer_links_ipv6", stringers: []fmt.Stringer{apstra.ResourceGroupNameLeafL3PeerLinkLinkIp6}},
 
-		//{string: "spine_leaf_link_ips_ipv6", stringers: []fmt.Stringer{apstra.ResourceGroupNameSpineLeafIp6}},             // todo: enable_rosetta_for_pools_with_leading_ipv6
-		//{string: "spine_superspine_link_ips_ipv6", stringers: []fmt.Stringer{apstra.ResourceGroupNameSuperspineSpineIp6}}, // todo: enable_rosetta_for_pools_with_leading_ipv6
-		//{string: "to_generic_link_ips_ipv6", stringers: []fmt.Stringer{apstra.ResourceGroupNameToGenericLinkIpv6}},        // todo: enable_rosetta_for_pools_with_leading_ipv6
+		{string: "spine_leaf_link_ips_ipv6", stringers: []fmt.Stringer{apstra.ResourceGroupNameSpineLeafIp6}},
+		{string: "spine_superspine_link_ips_ipv6", stringers: []fmt.Stringer{apstra.ResourceGroupNameSuperspineSpineIp6}},
+		{string: "to_generic_link_ips_ipv6", stringers: []fmt.Stringer{apstra.ResourceGroupNameToGenericLinkIpv6}},
 
 		{string: "none", stringers: []fmt.Stringer{apstra.InterfaceNumberingIpv4TypeNone}},
 		{string: "none", stringers: []fmt.Stringer{apstra.InterfaceNumberingIpv6TypeNone}},
@@ -65,6 +65,12 @@ func TestRosetta(t *testing.T) {
 			target = &x
 		case apstra.AsnAllocationScheme:
 			x := apstra.AsnAllocationScheme(-1)
+			target = &x
+		case apstra.InterfaceNumberingIpv4Type:
+			x := apstra.InterfaceNumberingIpv4Type{}
+			target = &x
+		case apstra.InterfaceNumberingIpv6Type:
+			x := apstra.InterfaceNumberingIpv6Type{}
 			target = &x
 		case apstra.OverlayControlProtocol:
 			x := apstra.OverlayControlProtocol(-1)

--- a/docs/resources/datacenter_resource_pool_allocation.md
+++ b/docs/resources/datacenter_resource_pool_allocation.md
@@ -73,9 +73,6 @@ resource "apstra_datacenter_resource_pool_allocation" "ipv4" {
   - generic_asns
   - generic_loopback_ips
   - generic_loopback_ips_ipv6
-  - ipv6_spine_leaf_link_ips
-  - ipv6_spine_superspine_link_ips
-  - ipv6_to_generic_link_ips
   - leaf_asns
   - leaf_l3_peer_links
   - leaf_l3_peer_links_ipv6
@@ -86,13 +83,16 @@ resource "apstra_datacenter_resource_pool_allocation" "ipv4" {
   - mlag_domain_svi_subnets_ipv6
   - spine_asns
   - spine_leaf_link_ips
+  - spine_leaf_link_ips_ipv6
   - spine_loopback_ips
   - spine_loopback_ips_ipv6
   - spine_superspine_link_ips
+  - spine_superspine_link_ips_ipv6
   - superspine_asns
   - superspine_loopback_ips
   - superspine_loopback_ips_ipv6
   - to_generic_link_ips
+  - to_generic_link_ips_ipv6
   - virtual_network_svi_subnets
   - virtual_network_svi_subnets_ipv6
   - vni_virtual_network_ids


### PR DESCRIPTION
This PR changes the set of valid strings for the `apstra_datacenter_resource_pool_allocation` resource's `role` attribute.

The following strings have been replaced for consistency with the many other valid values which put `ipv6` at the end:

 - `ipv6_spine_leaf_link_ips` --------> `spine_leaf_link_ips_ipv6`
 - `ipv6_spine_superspine_link_ips` -> `spine_superspine_link_ips_ipv6`
 - `ipv6_to_generic_link_ips`---------> `to_generic_link_ips_ipv6`

After upgrading to a provider release which includes this change, the terraform provider will no longer accept the old strings. A validation error will require the configuration to be amended to use these new values.

After the configuration has been updated to use the new values, Terraform will plan a change, but the change should be nondisruptive to the blueprint. Notice this resource is being *updated in-place*, and the only attribute subject to change is `role`:

```
Terraform will perform the following actions:

  # apstra_datacenter_resource_pool_allocation.spine_leaf_link_ips_ipv6 will be updated in-place
  ~ resource "apstra_datacenter_resource_pool_allocation" "spine_leaf_link_ips_ipv6" {
      ~ role         = "ipv6_spine_leaf_link_ips" -> "spine_leaf_link_ips_ipv6"
        # (2 unchanged attributes hidden)
    }
```

Details of what's in this PR:
- purged some placeholder stuff related to Freeform blueprints (this isn't going to happen)
- the `role` attribute's `RequiresReplace` plan modifier has been changed to `RequiresReplaceIf` with a helper function which recognizes the old and new strings: No replace when updating `role` from an old style value to a new style value.
- `rosetta` module required to bring the new values to life
- a couple of overlooked test cases related to `apstra.InterfaceNumberingIpv4Type` and `apstra.InterfaceNumberingIpv6Type` which were required to get the rosetta tests passing

Closes #749