### PR TITLE
Improve concurrency safety when tests share a blueprint

### DIFF
--- a/apstra/main_test.go
+++ b/apstra/main_test.go
@@ -1,0 +1,18 @@
+package tfapstra_test
+
+import (
+	"sync"
+	"testing"
+
+	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
+)
+
+// TestMain exists to initialize the MakeOrFindBlueprintMutex which makes the
+// MakeOrFindBlueprint function concurrency safe.
+func TestMain(m *testing.M) {
+	if testutils.MakeOrFindBlueprintMutex == nil {
+		testutils.MakeOrFindBlueprintMutex = new(sync.Mutex)
+	}
+
+	m.Run()
+}

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -22,16 +22,18 @@ func MakeOrFindBlueprint(t testing.TB, ctx context.Context, name string, f bFunc
 	client := GetTestClient(t, ctx)
 
 	MakeOrFindBlueprintMutex.Lock()
-	defer MakeOrFindBlueprintMutex.Unlock()
 
 	status, err := client.GetBlueprintStatusByName(ctx, name)
 	if err != nil {
+		defer MakeOrFindBlueprintMutex.Unlock()
 		if utils.IsApstra404(err) {
 			return f(t, ctx, name)
 		}
 
-		require.NoError(t, err)
+		t.Fatal(err)
 	}
+
+	MakeOrFindBlueprintMutex.Unlock()
 
 	bpClient, err := client.NewTwoStageL3ClosClient(ctx, status.Id)
 	require.NoError(t, err)

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -19,10 +19,10 @@ type bFunc func(t testing.TB, ctx context.Context, name ...string) *apstra.TwoSt
 func MakeOrFindBlueprint(t testing.TB, ctx context.Context, name string, f bFunc) *apstra.TwoStageL3ClosClient {
 	t.Helper()
 
+	client := GetTestClient(t, ctx)
+
 	MakeOrFindBlueprintMutex.Lock()
 	defer MakeOrFindBlueprintMutex.Unlock()
-
-	client := GetTestClient(t, ctx)
 
 	status, err := client.GetBlueprintStatusByName(ctx, name)
 	if err != nil {

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
@@ -10,10 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// MakeOrFindBlueprintMutex is created by TestMain()
+var MakeOrFindBlueprintMutex *sync.Mutex
+
 type bFunc func(t testing.TB, ctx context.Context, name ...string) *apstra.TwoStageL3ClosClient
 
 func MakeOrFindBlueprint(t testing.TB, ctx context.Context, name string, f bFunc) *apstra.TwoStageL3ClosClient {
 	t.Helper()
+
+	MakeOrFindBlueprintMutex.Lock()
+	defer MakeOrFindBlueprintMutex.Unlock()
 
 	client := GetTestClient(t, ctx)
 


### PR DESCRIPTION
The `MakeOrFindBlueprint()` function had a race condition:

1. Test A checks for blueprint, gets 404.
2. Test B checks for blueprint, gets 404.
3. Test A creates blueprint
4. TestB creates blueprint, gets error: "already exists"

This PR introduces `TestMain()` which creates a global `sync.Mutex` used to control access to the shared blueprint.

Closes #853