### PR TITLE
Mark `ipv4_address` and `ipv6_address` attributes of `apstra_freeform_link` resource as `Computed`

### DIFF
--- a/apstra/freeform/freeform_endpoint.go
+++ b/apstra/freeform/freeform_endpoint.go
@@ -114,12 +114,12 @@ func (o FreeformEndpoint) ResourceAttributes() map[string]resourceSchema.Attribu
 
 func (o *FreeformEndpoint) request(ctx context.Context, systemId string, diags *diag.Diagnostics) *apstra.FreeformEndpoint {
 	var ipNet4, ipNet6 *net.IPNet
-	if !o.Ipv4Address.IsNull() {
+	if utils.HasValue(o.Ipv4Address) {
 		var ip4 net.IP
 		ip4, ipNet4, _ = net.ParseCIDR(o.Ipv4Address.ValueString())
 		ipNet4.IP = ip4
 	}
-	if !o.Ipv6Address.IsNull() {
+	if utils.HasValue(o.Ipv6Address) {
 		var ip6 net.IP
 		ip6, ipNet6, _ = net.ParseCIDR(o.Ipv6Address.ValueString())
 		ipNet6.IP = ip6

--- a/apstra/freeform/freeform_endpoint.go
+++ b/apstra/freeform/freeform_endpoint.go
@@ -90,11 +90,13 @@ func (o FreeformEndpoint) ResourceAttributes() map[string]resourceSchema.Attribu
 		},
 		"ipv4_address": resourceSchema.StringAttribute{
 			Optional:            true,
+			Computed:            true,
 			MarkdownDescription: "Ipv4 address of the interface in CIDR notation",
 			CustomType:          cidrtypes.IPv4PrefixType{},
 		},
 		"ipv6_address": resourceSchema.StringAttribute{
 			Optional:            true,
+			Computed:            true,
 			MarkdownDescription: "Ipv6 address of the interface in CIDR notation",
 			CustomType:          cidrtypes.IPv6PrefixType{},
 		},

--- a/apstra/resource_freeform_link_integration_test.go
+++ b/apstra/resource_freeform_link_integration_test.go
@@ -8,14 +8,17 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
+	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -68,7 +71,7 @@ func (o resourceFreeformLink) render(rType, rName string) string {
 	)
 }
 
-func (o resourceFreeformLink) testChecks(t testing.TB, rType, rName string) testChecks {
+func (o resourceFreeformLink) testChecks(t testing.TB, rType, rName string, ipAllocationEnabled bool) testChecks {
 	result := newTestChecks(rType + "." + rName)
 
 	// required and computed attributes can always be checked
@@ -95,13 +98,21 @@ func (o resourceFreeformLink) testChecks(t testing.TB, rType, rName string) test
 		if endpoint.Interface.Data.Ipv4Address != nil {
 			result.append(t, "TestCheckResourceAttr", "endpoints."+endpoint.SystemId.String()+".ipv4_address", endpoint.Interface.Data.Ipv4Address.String())
 		} else {
-			result.append(t, "TestCheckNoResourceAttr", "endpoints."+endpoint.SystemId.String()+".ipv4_address")
+			if ipAllocationEnabled {
+				result.append(t, "TestCheckResourceAttrSet", "endpoints."+endpoint.SystemId.String()+".ipv4_address")
+			} else {
+				result.append(t, "TestCheckNoResourceAttr", "endpoints."+endpoint.SystemId.String()+".ipv4_address")
+			}
 		}
 
 		if endpoint.Interface.Data.Ipv6Address != nil {
 			result.append(t, "TestCheckResourceAttr", "endpoints."+endpoint.SystemId.String()+".ipv6_address", endpoint.Interface.Data.Ipv6Address.String())
 		} else {
-			result.append(t, "TestCheckNoResourceAttr", "endpoints."+endpoint.SystemId.String()+".ipv6_address")
+			if ipAllocationEnabled {
+				result.append(t, "TestCheckResourceAttrSet", "endpoints."+endpoint.SystemId.String()+".ipv6_address")
+			} else {
+				result.append(t, "TestCheckNoResourceAttr", "endpoints."+endpoint.SystemId.String()+".ipv6_address")
+			}
 		}
 	}
 
@@ -116,17 +127,74 @@ func TestResourceFreeformLink(t *testing.T) {
 	// create a blueprint
 	bp, sysIds := testutils.FfBlueprintB(t, ctx, 2)
 
+	// create an ipv4 allocation group
+	ipv4AllocGroupId, err := bp.CreateAllocGroup(ctx, &apstra.FreeformAllocGroupData{
+		Name:    acctest.RandString(6),
+		Type:    apstra.ResourcePoolTypeIpv4,
+		PoolIds: []apstra.ObjectId{"Private-10_0_0_0-8"},
+	})
+	require.NoError(t, err)
+
+	// create an ipv6 allocation group
+	ipv6AllocGroupId, err := bp.CreateAllocGroup(ctx, &apstra.FreeformAllocGroupData{
+		Name:    acctest.RandString(6),
+		Type:    apstra.ResourcePoolTypeIpv6,
+		PoolIds: []apstra.ObjectId{"Private-fc01-a05-fab-48"},
+	})
+	require.NoError(t, err)
+
+	// create a resource group
+	raGroupId, err := bp.CreateRaGroup(ctx, &apstra.FreeformRaGroupData{
+		Label: acctest.RandString(6),
+	})
+	require.NoError(t, err)
+
+	var associateIpResourcesToLinksDone bool
+	associateIpResourcesToLinksMutex := new(sync.Mutex)
+	associateIpResourcesToLinks := func(t testing.TB) {
+		t.Helper()
+
+		associateIpResourcesToLinksMutex.Lock()
+		defer associateIpResourcesToLinksMutex.Unlock()
+		if associateIpResourcesToLinksDone {
+			return
+		}
+
+		associateIpResourcesToLinksDone = true
+
+		_, err = bp.CreateResourceGenerator(ctx, &apstra.FreeformResourceGeneratorData{
+			ResourceType:    apstra.FFResourceTypeIpv4,
+			Label:           acctest.RandString(6),
+			Scope:           "node(type='link', name='target')",
+			AllocatedFrom:   &ipv4AllocGroupId,
+			ContainerId:     raGroupId,
+			SubnetPrefixLen: utils.ToPtr(31),
+		})
+		require.NoError(t, err)
+
+		_, err = bp.CreateResourceGenerator(ctx, &apstra.FreeformResourceGeneratorData{
+			ResourceType:    apstra.FFResourceTypeIpv6,
+			Label:           acctest.RandString(6),
+			Scope:           "node(type='link', name='target')",
+			AllocatedFrom:   &ipv6AllocGroupId,
+			ContainerId:     raGroupId,
+			SubnetPrefixLen: utils.ToPtr(127),
+		})
+		require.NoError(t, err)
+	}
+
 	type testStep struct {
 		config resourceFreeformLink
 	}
 
 	type testCase struct {
+		ipAllocationEnabled   bool
 		apiVersionConstraints version.Constraints
 		steps                 []testStep
 	}
 
 	testCases := map[string]testCase{
-		"start_minimal": {
+		"start_minimal_ip_allocation_disabled": {
 			steps: []testStep{
 				{
 					config: resourceFreeformLink{
@@ -227,7 +295,212 @@ func TestResourceFreeformLink(t *testing.T) {
 				},
 			},
 		},
-		"start_maximal": {
+		"start_maximal_ip_allocation_disabled": {
+			steps: []testStep{
+				{
+					config: resourceFreeformLink{
+						blueprintId: bp.Id().String(),
+						name:        acctest.RandString(6),
+						tags:        randomStrings(rand.Intn(10)+2, 6),
+						endpoints: []apstra.FreeformEndpoint{
+							{
+								SystemId: sysIds[0],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/4",
+										TransformationId: 1,
+										Ipv4Address:      &net.IPNet{IP: net.ParseIP("10.1.1.1"), Mask: net.CIDRMask(30, 32)},
+										Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8::1"), Mask: net.CIDRMask(64, 128)},
+										Tags:             randomStrings(rand.Intn(10)+2, 6),
+									},
+								},
+							},
+							{
+								SystemId: sysIds[1],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/4",
+										TransformationId: 1,
+										Ipv4Address:      &net.IPNet{IP: net.ParseIP("10.1.1.2"), Mask: net.CIDRMask(30, 32)},
+										Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8::2"), Mask: net.CIDRMask(64, 128)},
+										Tags:             randomStrings(rand.Intn(10)+2, 6),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					config: resourceFreeformLink{
+						blueprintId: bp.Id().String(),
+						name:        acctest.RandString(6),
+						endpoints: []apstra.FreeformEndpoint{
+							{
+								SystemId: sysIds[0],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/5",
+										TransformationId: 2,
+										Ipv4Address:      nil,
+										Ipv6Address:      nil,
+										Tags:             nil,
+									},
+								},
+							},
+							{
+								SystemId: sysIds[1],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/5",
+										TransformationId: 2,
+										Ipv4Address:      nil,
+										Ipv6Address:      nil,
+										Tags:             nil,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					config: resourceFreeformLink{
+						blueprintId: bp.Id().String(),
+						name:        acctest.RandString(6),
+						tags:        randomStrings(rand.Intn(10)+2, 6),
+						endpoints: []apstra.FreeformEndpoint{
+							{
+								SystemId: sysIds[0],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/6",
+										TransformationId: 1,
+										Ipv4Address:      &net.IPNet{IP: net.ParseIP("10.2.1.1"), Mask: net.CIDRMask(30, 32)},
+										Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8::3"), Mask: net.CIDRMask(64, 128)},
+										Tags:             randomStrings(rand.Intn(10)+2, 6),
+									},
+								},
+							},
+							{
+								SystemId: sysIds[1],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/6",
+										TransformationId: 1,
+										Ipv4Address:      &net.IPNet{IP: net.ParseIP("10.2.1.2"), Mask: net.CIDRMask(30, 32)},
+										Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8::4"), Mask: net.CIDRMask(64, 128)},
+										Tags:             randomStrings(rand.Intn(10)+2, 6),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"start_minimal_ip_allocation_enabled": {
+			ipAllocationEnabled: true,
+			steps: []testStep{
+				{
+					config: resourceFreeformLink{
+						blueprintId: bp.Id().String(),
+						name:        acctest.RandString(6),
+						endpoints: []apstra.FreeformEndpoint{
+							{
+								SystemId: sysIds[0],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/0",
+										TransformationId: 1,
+										Ipv4Address:      nil,
+										Ipv6Address:      nil,
+										Tags:             nil,
+									},
+								},
+							},
+							{
+								SystemId: sysIds[1],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/0",
+										TransformationId: 1,
+										Ipv4Address:      nil,
+										Ipv6Address:      nil,
+										Tags:             nil,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					config: resourceFreeformLink{
+						blueprintId: bp.Id().String(),
+						name:        acctest.RandString(6),
+						tags:        randomStrings(rand.Intn(10)+2, 6),
+						endpoints: []apstra.FreeformEndpoint{
+							{
+								SystemId: sysIds[0],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/1",
+										TransformationId: 2,
+										Ipv4Address:      &net.IPNet{IP: net.ParseIP("192.168.10.1"), Mask: net.CIDRMask(30, 32)},
+										Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8::3"), Mask: net.CIDRMask(64, 128)},
+										Tags:             randomStrings(rand.Intn(10)+2, 6),
+									},
+								},
+							},
+							{
+								SystemId: sysIds[1],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/1",
+										TransformationId: 2,
+										Ipv4Address:      &net.IPNet{IP: net.ParseIP("192.168.10.2"), Mask: net.CIDRMask(30, 32)},
+										Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8::4"), Mask: net.CIDRMask(64, 128)},
+										Tags:             randomStrings(rand.Intn(10)+2, 6),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					config: resourceFreeformLink{
+						blueprintId: bp.Id().String(),
+						name:        acctest.RandString(6),
+						endpoints: []apstra.FreeformEndpoint{
+							{
+								SystemId: sysIds[0],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/3",
+										TransformationId: 1,
+										Ipv4Address:      nil,
+										Ipv6Address:      nil,
+										Tags:             nil,
+									},
+								},
+							},
+							{
+								SystemId: sysIds[1],
+								Interface: apstra.FreeformInterface{
+									Data: &apstra.FreeformInterfaceData{
+										IfName:           "ge-0/0/3",
+										TransformationId: 1,
+										Ipv4Address:      nil,
+										Ipv6Address:      nil,
+										Tags:             nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"start_maximal_ip_allocation_enabled": {
+			ipAllocationEnabled: true,
 			steps: []testStep{
 				{
 					config: resourceFreeformLink{
@@ -331,20 +604,34 @@ func TestResourceFreeformLink(t *testing.T) {
 		},
 	}
 
+	// each test case which DOES NOT expect resource allocation to be set up will decrement the wait group when it's done
+	resourceAllocationWg := new(sync.WaitGroup)
+	for _, tc := range testCases {
+		if !tc.ipAllocationEnabled {
+			resourceAllocationWg.Add(1)
+		}
+	}
+
 	resourceType := tfapstra.ResourceName(ctx, &tfapstra.ResourceFreeformLink)
 
 	for tName, tCase := range testCases {
 		tName, tCase := tName, tCase
 		t.Run(tName, func(t *testing.T) {
 			t.Parallel()
+
 			if !tCase.apiVersionConstraints.Check(apiVersion) {
 				t.Skipf("test case %s requires Apstra %s", tName, tCase.apiVersionConstraints.String())
+			}
+
+			if tCase.ipAllocationEnabled {
+				resourceAllocationWg.Wait()
+				associateIpResourcesToLinks(t)
 			}
 
 			steps := make([]resource.TestStep, len(tCase.steps))
 			for i, step := range tCase.steps {
 				config := step.config.render(resourceType, tName)
-				checks := step.config.testChecks(t, resourceType, tName)
+				checks := step.config.testChecks(t, resourceType, tName, tCase.ipAllocationEnabled)
 
 				chkLog := checks.string()
 				stepName := fmt.Sprintf("test case %q step %d", tName, i+1)
@@ -362,6 +649,10 @@ func TestResourceFreeformLink(t *testing.T) {
 				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 				Steps:                    steps,
 			})
+
+			if !tCase.ipAllocationEnabled {
+				resourceAllocationWg.Done()
+			}
 		})
 	}
 }


### PR DESCRIPTION
#788 points out that IP addresses buried in `apstra_freeform_link` resource may be set by Apstra and therefore should have the `Computed` flag if we're going to read them during `Create()` or `Update()`.

Tests are updated to run in two phases:

1. Links created before associating an IP pool, generator, etc... (links without IP addresses)
2. Links created after associating an IP pool, generator, etc... (links get automatic IP addresses assigned)