### PR TITLE
Improve `TestCfgFileToEnv()` for testing w/out valid TLS certificate

### DIFF
--- a/apstra/resource_datacenter_rack_test.go
+++ b/apstra/resource_datacenter_rack_test.go
@@ -3,11 +3,12 @@ package tfapstra_test
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"testing"
 )
 
 const (
@@ -21,6 +22,8 @@ resource "apstra_datacenter_rack" "test" {
 
 func TestResourceDatacenterRack(t *testing.T) {
 	ctx := context.Background()
+
+	testutils.TestCfgFileToEnv(t)
 
 	bp := testutils.BlueprintC(t, ctx)
 


### PR DESCRIPTION
This PR:
- adds `tls_validation_disabled` (boolean) attribute to `.testconfig.hcl` file
- changes function signature of `TestCfgFileToEnv()` so that it takes a `testing.TB` and no longer returns `error`
- improves environmental setup with `t.SetEnv()`
- adds a call to `TestCfgFileToEnv()` to the problem test in #904

Closes #904