### PR TITLE
Remove `type` attribute from `freeform.Link` struct

### DIFF
--- a/apstra/freeform/link.go
+++ b/apstra/freeform/link.go
@@ -25,7 +25,6 @@ type Link struct {
 	BlueprintId     types.String `tfsdk:"blueprint_id"`
 	Id              types.String `tfsdk:"id"`
 	Speed           types.String `tfsdk:"speed"`
-	Type            types.String `tfsdk:"type"`
 	Name            types.String `tfsdk:"name"`
 	AggregateLinkId types.String `tfsdk:"aggregate_link_id"`
 	Endpoints       types.Map    `tfsdk:"endpoints"`
@@ -63,12 +62,6 @@ func (o Link) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 				"200G | 5G | 1G | 100G | 150g | 40g | 2500M | 25G | 25g | 10G | 50G | 800G " +
 				"| 10M | 100m | 2500m | 50g | 400g | 400G | 200g | 5g | 800g | 100M | 10g " +
 				"| 150G | 10m | 100g | 1g | 40G",
-			Computed: true,
-		},
-		"type": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "`aggregate_link` | `ethernet`\n" +
-				"An 'ethernet' link is a normal front-panel interface. " +
-				"An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.",
 			Computed: true,
 		},
 		"aggregate_link_id": dataSourceSchema.StringAttribute{
@@ -113,12 +106,6 @@ func (o Link) ResourceAttributes() map[string]resourceSchema.Attribute {
 		"speed": resourceSchema.StringAttribute{
 			MarkdownDescription: "Speed of the Freeform Link.",
 			Computed:            true,
-		},
-		"type": resourceSchema.StringAttribute{
-			MarkdownDescription: "`aggregate_link` | `ethernet`\n" +
-				"An 'ethernet' link is a normal front-panel interface. " +
-				"An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.",
-			Computed: true,
 		},
 		"aggregate_link_id": resourceSchema.StringAttribute{
 			MarkdownDescription: "This field always `null` in resource context. Ignore. " +

--- a/docs/data-sources/freeform_link.md
+++ b/docs/data-sources/freeform_link.md
@@ -52,7 +52,6 @@ output "test_Link_out" { value = data.apstra_freeform_link.test }
 #    "a",
 #    "b",
 #  ])
-#  "type" = "ethernet"
 #}
 ```
 
@@ -74,8 +73,6 @@ output "test_Link_out" { value = data.apstra_freeform_link.test }
 - `endpoints` (Attributes Map) Endpoints of the  Link, a Map keyed by System ID. (see [below for nested schema](#nestedatt--endpoints))
 - `speed` (String) Speed of the Link 200G | 5G | 1G | 100G | 150g | 40g | 2500M | 25G | 25g | 10G | 50G | 800G | 10M | 100m | 2500m | 50g | 400g | 400G | 200g | 5g | 800g | 100M | 10g | 150G | 10m | 100g | 1g | 40G
 - `tags` (Set of String) Set of unique case-insensitive tag labels
-- `type` (String) `aggregate_link` | `ethernet`
-An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.
 
 <a id="nestedatt--endpoints"></a>
 ### Nested Schema for `endpoints`

--- a/docs/resources/freeform_link.md
+++ b/docs/resources/freeform_link.md
@@ -53,8 +53,6 @@ resource "apstra_freeform_link" "test" {
 - `aggregate_link_id` (String) This field always `null` in resource context. Ignore. This information can be learned by invoking the complimentary data source.
 - `id` (String) ID of the Freeform Link.
 - `speed` (String) Speed of the Freeform Link.
-- `type` (String) `aggregate_link` | `ethernet`
-An 'ethernet' link is a normal front-panel interface. An 'aggregate_link' is a bonded interface which is typically used for LACP or Static LAGs.
 
 <a id="nestedatt--endpoints"></a>
 ### Nested Schema for `endpoints`

--- a/examples/data-sources/apstra_freeform_link/example.tf
+++ b/examples/data-sources/apstra_freeform_link/example.tf
@@ -34,6 +34,4 @@ output "test_Link_out" { value = data.apstra_freeform_link.test }
 #    "a",
 #    "b",
 #  ])
-#  "type" = "ethernet"
 #}
-


### PR DESCRIPTION
We previously decided to remove the `Type` attribute from the SDK's `FreeformLinkData` struct, because CRUD methods on Ethernet/physical and LAG links are so different.

But `type` hung around as a computed attribute on the Terraform object.

This PR removes `type` from terraform link structs.

Closes #877