### PR TITLE
Bugfix: `aggregate_link_id` is not an input field.

### DIFF
--- a/apstra/freeform/link.go
+++ b/apstra/freeform/link.go
@@ -66,16 +66,16 @@ func (o Link) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 			Computed: true,
 		},
 		"type": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "aggregate_link | ethernet\n" +
+			MarkdownDescription: "`aggregate_link` | `ethernet`\n" +
 				"Link Type. An 'ethernet' link is a normal front-panel interface. " +
 				"An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs. " +
 				"Note that the lag_mode parameter is a property of the interface and not the link, " +
 				"since interfaces may have different lag modes on opposite sides of the link - " +
-				"eg lacp_passive <-> lacp_active",
+				"e.g. lacp_passive <-> lacp_active",
 			Computed: true,
 		},
 		"aggregate_link_id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "ID of aggregate link node that the current link belongs to",
+			MarkdownDescription: "ID of Aggregate Link node to which this Link belongs, if any.",
 			Computed:            true,
 		},
 		"endpoints": dataSourceSchema.MapNestedAttribute{
@@ -118,13 +118,19 @@ func (o Link) ResourceAttributes() map[string]resourceSchema.Attribute {
 			Computed:            true,
 		},
 		"type": resourceSchema.StringAttribute{
-			MarkdownDescription: "Deploy mode of the Link",
-			Computed:            true,
+			MarkdownDescription: "`aggregate_link` | `ethernet`\n" +
+				"Link Type. An 'ethernet' link is a normal front-panel interface. " +
+				"An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs. " +
+				"Note that the lag_mode parameter is a property of the interface and not the link, " +
+				"since interfaces may have different lag modes on opposite sides of the link - " +
+				"e.g. lacp_passive <-> lacp_active",
+			Computed: true,
 		},
 		"aggregate_link_id": resourceSchema.StringAttribute{
-			MarkdownDescription: "ID of aggregate link node that the current link belongs to",
-			Optional:            true,
-			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
+			MarkdownDescription: "This field always `null` in resource context. Ignore. " +
+				"This information can be learned by invoking the complimentary data source.",
+			Computed:   true,
+			Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"endpoints": resourceSchema.MapNestedAttribute{
 			NestedObject: resourceSchema.NestedAttributeObject{

--- a/apstra/freeform/link.go
+++ b/apstra/freeform/link.go
@@ -68,10 +68,7 @@ func (o Link) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 		"type": dataSourceSchema.StringAttribute{
 			MarkdownDescription: "`aggregate_link` | `ethernet`\n" +
 				"Link Type. An 'ethernet' link is a normal front-panel interface. " +
-				"An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs. " +
-				"Note that the lag_mode parameter is a property of the interface and not the link, " +
-				"since interfaces may have different lag modes on opposite sides of the link - " +
-				"e.g. lacp_passive <-> lacp_active",
+				"An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.",
 			Computed: true,
 		},
 		"aggregate_link_id": dataSourceSchema.StringAttribute{
@@ -120,10 +117,7 @@ func (o Link) ResourceAttributes() map[string]resourceSchema.Attribute {
 		"type": resourceSchema.StringAttribute{
 			MarkdownDescription: "`aggregate_link` | `ethernet`\n" +
 				"Link Type. An 'ethernet' link is a normal front-panel interface. " +
-				"An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs. " +
-				"Note that the lag_mode parameter is a property of the interface and not the link, " +
-				"since interfaces may have different lag modes on opposite sides of the link - " +
-				"e.g. lacp_passive <-> lacp_active",
+				"An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.",
 			Computed: true,
 		},
 		"aggregate_link_id": resourceSchema.StringAttribute{

--- a/apstra/freeform/link.go
+++ b/apstra/freeform/link.go
@@ -67,7 +67,7 @@ func (o Link) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 		},
 		"type": dataSourceSchema.StringAttribute{
 			MarkdownDescription: "`aggregate_link` | `ethernet`\n" +
-				"Link Type. An 'ethernet' link is a normal front-panel interface. " +
+				"An 'ethernet' link is a normal front-panel interface. " +
 				"An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.",
 			Computed: true,
 		},
@@ -116,7 +116,7 @@ func (o Link) ResourceAttributes() map[string]resourceSchema.Attribute {
 		},
 		"type": resourceSchema.StringAttribute{
 			MarkdownDescription: "`aggregate_link` | `ethernet`\n" +
-				"Link Type. An 'ethernet' link is a normal front-panel interface. " +
+				"An 'ethernet' link is a normal front-panel interface. " +
 				"An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.",
 			Computed: true,
 		},

--- a/apstra/resource_freeform_link.go
+++ b/apstra/resource_freeform_link.go
@@ -87,6 +87,7 @@ func (o *resourceFreeformLink) Create(ctx context.Context, req resource.CreateRe
 
 	plan.Id = types.StringValue(id.String())
 	plan.LoadApiData(ctx, api.Data, &resp.Diagnostics)
+	plan.AggregateLinkId = types.StringNull()
 
 	// set state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/apstra/resource_freeform_link.go
+++ b/apstra/resource_freeform_link.go
@@ -171,6 +171,7 @@ func (o *resourceFreeformLink) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	// set state
+	plan.AggregateLinkId = types.StringNull()
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/docs/data-sources/freeform_link.md
+++ b/docs/data-sources/freeform_link.md
@@ -70,12 +70,12 @@ output "test_Link_out" { value = data.apstra_freeform_link.test }
 
 ### Read-Only
 
-- `aggregate_link_id` (String) ID of aggregate link node that the current link belongs to
+- `aggregate_link_id` (String) ID of Aggregate Link node to which this Link belongs, if any.
 - `endpoints` (Attributes Map) Endpoints of the  Link, a Map keyed by System ID. (see [below for nested schema](#nestedatt--endpoints))
 - `speed` (String) Speed of the Link 200G | 5G | 1G | 100G | 150g | 40g | 2500M | 25G | 25g | 10G | 50G | 800G | 10M | 100m | 2500m | 50g | 400g | 400G | 200g | 5g | 800g | 100M | 10g | 150G | 10m | 100g | 1g | 40G
 - `tags` (Set of String) Set of unique case-insensitive tag labels
-- `type` (String) aggregate_link | ethernet
-Link Type. An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs. Note that the lag_mode parameter is a property of the interface and not the link, since interfaces may have different lag modes on opposite sides of the link - eg lacp_passive <-> lacp_active
+- `type` (String) `aggregate_link` | `ethernet`
+Link Type. An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs. Note that the lag_mode parameter is a property of the interface and not the link, since interfaces may have different lag modes on opposite sides of the link - e.g. lacp_passive <-> lacp_active
 
 <a id="nestedatt--endpoints"></a>
 ### Nested Schema for `endpoints`

--- a/docs/data-sources/freeform_link.md
+++ b/docs/data-sources/freeform_link.md
@@ -75,7 +75,7 @@ output "test_Link_out" { value = data.apstra_freeform_link.test }
 - `speed` (String) Speed of the Link 200G | 5G | 1G | 100G | 150g | 40g | 2500M | 25G | 25g | 10G | 50G | 800G | 10M | 100m | 2500m | 50g | 400g | 400G | 200g | 5g | 800g | 100M | 10g | 150G | 10m | 100g | 1g | 40G
 - `tags` (Set of String) Set of unique case-insensitive tag labels
 - `type` (String) `aggregate_link` | `ethernet`
-Link Type. An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs. Note that the lag_mode parameter is a property of the interface and not the link, since interfaces may have different lag modes on opposite sides of the link - e.g. lacp_passive <-> lacp_active
+Link Type. An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.
 
 <a id="nestedatt--endpoints"></a>
 ### Nested Schema for `endpoints`

--- a/docs/data-sources/freeform_link.md
+++ b/docs/data-sources/freeform_link.md
@@ -75,7 +75,7 @@ output "test_Link_out" { value = data.apstra_freeform_link.test }
 - `speed` (String) Speed of the Link 200G | 5G | 1G | 100G | 150g | 40g | 2500M | 25G | 25g | 10G | 50G | 800G | 10M | 100m | 2500m | 50g | 400g | 400G | 200g | 5g | 800g | 100M | 10g | 150G | 10m | 100g | 1g | 40G
 - `tags` (Set of String) Set of unique case-insensitive tag labels
 - `type` (String) `aggregate_link` | `ethernet`
-Link Type. An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.
+An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.
 
 <a id="nestedatt--endpoints"></a>
 ### Nested Schema for `endpoints`

--- a/docs/resources/datacenter_connectivity_template_interface.md
+++ b/docs/resources/datacenter_connectivity_template_interface.md
@@ -70,8 +70,8 @@ data "apstra_datacenter_routing_zone" "selected" {
   id           = each.value
 }
 
-# Loop over the Routing Zones. For each one,and discover the IDs of all
-# associaated Virtual Networks.
+# Loop over the Routing Zones. For each RZ, discover the IDs of all
+# associated Virtual Networks.
 data "apstra_datacenter_virtual_networks" "selected" {
   for_each     = data.apstra_datacenter_routing_zone.selected
   blueprint_id = "82a4dde9-eb98-4666-a010-d82f66296be4"
@@ -82,9 +82,9 @@ data "apstra_datacenter_virtual_networks" "selected" {
   ]
 }
 
-# Finally, create an 'interface' type Connectivity Template. Multiple
-# "Virtual Network (Multiple)" primitives are included in this CT, one for
-# each Routing Zone. Each primitive lists all of the Virtual Networks in
+# Finally, create an 'interface' type Connectivity Template with a
+# "Virtual Network (Multiple)" primitive for each Routing Zone. Each
+# of these primitives lists all of the Virtual Networks in
 # that Routing Zone.
 resource "apstra_datacenter_connectivity_template_interface" "example" {
   blueprint_id = "82a4dde9-eb98-4666-a010-d82f66296be4"

--- a/docs/resources/freeform_link.md
+++ b/docs/resources/freeform_link.md
@@ -54,7 +54,7 @@ resource "apstra_freeform_link" "test" {
 - `id` (String) ID of the Freeform Link.
 - `speed` (String) Speed of the Freeform Link.
 - `type` (String) `aggregate_link` | `ethernet`
-Link Type. An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.
+An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.
 
 <a id="nestedatt--endpoints"></a>
 ### Nested Schema for `endpoints`

--- a/docs/resources/freeform_link.md
+++ b/docs/resources/freeform_link.md
@@ -46,14 +46,15 @@ resource "apstra_freeform_link" "test" {
 
 ### Optional
 
-- `aggregate_link_id` (String) ID of aggregate link node that the current link belongs to
 - `tags` (Set of String) Set of Tag labels
 
 ### Read-Only
 
+- `aggregate_link_id` (String) This field always `null` in resource context. Ignore. This information can be learned by invoking the complimentary data source.
 - `id` (String) ID of the Freeform Link.
 - `speed` (String) Speed of the Freeform Link.
-- `type` (String) Deploy mode of the Link
+- `type` (String) `aggregate_link` | `ethernet`
+Link Type. An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs. Note that the lag_mode parameter is a property of the interface and not the link, since interfaces may have different lag modes on opposite sides of the link - e.g. lacp_passive <-> lacp_active
 
 <a id="nestedatt--endpoints"></a>
 ### Nested Schema for `endpoints`

--- a/docs/resources/freeform_link.md
+++ b/docs/resources/freeform_link.md
@@ -54,7 +54,7 @@ resource "apstra_freeform_link" "test" {
 - `id` (String) ID of the Freeform Link.
 - `speed` (String) Speed of the Freeform Link.
 - `type` (String) `aggregate_link` | `ethernet`
-Link Type. An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs. Note that the lag_mode parameter is a property of the interface and not the link, since interfaces may have different lag modes on opposite sides of the link - e.g. lacp_passive <-> lacp_active
+Link Type. An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.
 
 <a id="nestedatt--endpoints"></a>
 ### Nested Schema for `endpoints`

--- a/examples/resources/apstra_datacenter_connectivity_template_interface/example.tf
+++ b/examples/resources/apstra_datacenter_connectivity_template_interface/example.tf
@@ -27,8 +27,8 @@ data "apstra_datacenter_routing_zone" "selected" {
   id           = each.value
 }
 
-# Loop over the Routing Zones. For each one,and discover the IDs of all
-# associaated Virtual Networks.
+# Loop over the Routing Zones. For each RZ, discover the IDs of all
+# associated Virtual Networks.
 data "apstra_datacenter_virtual_networks" "selected" {
   for_each     = data.apstra_datacenter_routing_zone.selected
   blueprint_id = "82a4dde9-eb98-4666-a010-d82f66296be4"
@@ -39,9 +39,9 @@ data "apstra_datacenter_virtual_networks" "selected" {
   ]
 }
 
-# Finally, create an 'interface' type Connectivity Template. Multiple
-# "Virtual Network (Multiple)" primitives are included in this CT, one for
-# each Routing Zone. Each primitive lists all of the Virtual Networks in
+# Finally, create an 'interface' type Connectivity Template with a
+# "Virtual Network (Multiple)" primitive for each Routing Zone. Each
+# of these primitives lists all of the Virtual Networks in
 # that Routing Zone.
 resource "apstra_datacenter_connectivity_template_interface" "example" {
   blueprint_id = "82a4dde9-eb98-4666-a010-d82f66296be4"


### PR DESCRIPTION
- Change `aggregate_link_id` attribute to `Computed`.
- Ensure that `aggregate_link_id` is always `null` in resource context.
- Update inline documentation.

Closes #822
Closes #819