### PR TITLE
Bugfix: `vn_single` primitives do not handle sub policies correctly.

### DIFF
--- a/apstra/blueprint/connectivity_templates/primitives/virtual_network_single.go
+++ b/apstra/blueprint/connectivity_templates/primitives/virtual_network_single.go
@@ -104,6 +104,9 @@ func (o VirtualNetworkSingle) primitive(ctx context.Context, diags *diag.Diagnos
 		result.BatchId = (*apstra.ObjectId)(o.BatchId.ValueStringPointer()) // nil when null
 	}
 
+	result.Subpolicies = append(result.Subpolicies, BgpPeeringGenericSystemSubpolicies(ctx, o.BgpPeeringGenericSystems, diags)...)
+	result.Subpolicies = append(result.Subpolicies, StaticRouteSubpolicies(ctx, o.StaticRoutes, diags)...)
+
 	return &result
 }
 


### PR DESCRIPTION
Each primitive type's `primitive()` method is responsible for returning an `*apstra.ConnectivityTemplatePrimitive` describing itself... including any nested primitives.

See the correct behavior of the `IpLink` primitive [here](https://github.com/Juniper/terraform-provider-apstra/blob/d5222bb58e86727c32a8aefa1b222d09f815feae/apstra/blueprint/connectivity_templates/primitives/ip_link.go#L208C1-L213C1), and `DynamicBgpPeering` primitive [here](https://github.com/Juniper/terraform-provider-apstra/blob/d5222bb58e86727c32a8aefa1b222d09f815feae/apstra/blueprint/connectivity_templates/primitives/dynamic_bgp_peering.go#L221).

The `VirtualNetworkSingle` primitive mistakenly omits inclusion of the subpolicies.

Closes #1015 