### PR TITLE
Fix validation of `Unknown` bindings in virtual network resource

### DIFF
--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -922,6 +922,10 @@ func (o DatacenterVirtualNetwork) ValidateConfigBindingsReservation(ctx context.
 func (o DatacenterVirtualNetwork) VersionConstraints() compatibility.ConfigConstraints {
 	var response compatibility.ConfigConstraints
 
+	if o.Bindings.IsUnknown() {
+		return response // cannot validate with unknown bindings
+	}
+
 	if len(o.Bindings.Elements()) == 0 {
 		response.AddAttributeConstraints(
 			compatibility.AttributeConstraint{


### PR DESCRIPTION
v0.74.0 introduced the ability to specify empty VN bindings, along with validation which ensured the empty bindings are used only with Apstra 5.0.0 and later.

This validation incorrectly attempts to count bindings which are not yet known.

Closes #961