### PR TITLE
`apstra_freeform_resource` validator should return when values-to-be-validated are not yet known

### DIFF
--- a/apstra/resource_freeform_resource.go
+++ b/apstra/resource_freeform_resource.go
@@ -51,6 +51,15 @@ func (o *resourceFreeformResource) ValidateConfig(ctx context.Context, req resou
 		return
 	}
 
+	// cannot proceed with unknown values
+	if config.Type.IsUnknown() ||
+		config.AllocatedFrom.IsUnknown() ||
+		config.IntValue.IsUnknown() ||
+		config.Ipv4Value.IsUnknown() ||
+		config.Ipv6Value.IsUnknown() {
+		return
+	}
+
 	var resourceType enum.FFResourceType
 	err := utils.ApiStringerFromFriendlyString(&resourceType, config.Type.ValueString())
 	if err != nil {


### PR DESCRIPTION
Attributes which are `unknown` when the validator is run *must not* cause a validation failure.

The validator must exit without error rather than trying to evaluate these attributes.

The validator will be called again after the attribute values are known.

Closes #953