### PR TITLE
Use more careful format string/quoting in validator messages

### DIFF
--- a/apstra/apstra_validator/forbidden_when_value_is.go
+++ b/apstra/apstra_validator/forbidden_when_value_is.go
@@ -3,6 +3,7 @@ package apstravalidator
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -11,9 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
 
-var (
-	_ NineTypesValidator = ForbiddenWhenValueIsValidator{}
-)
+var _ NineTypesValidator = ForbiddenWhenValueIsValidator{}
 
 type ForbiddenWhenValueIsValidator struct {
 	Expression path.Expression

--- a/apstra/apstra_validator/forbidden_when_value_is.go
+++ b/apstra/apstra_validator/forbidden_when_value_is.go
@@ -82,7 +82,7 @@ func (o ForbiddenWhenValueIsValidator) Validate(ctx context.Context, req Forbidd
 			if o.Value.Equal(mpVal) {
 				resp.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
 					req.Path,
-					fmt.Sprintf("attribute %q must not be set when %q has value %s, got: %q", req.Path, mp, mpVal, req.ConfigValue),
+					fmt.Sprintf("attribute %q must not be set when %q has value %s, got: %s", req.Path, mp, mpVal, req.ConfigValue),
 				))
 			}
 		}

--- a/apstra/apstra_validator/required_when_value_is.go
+++ b/apstra/apstra_validator/required_when_value_is.go
@@ -31,7 +31,7 @@ type RequiredWhenValueIsResponse struct {
 }
 
 func (o RequiredWhenValueIsValidator) Description(_ context.Context) string {
-	return fmt.Sprintf("Ensures that a value is supplied when attribute at %q has value %q", o.expression.String(), o.value)
+	return fmt.Sprintf("Ensures that a value is supplied when attribute at %s has value %s", o.expression.String(), o.value)
 }
 
 func (o RequiredWhenValueIsValidator) MarkdownDescription(ctx context.Context) string {
@@ -81,7 +81,7 @@ func (o RequiredWhenValueIsValidator) Validate(ctx context.Context, req Required
 				resp.Diagnostics.AddAttributeError(
 					req.Path,
 					"Missing required attribute",
-					fmt.Sprintf("Attribute %q required when %q has value %q.", req.Path, mp.String(), mpVal.String()),
+					fmt.Sprintf("Attribute %q required when %q has value %s.", req.Path, mp, mpVal),
 				)
 			}
 		}

--- a/apstra/apstra_validator/required_when_value_is.go
+++ b/apstra/apstra_validator/required_when_value_is.go
@@ -3,6 +3,7 @@ package apstravalidator
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -10,9 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
 
-var (
-	_ NineTypesValidator = RequiredWhenValueIsValidator{}
-)
+var _ NineTypesValidator = RequiredWhenValueIsValidator{}
 
 type RequiredWhenValueIsValidator struct {
 	expression path.Expression

--- a/apstra/apstra_validator/required_when_value_null.go
+++ b/apstra/apstra_validator/required_when_value_null.go
@@ -3,6 +3,7 @@ package apstravalidator
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -10,9 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
 
-var (
-	_ NineTypesValidator = RequiredWhenValueNullValidator{}
-)
+var _ NineTypesValidator = RequiredWhenValueNullValidator{}
 
 type RequiredWhenValueNullValidator struct {
 	expression path.Expression

--- a/apstra/apstra_validator/required_when_value_null.go
+++ b/apstra/apstra_validator/required_when_value_null.go
@@ -30,7 +30,7 @@ type RequiredWhenValueNullResponse struct {
 }
 
 func (o RequiredWhenValueNullValidator) Description(_ context.Context) string {
-	return fmt.Sprintf("Ensures that a value is supplied when attribute at %q is null", o.expression.String())
+	return fmt.Sprintf("Ensures that a value is supplied when attribute at %s is null", o.expression.String())
 }
 
 func (o RequiredWhenValueNullValidator) MarkdownDescription(ctx context.Context) string {
@@ -84,7 +84,7 @@ func (o RequiredWhenValueNullValidator) Validate(ctx context.Context, req Requir
 			resp.Diagnostics.AddAttributeError(
 				req.Path,
 				"Missing required attribute",
-				fmt.Sprintf("Attribute %q required when attribute %q is null.", req.Path, mp.String()),
+				fmt.Sprintf("Attribute %q required when attribute %q is null.", req.Path, mp),
 			)
 		}
 	}

--- a/apstra/apstra_validator/value_at_must_be.go
+++ b/apstra/apstra_validator/value_at_must_be.go
@@ -3,6 +3,7 @@ package apstravalidator
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/apstra/apstra_validator/value_at_must_be.go
+++ b/apstra/apstra_validator/value_at_must_be.go
@@ -32,7 +32,7 @@ type valueAtMustBeValidatorResponse struct {
 }
 
 func (o valueAtMustBeValidator) Description(_ context.Context) string {
-	return fmt.Sprintf("element at %q must be: %q (null is %t)", o.expression, o.value.String(), o.nullOk)
+	return fmt.Sprintf("element at %q must be: %s (null is %t)", o.expression, o.value, o.nullOk)
 }
 
 func (o valueAtMustBeValidator) MarkdownDescription(ctx context.Context) string {

--- a/apstra/apstra_validator/when_value_is.go
+++ b/apstra/apstra_validator/when_value_is.go
@@ -3,11 +3,12 @@ package apstravalidator
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"strings"
 )
 
 var _ NineTypesValidator = whenValueIsValidator{}

--- a/apstra/apstra_validator/when_value_is.go
+++ b/apstra/apstra_validator/when_value_is.go
@@ -57,7 +57,7 @@ func (o whenValueIsValidator) Description(ctx context.Context) string {
 		descriptions = append(descriptions, v.Description(ctx))
 	}
 
-	return fmt.Sprintf("element must satisfy all validations: %s becuase value is %q", strings.Join(descriptions, " + "), o.trigger)
+	return fmt.Sprintf("element must satisfy all validations: %s becuase value is %s", strings.Join(descriptions, " + "), o.trigger)
 }
 
 func (o whenValueIsValidator) MarkdownDescription(ctx context.Context) string {
@@ -78,7 +78,7 @@ func (o whenValueIsValidator) ValidateBool(ctx context.Context, req validator.Bo
 	for _, v := range o.boolValidators {
 		vResponse := new(validator.BoolResponse)
 		v.ValidateBool(ctx, req, vResponse)
-		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %q", req.Path, o.trigger), vResponse.Diagnostics...)
+		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %s", req.Path, o.trigger), vResponse.Diagnostics...)
 		resp.Diagnostics.Append(vResponse.Diagnostics...)
 	}
 }
@@ -97,7 +97,7 @@ func (o whenValueIsValidator) ValidateFloat64(ctx context.Context, req validator
 	for _, v := range o.float64Validators {
 		vResponse := new(validator.Float64Response)
 		v.ValidateFloat64(ctx, req, vResponse)
-		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %q", req.Path, o.trigger), vResponse.Diagnostics...)
+		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %s", req.Path, o.trigger), vResponse.Diagnostics...)
 		resp.Diagnostics.Append(vResponse.Diagnostics...)
 	}
 }
@@ -116,7 +116,7 @@ func (o whenValueIsValidator) ValidateInt64(ctx context.Context, req validator.I
 	for _, v := range o.int64Validators {
 		vResponse := new(validator.Int64Response)
 		v.ValidateInt64(ctx, req, vResponse)
-		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %q", req.Path, o.trigger), vResponse.Diagnostics...)
+		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %s", req.Path, o.trigger), vResponse.Diagnostics...)
 		resp.Diagnostics.Append(vResponse.Diagnostics...)
 	}
 }
@@ -135,7 +135,7 @@ func (o whenValueIsValidator) ValidateList(ctx context.Context, req validator.Li
 	for _, v := range o.listValidators {
 		vResponse := new(validator.ListResponse)
 		v.ValidateList(ctx, req, vResponse)
-		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %q", req.Path, o.trigger), vResponse.Diagnostics...)
+		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %s", req.Path, o.trigger), vResponse.Diagnostics...)
 		resp.Diagnostics.Append(vResponse.Diagnostics...)
 	}
 }
@@ -154,7 +154,7 @@ func (o whenValueIsValidator) ValidateMap(ctx context.Context, req validator.Map
 	for _, v := range o.mapValidators {
 		vResponse := new(validator.MapResponse)
 		v.ValidateMap(ctx, req, vResponse)
-		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %q", req.Path, o.trigger), vResponse.Diagnostics...)
+		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %s", req.Path, o.trigger), vResponse.Diagnostics...)
 		resp.Diagnostics.Append(vResponse.Diagnostics...)
 	}
 }
@@ -173,7 +173,7 @@ func (o whenValueIsValidator) ValidateNumber(ctx context.Context, req validator.
 	for _, v := range o.numberValidators {
 		vResponse := new(validator.NumberResponse)
 		v.ValidateNumber(ctx, req, vResponse)
-		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %q", req.Path, o.trigger), vResponse.Diagnostics...)
+		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %s", req.Path, o.trigger), vResponse.Diagnostics...)
 		resp.Diagnostics.Append(vResponse.Diagnostics...)
 	}
 }
@@ -192,7 +192,7 @@ func (o whenValueIsValidator) ValidateObject(ctx context.Context, req validator.
 	for _, v := range o.objectValidators {
 		vResponse := new(validator.ObjectResponse)
 		v.ValidateObject(ctx, req, vResponse)
-		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %q", req.Path, o.trigger), vResponse.Diagnostics...)
+		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %s", req.Path, o.trigger), vResponse.Diagnostics...)
 		resp.Diagnostics.Append(vResponse.Diagnostics...)
 	}
 }
@@ -211,7 +211,7 @@ func (o whenValueIsValidator) ValidateSet(ctx context.Context, req validator.Set
 	for _, v := range o.setValidators {
 		vResponse := new(validator.SetResponse)
 		v.ValidateSet(ctx, req, vResponse)
-		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %q", req.Path, o.trigger), vResponse.Diagnostics...)
+		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %s", req.Path, o.trigger), vResponse.Diagnostics...)
 		resp.Diagnostics.Append(vResponse.Diagnostics...)
 	}
 }
@@ -230,7 +230,7 @@ func (o whenValueIsValidator) ValidateString(ctx context.Context, req validator.
 	for _, v := range o.stringValidators {
 		vResponse := new(validator.StringResponse)
 		v.ValidateString(ctx, req, vResponse)
-		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %q", req.Path, o.trigger), vResponse.Diagnostics...)
+		utils.WrapEachDiagnostic(fmt.Sprintf("When attribute %s is %s", req.Path, o.trigger), vResponse.Diagnostics...)
 		resp.Diagnostics.Append(vResponse.Diagnostics...)
 	}
 }


### PR DESCRIPTION
For example, change this (scroll to right):

```
Attribute "leaf_switches[\"leaf\"].mlag_info" required when "leaf_switches[\"leaf\"].redundancy_protocol" has value "\"mlag\"".
```

To this:
```
Attribute "leaf_switches[\"leaf\"].mlag_info" required when "leaf_switches[\"leaf\"].redundancy_protocol" has value "mlag".
```