### PR TITLE
Data source `apstra_blueprint_device_rendered_config` no error on incremental config 404

### DIFF
--- a/apstra/data_source_blueprint_device_rendered_config.go
+++ b/apstra/data_source_blueprint_device_rendered_config.go
@@ -8,9 +8,9 @@ import (
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
+	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var (
@@ -46,77 +46,66 @@ func (o *dataSourceBlueprintNodeConfig) Read(ctx context.Context, req datasource
 		return
 	}
 
-	addNodeDiag := func(err error) {
-		var ace apstra.ClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
-			resp.Diagnostics.AddError(
-				"Not Found",
-				fmt.Sprintf("Node %s in blueprint %s not found", config.NodeId, config.BlueprintId),
-			)
-		} else {
-			resp.Diagnostics.AddError("Failed to fetch config", err.Error())
-		}
-	}
-
-	addSysDiag := func(err error) {
-		var ace apstra.ClientErr
-		if errors.As(err, &ace) && ace.Type() == apstra.ErrNotfound {
-			resp.Diagnostics.AddError(
-				"Not Found",
-				fmt.Sprintf("System %s in blueprint %s not found", config.SystemId, config.BlueprintId),
-			)
-		} else {
-			resp.Diagnostics.AddError("Failed to fetch config", err.Error())
-		}
-	}
-
 	bpId := apstra.ObjectId(config.BlueprintId.ValueString())
 
 	var err error
 	var deployed, staged, incremental string
+	var ace apstra.ClientErr
 
 	switch {
 	case !config.NodeId.IsNull():
 		node := apstra.ObjectId(config.NodeId.ValueString())
 		deployed, err = o.client.GetNodeRenderedConfig(ctx, bpId, node, enum.RenderedConfigTypeDeployed)
 		if err != nil {
-			addNodeDiag(err)
-			return
+			if !errors.As(err, &ace) || ace.Type() != apstra.ErrNotfound {
+				resp.Diagnostics.AddError(fmt.Sprintf("failed to fetch deployed configuration for node %s", config.NodeId), err.Error())
+				return
+			}
 		}
 		staged, err = o.client.GetNodeRenderedConfig(ctx, bpId, node, enum.RenderedConfigTypeStaging)
 		if err != nil {
-			addNodeDiag(err)
-			return
+			if !errors.As(err, &ace) || ace.Type() != apstra.ErrNotfound {
+				resp.Diagnostics.AddError(fmt.Sprintf("failed to fetch staged configuration for node %s", config.NodeId), err.Error())
+				return
+			}
 		}
 		diff, err := o.client.GetNodeRenderedConfigDiff(ctx, bpId, node)
 		if err != nil {
-			addNodeDiag(err)
-			return
+			if !errors.As(err, &ace) || ace.Type() != apstra.ErrNotfound {
+				resp.Diagnostics.AddError(fmt.Sprintf("failed to fetch incremental configuration for node %s", config.NodeId), err.Error())
+				return
+			}
 		}
 		incremental = diff.Config
 	case !config.SystemId.IsNull():
 		system := apstra.ObjectId(config.SystemId.ValueString())
 		deployed, err = o.client.GetSystemRenderedConfig(ctx, bpId, system, enum.RenderedConfigTypeDeployed)
 		if err != nil {
-			addSysDiag(err)
-			return
+			if !errors.As(err, &ace) || ace.Type() != apstra.ErrNotfound {
+				resp.Diagnostics.AddError(fmt.Sprintf("failed to fetch deployed configuration for system %s", config.SystemId), err.Error())
+				return
+			}
 		}
 		staged, err = o.client.GetSystemRenderedConfig(ctx, bpId, system, enum.RenderedConfigTypeStaging)
 		if err != nil {
-			addSysDiag(err)
-			return
+			if !errors.As(err, &ace) || ace.Type() != apstra.ErrNotfound {
+				resp.Diagnostics.AddError(fmt.Sprintf("failed to fetch staged configuration for system %s", config.SystemId), err.Error())
+				return
+			}
 		}
 		diff, err := o.client.GetSystemRenderedConfigDiff(ctx, bpId, system)
 		if err != nil {
-			addSysDiag(err)
-			return
+			if !errors.As(err, &ace) || ace.Type() != apstra.ErrNotfound {
+				resp.Diagnostics.AddError(fmt.Sprintf("failed to fetch incremental configuration for system %s", config.SystemId), err.Error())
+				return
+			}
 		}
 		incremental = diff.Config
 	}
 
-	config.DeployedCfg = types.StringValue(deployed)
-	config.StagedCfg = types.StringValue(staged)
-	config.Incremental = types.StringValue(incremental)
+	config.DeployedCfg = utils.StringValueOrNull(ctx, deployed, &resp.Diagnostics)
+	config.StagedCfg = utils.StringValueOrNull(ctx, staged, &resp.Diagnostics)
+	config.Incremental = utils.StringValueOrNull(ctx, incremental, &resp.Diagnostics)
 
 	// set state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)


### PR DESCRIPTION
The API endpoints used by `apstra_blueprint_device_rendered_config` return 404 when the node or system in question appears only in the staging config.

Requesting an incremental config between "staged" (with device assigned) and "deployed" (no device assigned) does not work.

Rather than surfacing an error early in the deployment lifecycle, this PR changes the behavior so that we return `Null` for these values.

Also, cleaned up some problematic test `sync.WaitGroup` code which has been causing intermittent test failures. Much simpler now.

Closes #962