### PR TITLE
Test env var improvements

### DIFF
--- a/apstra/resource_modular_device_profile_test.go
+++ b/apstra/resource_modular_device_profile_test.go
@@ -2,10 +2,12 @@ package tfapstra
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"strings"
 	"testing"
+
+	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 const (
@@ -21,6 +23,8 @@ resource "apstra_modular_device_profile" "test" {
 )
 
 func TestAccResourceModularDeviceProfile(t *testing.T) {
+	testutils.TestCfgFileToEnv(t)
+
 	name1 := acctest.RandString(5)
 	chassisProfile1 := "Juniper_PTX10008"
 	lineCardProfiles1 := map[int]string{

--- a/apstra/resource_property_set_test.go
+++ b/apstra/resource_property_set_test.go
@@ -2,12 +2,14 @@ package tfapstra
 
 import (
 	"fmt"
+	"testing"
+
+	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"testing"
 )
 
 const (
@@ -34,6 +36,8 @@ resource "apstra_property_set" "test" {
 )
 
 func TestAccResourcePropertySet(t *testing.T) {
+	testutils.TestCfgFileToEnv(t)
+
 	var (
 		testAccResourcePropertySet1Name = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 		testAccResourcePropertySetCfg1  = fmt.Sprintf(resourcePropertySetTemplateHCL, testAccResourcePropertySet1Name, data1_string)


### PR DESCRIPTION
This PR:

- ensures that the `.testconfig` file is read only once per test run
- sets test environment variables in a couple of tests which weren't picking them up

Closes #910