### PR TITLE
Audit tag validation

### DIFF
--- a/apstra/blueprint/connectivity_template.go
+++ b/apstra/blueprint/connectivity_template.go
@@ -53,7 +53,10 @@ func (o ConnectivityTemplate) ResourceAttributes() map[string]resourceSchema.Att
 			MarkdownDescription: "Set of Tag labels",
 			ElementType:         types.StringType,
 			Optional:            true,
-			Validators:          []validator.Set{setvalidator.SizeAtLeast(1)},
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+			},
 		},
 		"primitives": resourceSchema.SetAttribute{
 			MarkdownDescription: "Set of Connectivity Template Primitives expressed as JSON strings.",

--- a/apstra/blueprint/datacenter_generic_system.go
+++ b/apstra/blueprint/datacenter_generic_system.go
@@ -88,7 +88,10 @@ func (o DatacenterGenericSystem) ResourceAttributes() map[string]resourceSchema.
 				"in the Blueprint it will be created automatically.",
 			ElementType: types.StringType,
 			Optional:    true,
-			Validators:  []validator.Set{setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1))},
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+			},
 		},
 		"links": resourceSchema.SetNestedAttribute{
 			MarkdownDescription: fmt.Sprintf("Generic System link details. Note that tagging Links requires "+

--- a/apstra/blueprint/datacenter_generic_system_link.go
+++ b/apstra/blueprint/datacenter_generic_system_link.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	apiversions "github.com/Juniper/terraform-provider-apstra/apstra/api_versions"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -74,7 +75,10 @@ func (o DatacenterGenericSystemLink) ResourceAttributes() map[string]resourceSch
 				"in the Blueprint it will be created automatically.",
 			ElementType: types.StringType,
 			Optional:    true,
-			Validators:  []validator.Set{setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1))},
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+			},
 		},
 	}
 }

--- a/apstra/blueprint/datacenter_interfaces_by_link_tag.go
+++ b/apstra/blueprint/datacenter_interfaces_by_link_tag.go
@@ -3,6 +3,7 @@ package blueprint
 import (
 	"context"
 	"fmt"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -34,7 +35,10 @@ func (o InterfacesByLinkTag) DataSourceAttributes() map[string]dataSourceSchema.
 			MarkdownDescription: "Set of required Tags",
 			Required:            true,
 			ElementType:         types.StringType,
-			Validators:          []validator.Set{setvalidator.SizeAtLeast(1)},
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+			},
 		},
 		"system_type": dataSourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("Used to specify which interface/end of the link we're "+
@@ -80,12 +84,15 @@ func (o InterfacesByLinkTag) RunQuery(ctx context.Context, client *apstra.TwoSta
 		tq.Match(new(apstra.PathQuery).
 			Node([]apstra.QEEAttribute{
 				apstra.NodeTypeTag.QEEAttribute(),
-				{Key: "label", Value: apstra.QEStringVal(tag)}}).
+				{Key: "label", Value: apstra.QEStringVal(tag)},
+			}).
 			Out([]apstra.QEEAttribute{
-				apstra.RelationshipTypeTag.QEEAttribute()}).
+				apstra.RelationshipTypeTag.QEEAttribute(),
+			}).
 			Node([]apstra.QEEAttribute{
 				apstra.NodeTypeLink.QEEAttribute(),
-				{Key: "name", Value: apstra.QEStringVal("n_link")}}))
+				{Key: "name", Value: apstra.QEStringVal("n_link")},
+			}))
 	}
 
 	// create a query which follows discovered interfaces to the intended systems

--- a/apstra/blueprint/datacenter_interfaces_by_link_tag.go
+++ b/apstra/blueprint/datacenter_interfaces_by_link_tag.go
@@ -35,10 +35,7 @@ func (o InterfacesByLinkTag) DataSourceAttributes() map[string]dataSourceSchema.
 			MarkdownDescription: "Set of required Tags",
 			Required:            true,
 			ElementType:         types.StringType,
-			Validators: []validator.Set{
-				setvalidator.SizeAtLeast(1),
-				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
-			},
+			Validators:          []validator.Set{setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1))},
 		},
 		"system_type": dataSourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("Used to specify which interface/end of the link we're "+

--- a/apstra/blueprint/datacenter_security_policy.go
+++ b/apstra/blueprint/datacenter_security_policy.go
@@ -3,6 +3,7 @@ package blueprint
 import (
 	"context"
 	"fmt"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -130,6 +131,10 @@ func (o DatacenterSecurityPolicy) DataSourceFilterAttributes() map[string]dataSo
 				"but a matching Security Policy may have additional tags not enumerated in this set.",
 			Optional:    true,
 			ElementType: types.StringType,
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+			},
 		},
 	}
 }
@@ -181,11 +186,13 @@ func (o DatacenterSecurityPolicy) ResourceAttributes() map[string]resourceSchema
 			Validators: []validator.List{listvalidator.SizeAtLeast(1)},
 		},
 		"tags": resourceSchema.SetAttribute{
-			MarkdownDescription: "Set of Tags. All tags supplied here are used to match the Security Policy, " +
-				"but a matching Security Policy may have additional tags not enumerated in this set.",
-			Optional:    true,
-			ElementType: types.StringType,
-			Validators:  []validator.Set{setvalidator.SizeAtLeast(1)},
+			MarkdownDescription: "Set of Tags applied to the Security Policy.",
+			Optional:            true,
+			ElementType:         types.StringType,
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+			},
 		},
 	}
 }

--- a/apstra/blueprint/datacenter_security_policy.go
+++ b/apstra/blueprint/datacenter_security_policy.go
@@ -131,10 +131,7 @@ func (o DatacenterSecurityPolicy) DataSourceFilterAttributes() map[string]dataSo
 				"but a matching Security Policy may have additional tags not enumerated in this set.",
 			Optional:    true,
 			ElementType: types.StringType,
-			Validators: []validator.Set{
-				setvalidator.SizeAtLeast(1),
-				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
-			},
+			Validators:  []validator.Set{setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1))},
 		},
 	}
 }

--- a/apstra/blueprint/freeform_config_template.go
+++ b/apstra/blueprint/freeform_config_template.go
@@ -94,7 +94,10 @@ func (o FreeformConfigTemplate) ResourceAttributes() map[string]resourceSchema.A
 			MarkdownDescription: "Set of Tag labels",
 			ElementType:         types.StringType,
 			Optional:            true,
-			Validators:          []validator.Set{setvalidator.SizeAtLeast(1)},
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+			},
 		},
 	}
 }

--- a/apstra/blueprint/freeform_endpoint.go
+++ b/apstra/blueprint/freeform_endpoint.go
@@ -102,7 +102,10 @@ func (o freeformEndpoint) ResourceAttributes() map[string]resourceSchema.Attribu
 			MarkdownDescription: "Set of Tags applied to the interface",
 			Optional:            true,
 			ElementType:         types.StringType,
-			Validators:          []validator.Set{setvalidator.SizeAtLeast(1)},
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+			},
 		},
 	}
 }

--- a/apstra/blueprint/freeform_link.go
+++ b/apstra/blueprint/freeform_link.go
@@ -139,7 +139,10 @@ func (o FreeformLink) ResourceAttributes() map[string]resourceSchema.Attribute {
 			MarkdownDescription: "Set of Tag labels",
 			ElementType:         types.StringType,
 			Optional:            true,
-			Validators:          []validator.Set{setvalidator.SizeAtLeast(1)},
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+			},
 		},
 	}
 }

--- a/docs/resources/datacenter_security_policy.md
+++ b/docs/resources/datacenter_security_policy.md
@@ -102,7 +102,7 @@ resource "apstra_datacenter_security_policy" "server_traffic" {
 - `enabled` (Boolean) Indicates whether the Security Policy is enabled. Default value: `true`
 - `rules` (Attributes List) Ordered list of policy rules. (see [below for nested schema](#nestedatt--rules))
 - `source_application_point_id` (String) Graph node ID of the source Application Point (Virtual Network ID, Routing Zone ID, etc...)
-- `tags` (Set of String) Set of Tags. All tags supplied here are used to match the Security Policy, but a matching Security Policy may have additional tags not enumerated in this set.
+- `tags` (Set of String) Set of Tags applied to the Security Policy.
 
 ### Read-Only
 


### PR DESCRIPTION
There are two ways to express "none of something" in HCL:
```
  things = null
```
and
```
  things = []
```

In Terraform, these are distinct values, but most of our API endpoints don't distinguish between an empty set and a null set, making it tricky for us to avoid state churn by getting the correct value (`null` or `[]`) into the Terraform state.

The easiest way to police it is to just disallow one of the values.

This PR is the result of auditing the tag set on all resources and data sources to ensure that we (a) handle empty sets correctly in resources and (b) disallow empty tag values.

Closes #736