### PR TITLE
Bump SDK version to absorb iota -> enum conversion

### DIFF
--- a/apstra/blueprint/datacenter_external_gateway.go
+++ b/apstra/blueprint/datacenter_external_gateway.go
@@ -89,12 +89,12 @@ func (o DatacenterExternalGateway) ResourceAttributes() map[string]resourceSchem
 		},
 		"evpn_route_types": resourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf(`EVPN route types. Valid values are: ["%s"]. Default: %q`,
-				strings.Join(enum.RemoteGatewayRouteTypesEnum.Values(), `", "`),
-				enum.RemoteGatewayRouteTypesAll.Value),
+				strings.Join(enum.RemoteGatewayRouteTypes.Values(), `", "`),
+				enum.RemoteGatewayRouteTypeAll.Value),
 			Optional:   true,
 			Computed:   true,
-			Default:    stringdefault.StaticString(enum.RemoteGatewayRouteTypesAll.Value),
-			Validators: []validator.String{stringvalidator.OneOf(enum.RemoteGatewayRouteTypesEnum.Values()...)},
+			Default:    stringdefault.StaticString(enum.RemoteGatewayRouteTypeAll.Value),
+			Validators: []validator.String{stringvalidator.OneOf(enum.RemoteGatewayRouteTypes.Values()...)},
 		},
 		"local_gateway_nodes": resourceSchema.SetAttribute{
 			MarkdownDescription: "Set of IDs of switch nodes which will be configured to peer with the External Gateway",
@@ -160,8 +160,8 @@ func (o DatacenterExternalGateway) DataSourceAttributes() map[string]dataSourceS
 		},
 		"evpn_route_types": dataSourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf(`EVPN route types. Valid values are: ["%s"]. Default: %q`,
-				strings.Join(enum.RemoteGatewayRouteTypesEnum.Values(), `", "`),
-				enum.RemoteGatewayRouteTypesAll.Value),
+				strings.Join(enum.RemoteGatewayRouteTypes.Values(), `", "`),
+				enum.RemoteGatewayRouteTypeAll.Value),
 			Computed: true,
 		},
 		"local_gateway_nodes": dataSourceSchema.SetAttribute{
@@ -216,8 +216,8 @@ func (o DatacenterExternalGateway) DataSourceAttributesAsFilter() map[string]dat
 		},
 		"evpn_route_types": dataSourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf(`EVPN route types. Valid values are: ["%s"]. Default: %q`,
-				strings.Join(enum.RemoteGatewayRouteTypesEnum.Values(), `", "`),
-				enum.RemoteGatewayRouteTypesAll.Value),
+				strings.Join(enum.RemoteGatewayRouteTypes.Values(), `", "`),
+				enum.RemoteGatewayRouteTypeAll.Value),
 			Optional: true,
 		},
 		"local_gateway_nodes": dataSourceSchema.SetAttribute{
@@ -234,7 +234,7 @@ func (o DatacenterExternalGateway) DataSourceAttributesAsFilter() map[string]dat
 }
 
 func (o *DatacenterExternalGateway) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.RemoteGatewayData {
-	routeTypes := enum.RemoteGatewayRouteTypesEnum.Parse(o.EvpnRouteTypes.ValueString())
+	routeTypes := enum.RemoteGatewayRouteTypes.Parse(o.EvpnRouteTypes.ValueString())
 	// skipping nil check because input validation should make that impossible
 
 	var localGwNodes []apstra.ObjectId

--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	apiversions "github.com/Juniper/terraform-provider-apstra/apstra/api_versions"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
@@ -84,7 +85,7 @@ func (o DatacenterVirtualNetwork) DataSourceAttributes() map[string]dataSourceSc
 			Computed:            true,
 		},
 		"routing_zone_id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: fmt.Sprintf("Routing Zone ID (only applies when `type == %s`", apstra.VnTypeVxlan),
+			MarkdownDescription: fmt.Sprintf("Routing Zone ID (only applies when `type == %s`", enum.VnTypeVxlan),
 			Computed:            true,
 		},
 		"vni": dataSourceSchema.Int64Attribute{
@@ -98,7 +99,7 @@ func (o DatacenterVirtualNetwork) DataSourceAttributes() map[string]dataSourceSc
 		"reserve_vlan": dataSourceSchema.BoolAttribute{
 			MarkdownDescription: fmt.Sprintf("For use only with `%s` type Virtual networks when all `bindings` "+
 				"use the same VLAN ID. This option reserves the VLAN fabric-wide, even on switches to "+
-				"which the Virtual Network has not yet been deployed.", apstra.VnTypeVxlan),
+				"which the Virtual Network has not yet been deployed.", enum.VnTypeVxlan),
 			Computed: true,
 		},
 		"bindings": dataSourceSchema.MapNestedAttribute{
@@ -190,7 +191,7 @@ func (o DatacenterVirtualNetwork) DataSourceFilterAttributes() map[string]dataSo
 			Optional:            true,
 		},
 		"routing_zone_id": dataSourceSchema.StringAttribute{
-			MarkdownDescription: fmt.Sprintf("Routing Zone ID (required when `type == %s`)", apstra.VnTypeVxlan),
+			MarkdownDescription: fmt.Sprintf("Routing Zone ID (required when `type == %s`)", enum.VnTypeVxlan),
 			Optional:            true,
 		},
 		"vni": dataSourceSchema.Int64Attribute{
@@ -204,7 +205,7 @@ func (o DatacenterVirtualNetwork) DataSourceFilterAttributes() map[string]dataSo
 		"reserve_vlan": dataSourceSchema.BoolAttribute{
 			MarkdownDescription: fmt.Sprintf("For use only with `%s` type Virtual networks when all `bindings` "+
 				"use the same VLAN ID. This option reserves the VLAN fabric-wide, even on switches to "+
-				"which the Virtual Network has not yet been deployed.", apstra.VnTypeVxlan),
+				"which the Virtual Network has not yet been deployed.", enum.VnTypeVxlan),
 			Optional: true,
 		},
 		"bindings": dataSourceSchema.MapNestedAttribute{
@@ -308,23 +309,23 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 			MarkdownDescription: "Virtual Network Type",
 			Optional:            true,
 			Computed:            true,
-			Default:             stringdefault.StaticString(apstra.VnTypeVxlan.String()),
+			Default:             stringdefault.StaticString(enum.VnTypeVxlan.String()),
 			PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			Validators: []validator.String{
 				// specifically enumerated types - SDK supports additional
 				// types which do not make sense in this context.
-				stringvalidator.OneOf(apstra.VnTypeVlan.String(), apstra.VnTypeVxlan.String()),
+				stringvalidator.OneOf(enum.VnTypeVlan.String(), enum.VnTypeVxlan.String()),
 			},
 		},
 		"routing_zone_id": resourceSchema.StringAttribute{
-			MarkdownDescription: fmt.Sprintf("Routing Zone ID (required when `type == %s`", apstra.VnTypeVxlan),
+			MarkdownDescription: fmt.Sprintf("Routing Zone ID (required when `type == %s`", enum.VnTypeVxlan),
 			Optional:            true,
 			Computed:            true,
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
 				apstravalidator.RequiredWhenValueIs(
 					path.MatchRelative().AtParent().AtName("type"),
-					types.StringValue(apstra.VnTypeVxlan.String()),
+					types.StringValue(enum.VnTypeVxlan.String()),
 				),
 				apstravalidator.RequiredWhenValueNull(
 					path.MatchRelative().AtParent().AtName("type"),
@@ -343,7 +344,7 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 				int64validator.Between(constants.VniMin, constants.VniMax),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("type"),
-					types.StringValue(apstra.VnTypeVlan.String()),
+					types.StringValue(enum.VnTypeVlan.String()),
 				),
 			},
 		},
@@ -355,14 +356,14 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 			MarkdownDescription: fmt.Sprintf("For use only with `%s` type Virtual networks "+
 				"when all `bindings` use the same VLAN ID. This option reserves the VLAN fabric-wide, "+
 				"even on switches to which the Virtual Network has not yet been deployed. The only "+
-				"accepted values is `true`.", apstra.VnTypeVxlan.String()),
+				"accepted values is `true`.", enum.VnTypeVxlan.String()),
 			Optional: true,
 			Computed: true,
 			Validators: []validator.Bool{
 				apstravalidator.WhenValueIsBool(types.BoolValue(true),
 					apstravalidator.ValueAtMustBeBool(
 						path.MatchRelative().AtParent().AtName("type"),
-						types.StringValue(apstra.VnTypeVxlan.String()),
+						types.StringValue(enum.VnTypeVxlan.String()),
 						false,
 					),
 				),
@@ -382,7 +383,7 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 				mapvalidator.SizeAtLeast(1),
 				apstravalidator.WhenValueAtMustBeMap(
 					path.MatchRelative().AtParent().AtName("type"),
-					types.StringValue(apstra.VnTypeVlan.String()),
+					types.StringValue(enum.VnTypeVlan.String()),
 					mapvalidator.SizeAtMost(1),
 				),
 			},
@@ -541,7 +542,7 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 }
 
 func (o *DatacenterVirtualNetwork) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.VirtualNetworkData {
-	var vnType apstra.VnType
+	var vnType enum.VnType
 	err := vnType.FromString(o.Type.ValueString())
 	if err != nil {
 		diags.Append(
@@ -571,7 +572,7 @@ func (o *DatacenterVirtualNetwork) Request(ctx context.Context, diags *diag.Diag
 		vnId = &v
 	}
 
-	if o.Type.ValueString() == apstra.VnTypeVlan.String() {
+	if o.Type.ValueString() == enum.VnTypeVlan.String() {
 		// Maximum of one binding is required when type==vlan.
 		// Apstra requires vlan == vni when creating a "vlan" type VN.
 		// VNI attribute is forbidden when type == VLAN

--- a/apstra/data_source_datacenter_external_gateway_test.go
+++ b/apstra/data_source_datacenter_external_gateway_test.go
@@ -49,7 +49,7 @@ func TestDatacenterExternalGateway(t *testing.T) {
 
 	rgConfigs := []apstra.RemoteGatewayData{
 		{
-			RouteTypes:     enum.RemoteGatewayRouteTypesAll,
+			RouteTypes:     enum.RemoteGatewayRouteTypeAll,
 			LocalGwNodes:   leafIds,
 			GwAsn:          rand.Uint32(),
 			GwIp:           randIpvAddressMust(t, "10.0.0.0/8"),
@@ -60,7 +60,7 @@ func TestDatacenterExternalGateway(t *testing.T) {
 			Password:       &password,
 		},
 		{
-			RouteTypes:     enum.RemoteGatewayRouteTypesFiveOnly,
+			RouteTypes:     enum.RemoteGatewayRouteTypeFiveOnly,
 			LocalGwNodes:   leafIds,
 			GwAsn:          rand.Uint32(),
 			GwIp:           randIpvAddressMust(t, "10.0.0.0/8"),

--- a/apstra/data_source_datacenter_virtual_network_test.go
+++ b/apstra/data_source_datacenter_virtual_network_test.go
@@ -5,11 +5,13 @@ package tfapstra_test
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"testing"
 )
 
 const (
@@ -60,7 +62,7 @@ func TestDatacenterVirtualNetwork(t *testing.T) {
 				Ipv4Subnet:     randIpNetMust(t, "10.0.0.0/16"),
 				Label:          acctest.RandString(5),
 				SecurityZoneId: zoneId,
-				VnType:         apstra.VnTypeVxlan,
+				VnType:         enum.VnTypeVxlan,
 				VnBindings:     vnBindings,
 			},
 		},
@@ -70,7 +72,7 @@ func TestDatacenterVirtualNetwork(t *testing.T) {
 				Ipv4Subnet:     randIpNetMust(t, "10.1.0.0/16"),
 				Label:          acctest.RandString(5),
 				SecurityZoneId: zoneId,
-				VnType:         apstra.VnTypeVlan,
+				VnType:         enum.VnTypeVlan,
 				VnBindings:     []apstra.VnBinding{{SystemId: apstra.ObjectId(leafIdStrings[0])}},
 			},
 		},

--- a/apstra/freeform/link.go
+++ b/apstra/freeform/link.go
@@ -72,7 +72,7 @@ func (o Link) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 			MarkdownDescription: "Endpoints of the  Link, a Map keyed by System ID.",
 			Computed:            true,
 			NestedObject: dataSourceSchema.NestedAttributeObject{
-				Attributes: Endpoint{}.DatasourceAttributes(),
+				Attributes: LinkEndpoint{}.DatasourceAttributes(),
 			},
 		},
 		"tags": dataSourceSchema.SetAttribute{
@@ -115,7 +115,7 @@ func (o Link) ResourceAttributes() map[string]resourceSchema.Attribute {
 		},
 		"endpoints": resourceSchema.MapNestedAttribute{
 			NestedObject: resourceSchema.NestedAttributeObject{
-				Attributes: Endpoint{}.ResourceAttributes(),
+				Attributes: LinkEndpoint{}.ResourceAttributes(),
 			},
 			PlanModifiers:       []planmodifier.Map{mapplanmodifier.RequiresReplace()},
 			MarkdownDescription: "Endpoints of the  Link, a Map keyed by System ID.",
@@ -141,13 +141,13 @@ func (o *Link) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.Fre
 		return nil
 	}
 
-	var endpoints map[string]Endpoint
+	var endpoints map[string]LinkEndpoint
 	diags.Append(o.Endpoints.ElementsAs(ctx, &endpoints, false)...)
 	if diags.HasError() {
 		return nil
 	}
 
-	var epArray [2]apstra.FreeformEndpoint
+	var epArray [2]apstra.FreeformEthernetEndpoint
 	var i int
 	for systemId, endpoint := range endpoints {
 		epArray[i] = *endpoint.request(ctx, systemId, diags)

--- a/apstra/freeform/link_endpoint.go
+++ b/apstra/freeform/link_endpoint.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-type Endpoint struct {
+type LinkEndpoint struct {
 	InterfaceName    types.String         `tfsdk:"interface_name"`
 	InterfaceId      types.String         `tfsdk:"interface_id"`
 	TransformationId types.Int64          `tfsdk:"transformation_id"`
@@ -30,7 +30,7 @@ type Endpoint struct {
 	Tags             types.Set            `tfsdk:"tags"`
 }
 
-func (o Endpoint) attrTypes() map[string]attr.Type {
+func (o LinkEndpoint) attrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"interface_name":    types.StringType,
 		"interface_id":      types.StringType,
@@ -41,7 +41,7 @@ func (o Endpoint) attrTypes() map[string]attr.Type {
 	}
 }
 
-func (o Endpoint) DatasourceAttributes() map[string]dataSourceSchema.Attribute {
+func (o LinkEndpoint) DatasourceAttributes() map[string]dataSourceSchema.Attribute {
 	return map[string]dataSourceSchema.Attribute{
 		"interface_name": dataSourceSchema.StringAttribute{
 			Computed:            true,
@@ -73,7 +73,7 @@ func (o Endpoint) DatasourceAttributes() map[string]dataSourceSchema.Attribute {
 	}
 }
 
-func (o Endpoint) ResourceAttributes() map[string]resourceSchema.Attribute {
+func (o LinkEndpoint) ResourceAttributes() map[string]resourceSchema.Attribute {
 	return map[string]resourceSchema.Attribute{
 		"interface_name": resourceSchema.StringAttribute{
 			Optional:            true,
@@ -119,7 +119,7 @@ func (o Endpoint) ResourceAttributes() map[string]resourceSchema.Attribute {
 	}
 }
 
-func (o *Endpoint) request(ctx context.Context, systemId string, diags *diag.Diagnostics) *apstra.FreeformEndpoint {
+func (o *LinkEndpoint) request(ctx context.Context, systemId string, diags *diag.Diagnostics) *apstra.FreeformEthernetEndpoint {
 	var ipNet4, ipNet6 *net.IPNet
 	if utils.HasValue(o.Ipv4Address) {
 		var ip4 net.IP
@@ -140,7 +140,7 @@ func (o *Endpoint) request(ctx context.Context, systemId string, diags *diag.Dia
 		transformationId = utils.ToPtr(int(o.TransformationId.ValueInt64()))
 	}
 
-	return &apstra.FreeformEndpoint{
+	return &apstra.FreeformEthernetEndpoint{
 		SystemId: apstra.ObjectId(systemId),
 		Interface: apstra.FreeformInterface{
 			Data: &apstra.FreeformInterfaceData{
@@ -154,7 +154,7 @@ func (o *Endpoint) request(ctx context.Context, systemId string, diags *diag.Dia
 	}
 }
 
-func (o *Endpoint) loadApiData(ctx context.Context, in apstra.FreeformEndpoint, diags *diag.Diagnostics) {
+func (o *LinkEndpoint) loadApiData(ctx context.Context, in apstra.FreeformEthernetEndpoint, diags *diag.Diagnostics) {
 	if in.Interface.Id == nil {
 		diags.AddError(
 			fmt.Sprintf("api returned nil interface Id for system %s", in.SystemId),
@@ -182,16 +182,16 @@ func (o *Endpoint) loadApiData(ctx context.Context, in apstra.FreeformEndpoint, 
 	o.Tags = utils.SetValueOrNull(ctx, types.StringType, in.Interface.Data.Tags, diags)
 }
 
-func newFreeformEndpointMap(ctx context.Context, in [2]apstra.FreeformEndpoint, diags *diag.Diagnostics) types.Map {
-	endpoints := make(map[string]Endpoint, len(in))
+func newFreeformEndpointMap(ctx context.Context, in [2]apstra.FreeformEthernetEndpoint, diags *diag.Diagnostics) types.Map {
+	endpoints := make(map[string]LinkEndpoint, len(in))
 	for i := range in {
-		var endpoint Endpoint
+		var endpoint LinkEndpoint
 		endpoint.loadApiData(ctx, in[i], diags)
 		endpoints[in[i].SystemId.String()] = endpoint
 	}
 	if diags.HasError() {
-		return types.MapNull(types.ObjectType{AttrTypes: Endpoint{}.attrTypes()})
+		return types.MapNull(types.ObjectType{AttrTypes: LinkEndpoint{}.attrTypes()})
 	}
 
-	return utils.MapValueOrNull(ctx, types.ObjectType{AttrTypes: Endpoint{}.attrTypes()}, endpoints, diags)
+	return utils.MapValueOrNull(ctx, types.ObjectType{AttrTypes: LinkEndpoint{}.attrTypes()}, endpoints, diags)
 }

--- a/apstra/resource_datacenter_external_gateway_test.go
+++ b/apstra/resource_datacenter_external_gateway_test.go
@@ -37,7 +37,7 @@ type testCaseResourceExternalGateway struct {
 	name          string
 	ipAddress     net.IP
 	asn           uint32
-	routeTypes    enum.RemoteGatewayRouteTypes
+	routeTypes    enum.RemoteGatewayRouteType
 	nodes         string
 	ttl           *uint8
 	keepaliveTime *uint16
@@ -76,7 +76,7 @@ func TestResourceDatacenterExternalGateway(t *testing.T) {
 			name:       "name1",
 			ipAddress:  net.IP{1, 1, 1, 1},
 			asn:        1,
-			routeTypes: enum.RemoteGatewayRouteTypesAll,
+			routeTypes: enum.RemoteGatewayRouteTypeAll,
 			nodes:      leafIds[0],
 			testCheckFunc: resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
 				resource.TestCheckResourceAttrSet("apstra_datacenter_external_gateway.test", "id"),
@@ -84,7 +84,7 @@ func TestResourceDatacenterExternalGateway(t *testing.T) {
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "name", "name1"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "ip_address", "1.1.1.1"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "asn", "1"),
-				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "evpn_route_types", enum.RemoteGatewayRouteTypesAll.Value),
+				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "evpn_route_types", enum.RemoteGatewayRouteTypeAll.Value),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "local_gateway_nodes.#", "1"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "local_gateway_nodes.0", leafIds[0]),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "ttl", "30"),            // default
@@ -96,7 +96,7 @@ func TestResourceDatacenterExternalGateway(t *testing.T) {
 			name:       "name2",
 			ipAddress:  net.IP{1, 1, 1, 2},
 			asn:        2,
-			routeTypes: enum.RemoteGatewayRouteTypesFiveOnly,
+			routeTypes: enum.RemoteGatewayRouteTypeFiveOnly,
 			nodes:      strings.Join(leafIds[1:], `","`),
 			testCheckFunc: resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
 				resource.TestCheckResourceAttrSet("apstra_datacenter_external_gateway.test", "id"),
@@ -104,7 +104,7 @@ func TestResourceDatacenterExternalGateway(t *testing.T) {
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "name", "name2"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "ip_address", "1.1.1.2"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "asn", "2"),
-				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "evpn_route_types", enum.RemoteGatewayRouteTypesFiveOnly.Value),
+				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "evpn_route_types", enum.RemoteGatewayRouteTypeFiveOnly.Value),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "local_gateway_nodes.#", strconv.Itoa(len(leafIds)-1)),
 				resource.TestCheckTypeSetElemAttr("apstra_datacenter_external_gateway.test", "local_gateway_nodes.*", leafIds[1]),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "ttl", "30"),            // default
@@ -116,7 +116,7 @@ func TestResourceDatacenterExternalGateway(t *testing.T) {
 			name:          "name3",
 			ipAddress:     net.IP{1, 1, 1, 3},
 			asn:           3,
-			routeTypes:    enum.RemoteGatewayRouteTypesAll,
+			routeTypes:    enum.RemoteGatewayRouteTypeAll,
 			nodes:         leafIds[0],
 			ttl:           &uint8Val3,
 			keepaliveTime: &uint16Val1,
@@ -128,7 +128,7 @@ func TestResourceDatacenterExternalGateway(t *testing.T) {
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "name", "name3"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "ip_address", "1.1.1.3"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "asn", "3"),
-				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "evpn_route_types", enum.RemoteGatewayRouteTypesAll.Value),
+				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "evpn_route_types", enum.RemoteGatewayRouteTypeAll.Value),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "local_gateway_nodes.#", "1"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "local_gateway_nodes.0", leafIds[0]),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "ttl", "3"),
@@ -141,7 +141,7 @@ func TestResourceDatacenterExternalGateway(t *testing.T) {
 			name:       "name1",
 			ipAddress:  net.IP{1, 1, 1, 1},
 			asn:        1,
-			routeTypes: enum.RemoteGatewayRouteTypesAll,
+			routeTypes: enum.RemoteGatewayRouteTypeAll,
 			nodes:      leafIds[0],
 			testCheckFunc: resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
 				resource.TestCheckResourceAttrSet("apstra_datacenter_external_gateway.test", "id"),
@@ -149,7 +149,7 @@ func TestResourceDatacenterExternalGateway(t *testing.T) {
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "name", "name1"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "ip_address", "1.1.1.1"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "asn", "1"),
-				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "evpn_route_types", enum.RemoteGatewayRouteTypesAll.Value),
+				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "evpn_route_types", enum.RemoteGatewayRouteTypeAll.Value),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "local_gateway_nodes.#", "1"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "local_gateway_nodes.0", leafIds[0]),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "ttl", "30"),            // default
@@ -161,7 +161,7 @@ func TestResourceDatacenterExternalGateway(t *testing.T) {
 			name:       "name2",
 			ipAddress:  net.IP{1, 1, 1, 2},
 			asn:        2,
-			routeTypes: enum.RemoteGatewayRouteTypesFiveOnly,
+			routeTypes: enum.RemoteGatewayRouteTypeFiveOnly,
 			nodes:      strings.Join(leafIds[1:], `","`),
 			password:   "big secret2",
 			testCheckFunc: resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
@@ -170,7 +170,7 @@ func TestResourceDatacenterExternalGateway(t *testing.T) {
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "name", "name2"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "ip_address", "1.1.1.2"),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "asn", "2"),
-				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "evpn_route_types", enum.RemoteGatewayRouteTypesFiveOnly.Value),
+				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "evpn_route_types", enum.RemoteGatewayRouteTypeFiveOnly.Value),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "local_gateway_nodes.#", strconv.Itoa(len(leafIds)-1)),
 				resource.TestCheckTypeSetElemAttr("apstra_datacenter_external_gateway.test", "local_gateway_nodes.*", leafIds[1]),
 				resource.TestCheckResourceAttr("apstra_datacenter_external_gateway.test", "ttl", "30"),            // default

--- a/apstra/resource_datacenter_security_policy_test.go
+++ b/apstra/resource_datacenter_security_policy_test.go
@@ -152,7 +152,7 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 			Ipv4Enabled: true,
 			Label:       acctest.RandString(5),
 			VnBindings:  []apstra.VnBinding{{SystemId: apstra.ObjectId(leafIds[i])}},
-			VnType:      apstra.VnTypeVlan,
+			VnType:      enum.VnTypeVlan,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/apstra/resource_datacenter_virtual_network_test.go
+++ b/apstra/resource_datacenter_virtual_network_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
@@ -88,7 +89,7 @@ func (o resourceDatacenterVirtualNetworkTemplate) testChecks(t testing.TB, rType
 	if o.vnType != "" {
 		result.append(t, "TestCheckResourceAttr", "type", o.vnType)
 	} else {
-		result.append(t, "TestCheckResourceAttr", "type", apstra.VnTypeVxlan.String())
+		result.append(t, "TestCheckResourceAttr", "type", enum.VnTypeVxlan.String())
 	}
 
 	if o.vni != nil {
@@ -198,7 +199,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 					},
 				},
@@ -206,7 +207,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 						l3Mtu:         utils.ToPtr(8800),
 					},
@@ -215,7 +216,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 					},
 				},
@@ -228,7 +229,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 						l3Mtu:         utils.ToPtr(8800),
 					},
@@ -237,7 +238,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 					},
 				},
@@ -245,7 +246,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 						l3Mtu:         utils.ToPtr(8900),
 					},
@@ -259,7 +260,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						routingZoneId: szId,
 					},
 				},
@@ -267,7 +268,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						vni:           utils.ToPtr(rand.IntN(10000) + 5000),
 						routingZoneId: szId,
 						l3Mtu:         utils.ToPtr(8800),
@@ -277,7 +278,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						routingZoneId: szId,
 					},
 				},
@@ -290,7 +291,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						vni:           utils.ToPtr(rand.IntN(10000) + 5000),
 						routingZoneId: szId,
 						l3Mtu:         utils.ToPtr(8800),
@@ -300,7 +301,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						routingZoneId: szId,
 					},
 				},
@@ -308,7 +309,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						vni:           utils.ToPtr(rand.IntN(10000) + 5000),
 						routingZoneId: szId,
 						l3Mtu:         utils.ToPtr(8900),
@@ -322,7 +323,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 						bindings: []resourceDatacenterVirtualNetworkTemplateBinding{
 							{
@@ -335,7 +336,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 						l3Mtu:         utils.ToPtr(8900),
 						bindings: []resourceDatacenterVirtualNetworkTemplateBinding{
@@ -351,7 +352,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 						bindings: []resourceDatacenterVirtualNetworkTemplateBinding{
 							{
@@ -368,7 +369,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 						l3Mtu:         utils.ToPtr(8800),
 						bindings: []resourceDatacenterVirtualNetworkTemplateBinding{
@@ -384,7 +385,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 						bindings: []resourceDatacenterVirtualNetworkTemplateBinding{
 							{
@@ -397,7 +398,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVlan.String(),
+						vnType:        enum.VnTypeVlan.String(),
 						routingZoneId: szId,
 						l3Mtu:         utils.ToPtr(8900),
 						bindings: []resourceDatacenterVirtualNetworkTemplateBinding{
@@ -417,7 +418,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						routingZoneId: szId,
 						bindings: []resourceDatacenterVirtualNetworkTemplateBinding{
 							{
@@ -430,7 +431,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						vni:           nil,
 						routingZoneId: szId,
 						l3Mtu:         nil,
@@ -457,7 +458,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						routingZoneId: szId,
 						bindings: []resourceDatacenterVirtualNetworkTemplateBinding{
 							{
@@ -474,7 +475,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						vni:           nil,
 						routingZoneId: szId,
 						l3Mtu:         nil,
@@ -501,7 +502,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						routingZoneId: szId,
 						bindings: []resourceDatacenterVirtualNetworkTemplateBinding{
 							{
@@ -514,7 +515,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 					config: resourceDatacenterVirtualNetworkTemplate{
 						blueprintId:   bp.Id(),
 						name:          acctest.RandString(6),
-						vnType:        apstra.VnTypeVxlan.String(),
+						vnType:        enum.VnTypeVxlan.String(),
 						vni:           nil,
 						routingZoneId: szId,
 						l3Mtu:         nil,
@@ -589,7 +590,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 		{
 			name:          acctest.RandString(10),
 			blueprintId:   bp.Id().String(),
-			vnType:        apstra.VnTypeVlan.String(),
+			vnType:        enum.VnTypeVlan.String(),
 			vni:           "null",
 			routingZoneId: szId.String(),
 			bindings: []bindingParams{
@@ -602,7 +603,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 		{
 			name:          acctest.RandString(10),
 			blueprintId:   bp.Id().String(),
-			vnType:        apstra.VnTypeVlan.String(),
+			vnType:        enum.VnTypeVlan.String(),
 			vni:           "null",
 			routingZoneId: szId.String(),
 			bindings: []bindingParams{
@@ -615,7 +616,7 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 		{
 			name:          acctest.RandString(10),
 			blueprintId:   bp.Id().String(),
-			vnType:        apstra.VnTypeVxlan.String(),
+			vnType:        enum.VnTypeVxlan.String(),
 			vni:           "null",
 			routingZoneId: szId.String(),
 			bindings: []bindingParams{

--- a/apstra/resource_datacenter_virtual_network_test.go
+++ b/apstra/resource_datacenter_virtual_network_test.go
@@ -146,8 +146,6 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 	client := testutils.GetTestClient(t, ctx)
 	apiVersion := version.Must(version.NewVersion(client.ApiVersion()))
 
-	// bp, err := client.NewTwoStageL3ClosClient(ctx, "ab4468ce-c007-441c-876c-5cec6566496b")
-	// szId := apstra.ObjectId("H0NOxllV2AQ2qRroxA")
 	// Create blueprint and routing zone
 	bp := testutils.BlueprintC(t, ctx)
 	szId := testutils.SecurityZoneA(t, ctx, bp, true)

--- a/apstra/resource_freeform_link_integration_test.go
+++ b/apstra/resource_freeform_link_integration_test.go
@@ -49,7 +49,7 @@ resource %q %q {
 type resourceFreeformLink struct {
 	blueprintId string
 	name        string
-	endpoints   []apstra.FreeformEndpoint
+	endpoints   []apstra.FreeformEthernetEndpoint
 	tags        []string
 }
 
@@ -207,7 +207,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -240,7 +240,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -272,7 +272,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -309,7 +309,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -341,7 +341,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -374,7 +374,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -411,7 +411,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -444,7 +444,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -476,7 +476,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -514,7 +514,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -546,7 +546,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -579,7 +579,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -615,7 +615,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -639,7 +639,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -669,7 +669,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -704,7 +704,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -734,7 +734,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -765,7 +765,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -799,7 +799,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: extSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -820,7 +820,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: intSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -848,7 +848,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: extSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -873,7 +873,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: extSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -901,7 +901,7 @@ func TestResourceFreeformLink(t *testing.T) {
 					config: resourceFreeformLink{
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: extSysIds[0],
 								Interface: apstra.FreeformInterface{
@@ -922,7 +922,7 @@ func TestResourceFreeformLink(t *testing.T) {
 						blueprintId: bp.Id().String(),
 						name:        acctest.RandString(6),
 						tags:        randomStrings(rand.Intn(10)+2, 6),
-						endpoints: []apstra.FreeformEndpoint{
+						endpoints: []apstra.FreeformEthernetEndpoint{
 							{
 								SystemId: extSysIds[0],
 								Interface: apstra.FreeformInterface{

--- a/apstra/test_utils/virtual_network.go
+++ b/apstra/test_utils/virtual_network.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +23,7 @@ func VirtualNetworkVxlan(t testing.TB, ctx context.Context, client *apstra.TwoSt
 		Label:          acctest.RandString(6),
 		SecurityZoneId: SecurityZoneA(t, ctx, client, cleanup),
 		VnBindings:     vnBindings,
-		VnType:         apstra.VnTypeVxlan,
+		VnType:         enum.VnTypeVxlan,
 	})
 	require.NoError(t, err)
 	if cleanup {

--- a/apstra/validator/exactly_one_binding_when_vn_type_vlan.go
+++ b/apstra/validator/exactly_one_binding_when_vn_type_vlan.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -15,7 +15,7 @@ var _ validator.Map = ExactlyOneBindingWhenVnTypeVlanValidator{}
 type ExactlyOneBindingWhenVnTypeVlanValidator struct{}
 
 func (o ExactlyOneBindingWhenVnTypeVlanValidator) Description(_ context.Context) string {
-	return fmt.Sprintf("Ensure that when the VN type is %q, only a single binding is configured", apstra.VnTypeVlan)
+	return fmt.Sprintf("Ensure that when the VN type is %q, only a single binding is configured", enum.VnTypeVlan)
 }
 
 func (o ExactlyOneBindingWhenVnTypeVlanValidator) MarkdownDescription(ctx context.Context) string {
@@ -32,7 +32,7 @@ func (o ExactlyOneBindingWhenVnTypeVlanValidator) ValidateMap(ctx context.Contex
 	var typeVal types.String
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, typePath, &typeVal)...)
 
-	isVlanType := typeVal.ValueString() == apstra.VnTypeVlan.String()
+	isVlanType := typeVal.ValueString() == enum.VnTypeVlan.String()
 	hasMultipleBindings := len(req.ConfigValue.Elements()) > 1
 
 	if isVlanType && hasMultipleBindings {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.22.5
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20241024162142-cce7d14547b2
+	github.com/Juniper/apstra-go-sdk v0.0.0-20241024184224-35a52b7c16d8
 	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
 	github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820
 	github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.22.5
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20241025013724-c6a81f8b2048
+	github.com/Juniper/apstra-go-sdk v0.0.0-20241030173401-010ff47cbc51
 	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
 	github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820
 	github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.22.5
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20241024184224-35a52b7c16d8
+	github.com/Juniper/apstra-go-sdk v0.0.0-20241025013724-c6a81f8b2048
 	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
 	github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820
 	github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.22.5
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20241017000354-6a9a100626cc
+	github.com/Juniper/apstra-go-sdk v0.0.0-20241024162142-cce7d14547b2
 	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
 	github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20241024162142-cce7d14547b2 h1:kHvr6yOFXv3a8IT2i8Ui6J5hDFcj3qUzEhhMqOc2QWo=
-github.com/Juniper/apstra-go-sdk v0.0.0-20241024162142-cce7d14547b2/go.mod h1:j0XhEo0IoltyST4cqdLwrDUNLDHC7JWJxBPDVffeSCg=
+github.com/Juniper/apstra-go-sdk v0.0.0-20241024184224-35a52b7c16d8 h1:XfYDvU66nfDqrUu2OmuQLoF3hu+LtOiwArzsTO6WyUY=
+github.com/Juniper/apstra-go-sdk v0.0.0-20241024184224-35a52b7c16d8/go.mod h1:j0XhEo0IoltyST4cqdLwrDUNLDHC7JWJxBPDVffeSCg=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20241025013724-c6a81f8b2048 h1:PKz4txg1f3UK43H3iOere64WlMbl7xTjd9YxGnocteU=
-github.com/Juniper/apstra-go-sdk v0.0.0-20241025013724-c6a81f8b2048/go.mod h1:j0XhEo0IoltyST4cqdLwrDUNLDHC7JWJxBPDVffeSCg=
+github.com/Juniper/apstra-go-sdk v0.0.0-20241030173401-010ff47cbc51 h1:w1fSQV1ad+I1oLCzpb7/PT8qH7To2MgRyAO7EtSWZ9A=
+github.com/Juniper/apstra-go-sdk v0.0.0-20241030173401-010ff47cbc51/go.mod h1:j0XhEo0IoltyST4cqdLwrDUNLDHC7JWJxBPDVffeSCg=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20241017000354-6a9a100626cc h1:qOsOL6JdVA8C1Y9xso8U2bbuzYdo2jXp0u8AHdiEcok=
-github.com/Juniper/apstra-go-sdk v0.0.0-20241017000354-6a9a100626cc/go.mod h1:qXNVTdnVa40aMTOsBTnKoFNYT5ftga2NAkGJhx4o6bY=
+github.com/Juniper/apstra-go-sdk v0.0.0-20241024162142-cce7d14547b2 h1:kHvr6yOFXv3a8IT2i8Ui6J5hDFcj3qUzEhhMqOc2QWo=
+github.com/Juniper/apstra-go-sdk v0.0.0-20241024162142-cce7d14547b2/go.mod h1:j0XhEo0IoltyST4cqdLwrDUNLDHC7JWJxBPDVffeSCg=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20241024184224-35a52b7c16d8 h1:XfYDvU66nfDqrUu2OmuQLoF3hu+LtOiwArzsTO6WyUY=
-github.com/Juniper/apstra-go-sdk v0.0.0-20241024184224-35a52b7c16d8/go.mod h1:j0XhEo0IoltyST4cqdLwrDUNLDHC7JWJxBPDVffeSCg=
+github.com/Juniper/apstra-go-sdk v0.0.0-20241025013724-c6a81f8b2048 h1:PKz4txg1f3UK43H3iOere64WlMbl7xTjd9YxGnocteU=
+github.com/Juniper/apstra-go-sdk v0.0.0-20241025013724-c6a81f8b2048/go.mod h1:j0XhEo0IoltyST4cqdLwrDUNLDHC7JWJxBPDVffeSCg=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
Bump SDK version to absorb iota -> enum conversions related to the virtual network structs and methods.