### PR TITLE
Update `stringSliceOrNull()` test helper function to support generic strings

### DIFF
--- a/apstra/resource_datacenter_connectivity_template_interface_integration_test.go
+++ b/apstra/resource_datacenter_connectivity_template_interface_integration_test.go
@@ -88,7 +88,7 @@ func (o resourceDataCenterConnectivityTemplateInterface) render(rType, rName str
 		o.blueprintId,
 		o.name,
 		stringOrNull(o.description),
-		stringSetOrNull(o.tags),
+		stringSliceOrNull(o.tags),
 		ipLinks,
 		routingZoneConstraints,
 		virtualNetworkMultiples,

--- a/apstra/resource_datacenter_connectivity_template_loopback_integration_test.go
+++ b/apstra/resource_datacenter_connectivity_template_loopback_integration_test.go
@@ -51,7 +51,7 @@ func (o resourceDataCenterConnectivityTemplateLoopback) render(rType, rName stri
 		o.blueprintId,
 		o.name,
 		stringOrNull(o.description),
-		stringSetOrNull(o.tags),
+		stringSliceOrNull(o.tags),
 		bgpPeeringIpEndoints,
 	)
 }

--- a/apstra/resource_datacenter_connectivity_template_primitives_test.go
+++ b/apstra/resource_datacenter_connectivity_template_primitives_test.go
@@ -709,7 +709,7 @@ func (o resourceDataCenterConnectivityTemplatePrimitiveVirtualNetworkMultiple) r
 		fmt.Sprintf(resourceDataCenterConnectivityTemplatePrimitiveVirtualNetworkMultipleHCL,
 			o.name,
 			stringOrNull(o.untaggedVnId),
-			stringSetOrNull(o.taggedVnIds),
+			stringSliceOrNull(o.taggedVnIds),
 		),
 	)
 }

--- a/apstra/resource_datacenter_connectivity_template_svi_integration_test.go
+++ b/apstra/resource_datacenter_connectivity_template_svi_integration_test.go
@@ -64,7 +64,7 @@ func (o resourceDataCenterConnectivityTemplateSvi) render(rType, rName string) s
 		o.blueprintId,
 		o.name,
 		stringOrNull(o.description),
-		stringSetOrNull(o.tags),
+		stringSliceOrNull(o.tags),
 		bgpPeeringIpEndoints,
 		dynamicBgpPeerings,
 	)

--- a/apstra/resource_datacenter_connectivity_template_system_integration_test.go
+++ b/apstra/resource_datacenter_connectivity_template_system_integration_test.go
@@ -51,7 +51,7 @@ func (o resourceDataCenterConnectivityTemplateSystem) render(rType, rName string
 		o.blueprintId,
 		o.name,
 		stringOrNull(o.description),
-		stringSetOrNull(o.tags),
+		stringSliceOrNull(o.tags),
 		customStaticRoutes,
 	)
 }

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -88,7 +88,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 			cidrOrNull(in.loopbackIpv4),
 			cidrOrNull(in.loopbackIpv6),
 			stringOrNull(in.deployMode),
-			stringSetOrNull(in.tags),
+			stringSliceOrNull(in.tags),
 		)
 	}
 

--- a/apstra/resource_datacenter_routing_zone_integration_test.go
+++ b/apstra/resource_datacenter_routing_zone_integration_test.go
@@ -53,10 +53,10 @@ func (o testRoutingZone) render(bpId apstra.ObjectId, rType, rName string) strin
 
 		intPtrOrNull(o.vlan),
 		intPtrOrNull(o.vni),
-		stringSetOrNull(o.dhcpServers),
+		stringSliceOrNull(o.dhcpServers),
 		stringOrNull(o.routingPolicy),
-		stringSetOrNull(o.importRTs),
-		stringSetOrNull(o.exportRTs),
+		stringSliceOrNull(o.importRTs),
+		stringSliceOrNull(o.exportRTs),
 		stringOrNull(o.irbMode),
 	)
 }

--- a/apstra/resource_freeform_allocation_group_integration_test.go
+++ b/apstra/resource_freeform_allocation_group_integration_test.go
@@ -42,7 +42,7 @@ func (o resourceAllocGroup) render(rType, rName string) string {
 		o.blueprintId,
 		o.name,
 		utils.StringersToFriendlyString(o.groupType),
-		stringSetOrNull(o.poolIds),
+		stringSliceOrNull(o.poolIds),
 	)
 }
 

--- a/apstra/resource_freeform_config_template_integration_test.go
+++ b/apstra/resource_freeform_config_template_integration_test.go
@@ -40,7 +40,7 @@ func (o resourceFreeformConfigTemplate) render(rType, rName string) string {
 		o.blueprintId,
 		o.name,
 		o.text,
-		stringSetOrNull(o.tags),
+		stringSliceOrNull(o.tags),
 	)
 }
 

--- a/apstra/resource_freeform_link_integration_test.go
+++ b/apstra/resource_freeform_link_integration_test.go
@@ -57,7 +57,7 @@ func (o resourceFreeformLink) render(rType, rName string) string {
 		rType, rName,
 		o.blueprintId,
 		o.name,
-		stringSetOrNull(o.tags),
+		stringSliceOrNull(o.tags),
 		o.endpoints[0].SystemId,
 		stringPtrOrNull(o.endpoints[0].Interface.Data.IfName),
 		intPtrOrNull(o.endpoints[0].Interface.Data.TransformationId),

--- a/apstra/resource_freeform_resource_integraion_test.go
+++ b/apstra/resource_freeform_resource_integraion_test.go
@@ -59,7 +59,7 @@ func (o resourceFreeformResource) render(rType, rName string) string {
 		ipNetOrNull(o.ipv4Value),
 		ipNetOrNull(o.ipv6Value),
 		stringOrNull(o.allocatedFrom.String()),
-		stringSetOrNull(o.assignedTo),
+		stringSliceOrNull(o.assignedTo),
 	)
 }
 

--- a/apstra/resource_freeform_system_integration_test.go
+++ b/apstra/resource_freeform_system_integration_test.go
@@ -50,7 +50,7 @@ func (o resourceFreeformSystem) render(rType, rName string) string {
 		o.hostname,
 		o.systemType,
 		stringOrNull(o.deployMode),
-		stringSetOrNull(o.tags),
+		stringSliceOrNull(o.tags),
 	)
 }
 

--- a/apstra/test_helpers_test.go
+++ b/apstra/test_helpers_test.go
@@ -138,7 +138,7 @@ func intPtrOrNull[A constraints.Integer](in *A) string {
 	return fmt.Sprintf("%d", *in)
 }
 
-func stringSetOrNull(in []string) string {
+func stringSliceOrNull[S ~string](in []S) string {
 	if len(in) == 0 {
 		return "null"
 	}
@@ -405,6 +405,68 @@ func padFormatStr(n, base int) (string, error) {
 
 	c := int(math.Floor(math.Log(float64(n))/math.Log(float64(base)))) + 1
 	return fmt.Sprintf("%%%d%s", c, baseChar), nil
+}
+
+func TestStringSliceOrNull(t *testing.T) {
+	type stringTestCase struct {
+		s []string
+		e string
+	}
+
+	stringTestCases := map[string]stringTestCase{
+		"with_strings": {
+			s: []string{"a", "b", "c"},
+			e: `[ "a", "b", "c" ]`,
+		},
+		"empty": {
+			s: []string{},
+			e: "null",
+		},
+		"nil": {
+			s: nil,
+			e: "null",
+		},
+	}
+
+	for tName, tCase := range stringTestCases {
+		t.Run("string_"+tName, func(t *testing.T) {
+			t.Parallel()
+			r := stringSliceOrNull(tCase.s)
+			if tCase.e != r {
+				t.Fatalf("expected %q, got %q", tCase.e, r)
+			}
+		})
+	}
+
+	type idTestCase struct {
+		s []apstra.ObjectId
+		e string
+	}
+
+	idTestCases := map[string]idTestCase{
+		"with_strings": {
+			s: []apstra.ObjectId{"a", "b", "c"},
+			e: `[ "a", "b", "c" ]`,
+		},
+		"empty": {
+			s: []apstra.ObjectId{},
+			e: "null",
+		},
+		"nil": {
+			s: nil,
+			e: "null",
+		},
+	}
+
+	for tName, tCase := range idTestCases {
+		t.Run("ObjectId_"+tName, func(t *testing.T) {
+			t.Parallel()
+			r := stringSliceOrNull(tCase.s)
+			if tCase.e != r {
+				t.Fatalf("expected %q, got %q", tCase.e, r)
+			}
+		})
+	}
 }
 
 func TestPadFormatStr(t *testing.T) {


### PR DESCRIPTION
- `stringSliceOrNull()` now supports generic string types `~string` instead of just `string`
- renamed from `stringSetOrNull()`, because it's not not actually an un-ordered set