### PR TITLE
Fix build on 32-bit platforms

### DIFF
--- a/apstra/resource_freeform_resource.go
+++ b/apstra/resource_freeform_resource.go
@@ -71,7 +71,7 @@ func (o *resourceFreeformResource) ValidateConfig(ctx context.Context, req resou
 			resp.Diagnostics.AddAttributeError(
 				path.Root("integer_value"),
 				errInvalidConfig,
-				fmt.Sprintf("When type is %s, value must be between %d and %d, got %s", config.Type, constants.AsnMin, constants.AsnMax, config.IntValue.String()),
+				fmt.Sprintf("When type is %s, value must be between %d and %d, got %s", config.Type, constants.AsnMin, uint32(constants.AsnMax), config.IntValue.String()),
 			)
 		}
 	case apstra.FFResourceTypeVni:
@@ -116,7 +116,7 @@ func (o *resourceFreeformResource) ValidateConfig(ctx context.Context, req resou
 			resp.Diagnostics.AddAttributeError(
 				path.Root("integer_value"),
 				errInvalidConfig,
-				fmt.Sprintf("When type is %s, value must be between %d and %d, got %s", config.Type, 1, math.MaxUint32, config.IntValue.String()),
+				fmt.Sprintf("When type is %s, value must be between %d and %d, got %s", config.Type, 1, uint32(math.MaxUint32), config.IntValue.String()),
 			)
 		}
 	case apstra.FFResourceTypeHostIpv4:


### PR DESCRIPTION
Large like constants like `AsnMax` (4294967295) will overflow if passed as `int` to `fmt.Sprintf()` in our inline documentation.

This PR introduces type conversion so they're treated as `uint32` in these cases.