### PR TITLE
Remove comments suggesting a change to the blueprint resource

### DIFF
--- a/apstra/blueprint/blueprint.go
+++ b/apstra/blueprint/blueprint.go
@@ -330,8 +330,6 @@ func (o Blueprint) ResourceAttributes() map[string]resourceSchema.Attribute {
 					apstra.AddressingSchemeIp46.String(),
 				}, ", ")),
 			Optional: true,
-			// todo once depreciated 4.1.0 add this
-			// Default: stringdefault.StaticString(apstra.AddressingSchemeIp4.String()),
 			Validators: []validator.String{stringvalidator.OneOf(
 				apstra.AddressingSchemeIp4.String(),
 				apstra.AddressingSchemeIp6.String(),


### PR DESCRIPTION
The comments deleted by this PR suggest that we set a default value (ipv4) for `fabric_addressing` in the `apstra_datacenter_blueprint` resource...

...But it's not so simple.

Users who have omitted that value will find their blueprint replaced if such a change were implemented.

We could *also* implement a custom type where `null` is semantically equal to `ipv4`, but I don't think it's worth the effort.

This PR is pretty much a "won't do" to those old comments.

Closes #928