### PR TITLE
Disable IBA Probe with 5.x

### DIFF
--- a/apstra/compatibility/constraints.go
+++ b/apstra/compatibility/constraints.go
@@ -5,4 +5,7 @@ import (
 	"github.com/chrismarget-j/version-constraints"
 )
 
-var BpIbaDashboardOk = versionconstraints.New(apiversions.LtApstra500)
+var (
+	BpIbaDashboardOk = versionconstraints.New(apiversions.LtApstra500)
+	BpIbaProbeOk     = versionconstraints.New(apiversions.LtApstra500)
+)

--- a/apstra/data_source_blueprint_iba_dashboard.go
+++ b/apstra/data_source_blueprint_iba_dashboard.go
@@ -38,7 +38,8 @@ func (o *dataSourceBlueprintIbaDashboard) Schema(_ context.Context, _ datasource
 	resp.Schema = schema.Schema{
 		MarkdownDescription: docCategoryRefDesignAny + "This data source provides details of a specific IBA Dashboard in a Blueprint." +
 			"\n\n" +
-			"At least one optional attribute is required.",
+			"At least one optional attribute is required.\n\n" +
+			"*Note: Compatible only with Apstra " + compatibility.BpIbaDashboardOk.String() + "*",
 		Attributes: iba.Dashboard{}.DataSourceAttributes(),
 	}
 }

--- a/apstra/data_source_blueprint_iba_dashboards.go
+++ b/apstra/data_source_blueprint_iba_dashboards.go
@@ -38,7 +38,8 @@ func (o *dataSourceBlueprintIbaDashboards) Configure(ctx context.Context, req da
 
 func (o *dataSourceBlueprintIbaDashboards) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: docCategoryRefDesignAny + "This data source returns the ID numbers of all IBA Dashboards in a Blueprint.",
+		MarkdownDescription: docCategoryRefDesignAny + "This data source returns the ID numbers of all IBA Dashboards in a Blueprint.\n\n" +
+			"*Note: Compatible only with Apstra " + compatibility.BpIbaDashboardOk.String() + "*",
 		Attributes: map[string]schema.Attribute{
 			"blueprint_id": schema.StringAttribute{
 				MarkdownDescription: "Apstra Blueprint ID. " +

--- a/apstra/data_source_blueprint_iba_predefined_probe.go
+++ b/apstra/data_source_blueprint_iba_predefined_probe.go
@@ -3,7 +3,9 @@ package tfapstra
 import (
 	"context"
 	"fmt"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/iba"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -11,8 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
-var _ datasource.DataSourceWithConfigure = &dataSourceBlueprintIbaPredefinedProbe{}
-var _ datasourceWithSetDcBpClientFunc = &dataSourceBlueprintIbaPredefinedProbe{}
+var (
+	_ datasource.DataSourceWithConfigure = &dataSourceBlueprintIbaPredefinedProbe{}
+	_ datasourceWithSetDcBpClientFunc    = &dataSourceBlueprintIbaPredefinedProbe{}
+)
 
 type dataSourceBlueprintIbaPredefinedProbe struct {
 	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)
@@ -28,8 +32,9 @@ func (o *dataSourceBlueprintIbaPredefinedProbe) Configure(ctx context.Context, r
 
 func (o *dataSourceBlueprintIbaPredefinedProbe) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: docCategoryRefDesignAny + "This data source provides details of a specific IBA Predefined Probe in a Blueprint.",
-		Attributes:          iba.PredefinedProbe{}.DataSourceAttributes(),
+		MarkdownDescription: docCategoryRefDesignAny + "This data source provides details of a specific IBA Predefined Probe in a Blueprint.\n\n" +
+			"*Note: Compatible only with Apstra " + compatibility.BpIbaProbeOk.String() + "*",
+		Attributes: iba.PredefinedProbe{}.DataSourceAttributes(),
 	}
 }
 

--- a/apstra/resource_blueprint_iba_dashboard.go
+++ b/apstra/resource_blueprint_iba_dashboard.go
@@ -35,8 +35,9 @@ func (o *resourceBlueprintIbaDashboard) Configure(ctx context.Context, req resou
 
 func (o *resourceBlueprintIbaDashboard) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: docCategoryRefDesignAny + "This resource creates a IBA Dashboard.",
-		Attributes:          iba.Dashboard{}.ResourceAttributes(),
+		MarkdownDescription: docCategoryRefDesignAny + "This resource creates a IBA Dashboard.\n\n" +
+			"*Note: Compatible only with Apstra " + compatibility.BpIbaDashboardOk.String() + "*",
+		Attributes: iba.Dashboard{}.ResourceAttributes(),
 	}
 }
 

--- a/apstra/resource_blueprint_iba_probe_test.go
+++ b/apstra/resource_blueprint_iba_probe_test.go
@@ -3,10 +3,13 @@ package tfapstra
 import (
 	"context"
 	"fmt"
-	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"regexp"
 	"testing"
+
+	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
+	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 const (
@@ -166,6 +169,13 @@ resource "apstra_blueprint_iba_probe" "p_device_health" {
 
 func TestAccResourceProbe(t *testing.T) {
 	ctx := context.Background()
+
+	client := testutils.GetTestClient(t, ctx)
+	clientVersion := version.Must(version.NewVersion(client.ApiVersion()))
+	if !compatibility.BpIbaProbeOk.Check(clientVersion) {
+		t.Skipf("skipping due to version constraint %s", compatibility.BpIbaProbeOk)
+	}
+
 	bpClient := testutils.MakeOrFindBlueprint(t, ctx, "BPA", testutils.BlueprintA)
 
 	type testCase struct {

--- a/docs/data-sources/blueprint_iba_dashboard.md
+++ b/docs/data-sources/blueprint_iba_dashboard.md
@@ -4,6 +4,7 @@ subcategory: "Reference Design: Shared"
 description: |-
   This data source provides details of a specific IBA Dashboard in a Blueprint.
   At least one optional attribute is required.
+  Note: Compatible only with Apstra <5.0.0
 ---
 
 # apstra_blueprint_iba_dashboard (Data Source)
@@ -11,6 +12,8 @@ description: |-
 This data source provides details of a specific IBA Dashboard in a Blueprint.
 
 At least one optional attribute is required.
+
+*Note: Compatible only with Apstra <5.0.0*
 
 
 ## Example Usage

--- a/docs/data-sources/blueprint_iba_dashboards.md
+++ b/docs/data-sources/blueprint_iba_dashboards.md
@@ -3,11 +3,14 @@ page_title: "apstra_blueprint_iba_dashboards Data Source - terraform-provider-ap
 subcategory: "Reference Design: Shared"
 description: |-
   This data source returns the ID numbers of all IBA Dashboards in a Blueprint.
+  Note: Compatible only with Apstra <5.0.0
 ---
 
 # apstra_blueprint_iba_dashboards (Data Source)
 
 This data source returns the ID numbers of all IBA Dashboards in a Blueprint.
+
+*Note: Compatible only with Apstra <5.0.0*
 
 
 ## Example Usage

--- a/docs/data-sources/blueprint_iba_predefined_probe.md
+++ b/docs/data-sources/blueprint_iba_predefined_probe.md
@@ -3,11 +3,14 @@ page_title: "apstra_blueprint_iba_predefined_probe Data Source - terraform-provi
 subcategory: "Reference Design: Shared"
 description: |-
   This data source provides details of a specific IBA Predefined Probe in a Blueprint.
+  Note: Compatible only with Apstra <5.0.0
 ---
 
 # apstra_blueprint_iba_predefined_probe (Data Source)
 
 This data source provides details of a specific IBA Predefined Probe in a Blueprint.
+
+*Note: Compatible only with Apstra <5.0.0*
 
 
 ## Example Usage

--- a/docs/resources/blueprint_iba_dashboard.md
+++ b/docs/resources/blueprint_iba_dashboard.md
@@ -3,11 +3,14 @@ page_title: "apstra_blueprint_iba_dashboard Resource - terraform-provider-apstra
 subcategory: "Reference Design: Shared"
 description: |-
   This resource creates a IBA Dashboard.
+  Note: Compatible only with Apstra <5.0.0
 ---
 
 # apstra_blueprint_iba_dashboard (Resource)
 
 This resource creates a IBA Dashboard.
+
+*Note: Compatible only with Apstra <5.0.0*
 
 
 ## Example Usage


### PR DESCRIPTION
This PR:
- Adds version checking to IBA Probe config validation for IBA probe resource/data sources
- Mentions the version constraint in the rendered docs for those resource/data sources
- Disables tests for these versions

Also:
- Mentions the version constraint in previously-disabled IBA Dashboard resource/data sources