### PR TITLE
Remove `*apstra.Client` from `dataSourceDatacenterCtIpLink{}`

### DIFF
--- a/apstra/data_source_datacenter_ct_ip_link.go
+++ b/apstra/data_source_datacenter_ct_ip_link.go
@@ -3,18 +3,13 @@ package tfapstra
 import (
 	"context"
 
-	"github.com/Juniper/apstra-go-sdk/apstra"
 	connectivitytemplate "github.com/Juniper/terraform-provider-apstra/apstra/connectivity_template"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ datasourceWithSetClient = &dataSourceDatacenterCtIpLink{}
-
-type dataSourceDatacenterCtIpLink struct {
-	client *apstra.Client
-}
+type dataSourceDatacenterCtIpLink struct{}
 
 func (o *dataSourceDatacenterCtIpLink) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_datacenter_ct_ip_link"
@@ -54,8 +49,4 @@ func (o *dataSourceDatacenterCtIpLink) Read(ctx context.Context, req datasource.
 
 	// set state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
-}
-
-func (o *dataSourceDatacenterCtIpLink) setClient(client *apstra.Client) {
-	o.client = client
 }


### PR DESCRIPTION
The `*apstra.Client` struct element isn't needed.

Closes #983