### PR TITLE
Disable resource apstra_blueprint_iba_dashboards with 5.x.x 

### DIFF
--- a/apstra/data_source_blueprint_iba_dashboard.go
+++ b/apstra/data_source_blueprint_iba_dashboard.go
@@ -43,15 +43,8 @@ func (o *dataSourceBlueprintIbaDashboard) Schema(_ context.Context, _ datasource
 	}
 }
 
-func (o *dataSourceBlueprintIbaDashboard) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
-	// Retrieve values from config.
-	var config iba.Dashboard
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// cannot proceed to config + api version validation if the provider has not been configured
+func (o *dataSourceBlueprintIbaDashboard) ValidateConfig(_ context.Context, _ datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	// cannot proceed to api version validation if the provider has not been configured
 	if o.client == nil {
 		return
 	}
@@ -62,7 +55,6 @@ func (o *dataSourceBlueprintIbaDashboard) ValidateConfig(ctx context.Context, re
 			"Incompatible API version",
 			"This data source is compatible only with Apstra "+compatibility.BpIbaDashboardOk.String(),
 		)
-		return
 	}
 }
 
@@ -127,11 +119,11 @@ func (o *dataSourceBlueprintIbaDashboard) Read(ctx context.Context, req datasour
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 }
 
+func (o *dataSourceBlueprintIbaDashboard) setBpClientFunc(f func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)) {
+	o.getBpClientFunc = f
+}
+
 // setClient is used for API version compatibility check only
 func (o *dataSourceBlueprintIbaDashboard) setClient(client *apstra.Client) {
 	o.client = client
-}
-
-func (o *dataSourceBlueprintIbaDashboard) setBpClientFunc(f func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)) {
-	o.getBpClientFunc = f
 }

--- a/apstra/data_source_blueprint_iba_dashboards.go
+++ b/apstra/data_source_blueprint_iba_dashboards.go
@@ -52,18 +52,7 @@ func (o *dataSourceBlueprintIbaDashboards) Schema(_ context.Context, _ datasourc
 	}
 }
 
-func (o *dataSourceBlueprintIbaDashboards) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
-	var config struct {
-		BlueprintId types.String `tfsdk:"blueprint_id"`
-		Ids         types.Set    `tfsdk:"ids"`
-	}
-
-	// Retrieve values from config.
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
+func (o *dataSourceBlueprintIbaDashboards) ValidateConfig(_ context.Context, _ datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
 	// cannot proceed to config + api version validation if the provider has not been configured
 	if o.client == nil {
 		return

--- a/apstra/data_source_blueprint_iba_dashboards.go
+++ b/apstra/data_source_blueprint_iba_dashboards.go
@@ -64,7 +64,6 @@ func (o *dataSourceBlueprintIbaDashboards) ValidateConfig(_ context.Context, _ d
 			"Incompatible API version",
 			"This data source is compatible only with Apstra "+compatibility.BpIbaDashboardOk.String(),
 		)
-		return
 	}
 }
 

--- a/apstra/data_source_blueprint_iba_dashboards.go
+++ b/apstra/data_source_blueprint_iba_dashboards.go
@@ -3,6 +3,7 @@ package tfapstra
 import (
 	"context"
 	"fmt"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -15,10 +16,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ datasource.DataSourceWithConfigure = &dataSourceBlueprintIbaDashboards{}
-var _ datasource.DataSourceWithValidateConfig = &dataSourceBlueprintIbaDashboards{}
-var _ datasourceWithSetDcBpClientFunc = &dataSourceBlueprintIbaDashboards{}
-var _ datasourceWithSetClient = &dataSourceBlueprintIbaDashboards{}
+var (
+	_ datasource.DataSourceWithConfigure      = &dataSourceBlueprintIbaDashboards{}
+	_ datasource.DataSourceWithValidateConfig = &dataSourceBlueprintIbaDashboards{}
+	_ datasourceWithSetDcBpClientFunc         = &dataSourceBlueprintIbaDashboards{}
+	_ datasourceWithSetClient                 = &dataSourceBlueprintIbaDashboards{}
+)
 
 type dataSourceBlueprintIbaDashboards struct {
 	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)


### PR DESCRIPTION
In addition to adding the validation checks, I removed the configuration fetch from `dataSourceBlueprintIbaDashboard.ValidateConfig()`.

It turns out, we don't need the actual config when we're interested only in checking the API version.

We know the config *exists* because we entered that function. That fact, combined with the API version is enough to detect a problem. No need to fetch the actual configuration. 

Closes #871