### PR TITLE
Remove 4.1.x support from `apstra_datacenter_routing_zone` resource

### DIFF
--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -20,12 +20,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
-
-var junosEvpnIrbModeDefault = enum.JunosEvpnIrbModeAsymmetric.Value
 
 type DatacenterRoutingZone struct {
 	Id                   types.String `tfsdk:"id"`
@@ -279,17 +278,13 @@ func (o DatacenterRoutingZone) ResourceAttributes() map[string]resourceSchema.At
 			},
 		},
 		"junos_evpn_irb_mode": resourceSchema.StringAttribute{
-			MarkdownDescription: fmt.Sprintf("Symmetric IRB Routing for EVPN on Junos devices makes use of "+
-				"an L3 VNI for inter-subnet routing which is embedded into EVPN Type2-routes to support better "+
-				"scaling for networks with large amounts of VLANs. Applicable only to Apstra 4.2.0+. When omitted, "+
-				"Routing Zones in Apstra 4.2.0 and later will be configured with mode `%s`.", junosEvpnIrbModeDefault),
-			Optional:      true,
-			Computed:      true,
-			PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
-			Validators:    []validator.String{stringvalidator.OneOf(enum.JunosEvpnIrbModes.Values()...)},
-			// Default: DO NOT USE stringdefault.StaticString(apstra.JunosEvpnIrbModeAsymmetric.Value) here
-			// because that will set the attribute for Apstra < 4.2.0 (which do not support it) leading to
-			// confusion.
+			MarkdownDescription: "Symmetric IRB Routing for EVPN on Junos devices makes use of an L3 VNI for " +
+				"inter-subnet routing which is embedded into EVPN Type2-routes to support better scaling for " +
+				"networks with large amounts of VLANs.",
+			Optional:   true,
+			Computed:   true,
+			Validators: []validator.String{stringvalidator.OneOf(enum.JunosEvpnIrbModes.Values()...)},
+			Default:    stringdefault.StaticString(enum.JunosEvpnIrbModeAsymmetric.String()),
 		},
 	}
 }

--- a/docs/resources/datacenter_routing_zone.md
+++ b/docs/resources/datacenter_routing_zone.md
@@ -47,7 +47,7 @@ resource "apstra_datacenter_resource_pool_allocation" "blue_loopbacks" {
 - `dhcp_servers` (Set of String) Set of DHCP server IPv4 or IPv6 addresses of DHCP servers.
 - `export_route_targets` (Set of String) Used to export routes from the EVPN VRF.
 - `import_route_targets` (Set of String) Used to import routes into the EVPN VRF.
-- `junos_evpn_irb_mode` (String) Symmetric IRB Routing for EVPN on Junos devices makes use of an L3 VNI for inter-subnet routing which is embedded into EVPN Type2-routes to support better scaling for networks with large amounts of VLANs. Applicable only to Apstra 4.2.0+. When omitted, Routing Zones in Apstra 4.2.0 and later will be configured with mode `asymmetric`.
+- `junos_evpn_irb_mode` (String) Symmetric IRB Routing for EVPN on Junos devices makes use of an L3 VNI for inter-subnet routing which is embedded into EVPN Type2-routes to support better scaling for networks with large amounts of VLANs.
 - `routing_policy_id` (String) Non-EVPN blueprints must use the default policy, so this field must be null. Set this attribute in an EVPN blueprint to use a non-default policy.
 - `vlan_id` (Number) Used for VLAN tagged Layer 3 links on external connections. Leave this field blank to have it automatically assigned from a static pool in the range of 2-4094, or enter a specific value.
 - `vni` (Number) VxLAN VNI associated with the routing zone. Leave this field blank to have it automatically assigned from an allocated resource pool, or enter a specific value.


### PR DESCRIPTION
This PR introduces a `Default` element to the `junos_evpn_irb_mode` attribute of the `apstra_datacenter_routing_zone` resource.

This wasn't possible while supporting 4.1.x because the 4.1.x API didn't support setting the IRB mode, but 4.2 requires it.