### PR TITLE
Add 5.0.0 to list of supported versions

### DIFF
--- a/apstra/compatibility/api_versions.go
+++ b/apstra/compatibility/api_versions.go
@@ -16,20 +16,24 @@ func SupportedApiVersions() []string {
 		apiversions.Apstra421,
 		apiversions.Apstra4211,
 		apiversions.Apstra422,
+		apiversions.Apstra500,
 	}
 
 	sdkVersions := compatibility.SupportedApiVersions()
 
-	return utils.SliceIntersectionOfAB(providerVersions, sdkVersions)
+	bothVersions := utils.SliceIntersectionOfAB(providerVersions, sdkVersions)
+
+	sort.Slice(bothVersions, func(i, j int) bool {
+		iv := version.Must(version.NewVersion(bothVersions[i]))
+		jv := version.Must(version.NewVersion(bothVersions[j]))
+		return iv.LessThan(jv)
+	})
+
+	return bothVersions
 }
 
 func SupportedApiVersionsPretty() string {
 	supportedVers := SupportedApiVersions()
-	sort.Slice(supportedVers, func(i, j int) bool {
-		iv := version.Must(version.NewVersion(supportedVers[i]))
-		jv := version.Must(version.NewVersion(supportedVers[j]))
-		return iv.LessThan(jv)
-	})
 
 	stop := len(supportedVers) - 1
 	for i := range supportedVers {

--- a/apstra/compatibility/api_versions_test.go
+++ b/apstra/compatibility/api_versions_test.go
@@ -8,10 +8,11 @@ import (
 
 func TestSupportedApiVersions(t *testing.T) {
 	expected := []string{
-		apiversions.Apstra410,
-		apiversions.Apstra411,
-		apiversions.Apstra412,
 		apiversions.Apstra420,
+		apiversions.Apstra421,
+		apiversions.Apstra4211,
+		apiversions.Apstra422,
+		apiversions.Apstra500,
 	}
 
 	result := SupportedApiVersions()
@@ -22,7 +23,13 @@ func TestSupportedApiVersions(t *testing.T) {
 }
 
 func TestSupportedApiVersionsPretty(t *testing.T) {
-	expected := apiversions.Apstra410 + ", " + apiversions.Apstra411 + ", " + apiversions.Apstra412 + ", " + apiversions.Apstra420 + ", " + apiversions.Apstra421 + ", " + apiversions.Apstra4211 + ", and " + apiversions.Apstra422
+	expected :=
+		apiversions.Apstra420 + ", " +
+			apiversions.Apstra421 + ", " +
+			apiversions.Apstra4211 + ", " +
+			apiversions.Apstra422 + ", and " +
+			apiversions.Apstra500
+
 	result := SupportedApiVersionsPretty()
 	if expected != result {
 		t.Fatalf("expected %q; got %q", expected, result)

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ It covers day 0 and day 1 operations (design and deployment), and a growing list
 
 Use the navigation tree to the left to read about the available resources and data sources.
 
-This release has been tested with Apstra versions 4.2.0, 4.2.1, 4.2.1.1, and 4.2.2.
+This release has been tested with Apstra versions 4.2.0, 4.2.1, 4.2.1.1, 4.2.2, and 5.0.0.
 
 Some example projects which make use of this provider can be found [here](https://github.com/Juniper/terraform-apstra-examples).
 


### PR DESCRIPTION
This PR:
- adds Apstra 5.0.0 to the list of supported versions
- moves sorting of the supported version list upstream from `SupportedApiVersionsPretty()` to `SupportedApiVersions()`