### PR TITLE
Fix 404 handling in `apstra_datacenter_connectivity_template_assignments` resource

### DIFF
--- a/apstra/resource_datacenter_connectivity_template_assignments.go
+++ b/apstra/resource_datacenter_connectivity_template_assignments.go
@@ -116,6 +116,7 @@ func (o *resourceDatacenterConnectivityTemplateAssignments) Read(ctx context.Con
 		var ace apstra.ClientErr
 		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
 			resp.State.RemoveResource(ctx)
+			return
 		}
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("failed while reading Application Point assignments for Connectivity Template %s", state.ConnectivityTemplateId),


### PR DESCRIPTION
After handling 404 response via `resp.State.RemoveResource()`, `resourceDatacenterConnectivityTemplateAssignments.Read()` should return cleanly to allow Terraform to plan re-creation of the missing resource.

The return isn't there, leading terraform to surface a handle-able error to the user.

Closes #764 

cc: @michaelbhughes