### PR TITLE
Bump SDK to version with Apstra 5.0.0 support

### DIFF
--- a/apstra/analytics/telemetry_service_registry_entry.go
+++ b/apstra/analytics/telemetry_service_registry_entry.go
@@ -73,11 +73,11 @@ func (o TelemetryServiceRegistryEntry) ResourceAttributes() map[string]resourceS
 			Required:            true,
 		},
 		"storage_schema_path": resourceSchema.StringAttribute{
-			MarkdownDescription: "Storage Schema Path. Must be one of:\n  - " + strings.Join([]string{utils.StringersToFriendlyString(enum.StorageSchemaPathIBA_STRING_DATA), utils.StringersToFriendlyString(enum.StorageSchemaPathIBA_INTEGER_DATA)}, "\n  - ") + "\n",
+			MarkdownDescription: "Storage Schema Path. Must be one of:\n  - " + strings.Join([]string{utils.StringersToFriendlyString(enum.StorageSchemaPathIbaStringData), utils.StringersToFriendlyString(enum.StorageSchemaPathIbaIntegerData)}, "\n  - ") + "\n",
 			Required:            true,
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
-				stringvalidator.OneOf(utils.StringersToFriendlyString(enum.StorageSchemaPathIBA_STRING_DATA), utils.StringersToFriendlyString(enum.StorageSchemaPathIBA_INTEGER_DATA)),
+				stringvalidator.OneOf(utils.StringersToFriendlyString(enum.StorageSchemaPathIbaStringData), utils.StringersToFriendlyString(enum.StorageSchemaPathIbaIntegerData)),
 			},
 		},
 		"description": resourceSchema.StringAttribute{

--- a/apstra/test_utils/telemetry_service_registry_entry.go
+++ b/apstra/test_utils/telemetry_service_registry_entry.go
@@ -63,7 +63,7 @@ func TelemetryServiceRegistryEntryA(t testing.TB, ctx context.Context) *apstra.T
 	request := apstra.TelemetryServiceRegistryEntry{
 		ServiceName:       acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum),
 		ApplicationSchema: schema,
-		StorageSchemaPath: enum.StorageSchemaPathIBA_INTEGER_DATA,
+		StorageSchemaPath: enum.StorageSchemaPathIbaIntegerData,
 		Builtin:           false,
 		Description:       "Test Telemetry Service A",
 		Version:           "",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.22.5
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20240918143008-25a5d4a34fbe
+	github.com/Juniper/apstra-go-sdk v0.0.0-20240920145043-b30ce0dd776c
 	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-version v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20240918143008-25a5d4a34fbe h1:n1zsTKXDjjyMvEtWm19L7xfXVFl3W7e/p/LJrt6AAlQ=
-github.com/Juniper/apstra-go-sdk v0.0.0-20240918143008-25a5d4a34fbe/go.mod h1:qXNVTdnVa40aMTOsBTnKoFNYT5ftga2NAkGJhx4o6bY=
+github.com/Juniper/apstra-go-sdk v0.0.0-20240920145043-b30ce0dd776c h1:TbwhSEMYKjH2un1G9tpiv8tsK9M21YPkOZsajAdn9R0=
+github.com/Juniper/apstra-go-sdk v0.0.0-20240920145043-b30ce0dd776c/go.mod h1:qXNVTdnVa40aMTOsBTnKoFNYT5ftga2NAkGJhx4o6bY=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
Bump SDK to version with Apstra 5.0.0 support.

This does not add 5.0.0 support to the provider - the provider has separate version dependencies.

Absorb some SDK changes along the way (some enums got renamed)