### PR TITLE
Set anti affinity policy as separate action with Apstra 4.2.0

### DIFF
--- a/apstra/data_source_datacenter_blueprint_test.go
+++ b/apstra/data_source_datacenter_blueprint_test.go
@@ -235,6 +235,11 @@ func TestDatasourceDatacenterBlueprint(t *testing.T) {
 					require.NoError(t, err)
 				}
 
+				// force IPv6 lever as specified by the test case (it may need to be on)
+				if tCase.ipv6 {
+					tCase.fabricSettings.Ipv6Enabled = utils.ToPtr(true)
+				}
+
 				err = bpClient.SetFabricSettings(ctx, &tCase.fabricSettings)
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
`TestDatasourceDatacenterBlueprint()` is failing with Apstra 4.2.0 because the test setup code (creating a blueprint) fails to set the Anti Affinity Policy. This is because Apstra 4.2.0 takes the Anti Affinity Policy from the template, rather than the blueprint instantiation request.

This PR detects v4.2.0 while prepping Apstra for running the data source, and sets the policy as a separate action when required.

Closes #902