### PR TITLE
835 review: WIP - tests still not passing

### DIFF
--- a/apstra/data_source_freeform_config_template.go
+++ b/apstra/data_source_freeform_config_template.go
@@ -93,7 +93,6 @@ func (o *dataSourceFreeformConfigTemplate) Read(ctx context.Context, req datasou
 	}
 
 	// Read the system assignments
-
 	assignments, err := bp.GetConfigTemplateAssignments(ctx, api.Id)
 	if err != nil {
 		resp.Diagnostics.AddError("error reading ConfigTemplate System Assignments", err.Error())

--- a/apstra/freeform/config_template.go
+++ b/apstra/freeform/config_template.go
@@ -136,3 +136,16 @@ func (o *ConfigTemplate) LoadApiData(ctx context.Context, in *apstra.ConfigTempl
 	o.Text = types.StringValue(in.Text)
 	o.Tags = utils.SetValueOrNull(ctx, types.StringType, in.Tags, diags) // safe to ignore diagnostic here
 }
+
+func (o ConfigTemplate) NeedsUpdate(state ConfigTemplate) bool {
+	switch {
+	case !o.Name.Equal(state.Name):
+		return true
+	case !o.Text.Equal(state.Text):
+		return true
+	case !o.Tags.Equal(state.Tags):
+		return true
+	}
+
+	return false
+}

--- a/apstra/resource_freeform_config_template_integration_test.go
+++ b/apstra/resource_freeform_config_template_integration_test.go
@@ -69,6 +69,8 @@ func (o resourceFreeformConfigTemplate) testChecks(t testing.TB, rType, rName st
 		for _, assignment := range o.assignedTo {
 			result.append(t, "TestCheckTypeSetElemAttr", "assigned_to.*", string(assignment))
 		}
+	} else {
+		result.append(t, "TestCheckNoResourceAttr", "assigned_to")
 	}
 
 	return result
@@ -91,7 +93,7 @@ func TestResourceFreeformConfigTemplate(t *testing.T) {
 	}
 
 	testCases := map[string]testCase{
-		"start_with_no_tags": {
+		"start_minimal": {
 			steps: []testStep{
 				{
 					config: resourceFreeformConfigTemplate{
@@ -118,7 +120,7 @@ func TestResourceFreeformConfigTemplate(t *testing.T) {
 				},
 			},
 		},
-		"start_with_tags": {
+		"start_maximal": {
 			steps: []testStep{
 				{
 					config: resourceFreeformConfigTemplate{

--- a/apstra/resource_freeform_link_integration_test.go
+++ b/apstra/resource_freeform_link_integration_test.go
@@ -76,7 +76,6 @@ func (o resourceFreeformLink) testChecks(t testing.TB, rType, rName string, ipAl
 
 	// required and computed attributes can always be checked
 	result.append(t, "TestCheckResourceAttrSet", "id")
-	result.append(t, "TestCheckResourceAttr", "type", apstra.FFLinkTypeEthernet.String())
 	result.append(t, "TestCheckNoResourceAttr", "aggregate_link_id")
 	result.append(t, "TestCheckResourceAttr", "blueprint_id", o.blueprintId)
 	result.append(t, "TestCheckResourceAttr", "name", o.name)


### PR DESCRIPTION
We need to write tests for the recent "assignments" methods in the SDK for both resource and for config template.

I think they might not be working right.

Tests currently failing.

Still, I think everything in here is correct and should be merged with the parent 835 branch.