### PR TITLE
Update CT primitive `batch_id` plan modifiers

### DIFF
--- a/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
+++ b/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
@@ -353,7 +353,7 @@ var _ planmodifier.String = (*bgpPeeringGenericSystemBatchIdPlanModifier)(nil)
 type bgpPeeringGenericSystemBatchIdPlanModifier struct{}
 
 func (o bgpPeeringGenericSystemBatchIdPlanModifier) Description(_ context.Context) string {
-	return "preserves the the state value unless all child primitives have been removed, in which case null is planned"
+	return "preserves the the state value unless we're transitioning between zero and non-zero child primitives, in which case null or unknown is planned"
 }
 
 func (o bgpPeeringGenericSystemBatchIdPlanModifier) MarkdownDescription(ctx context.Context) string {
@@ -363,7 +363,7 @@ func (o bgpPeeringGenericSystemBatchIdPlanModifier) MarkdownDescription(ctx cont
 func (o bgpPeeringGenericSystemBatchIdPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	var plan, state BgpPeeringGenericSystem
 
-	// unpacking the parent object's plan should always work
+	// unpacking the parent object's planed value should always work
 	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.ParentPath(), &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -373,13 +373,17 @@ func (o bgpPeeringGenericSystemBatchIdPlanModifier) PlanModifyString(ctx context
 	d := req.State.GetAttribute(ctx, req.Path.ParentPath(), &state)
 	stateDoesNotExist := d.HasError()
 
+	planHasChildren := len(plan.RoutingPolicies.Elements()) > 0
+
 	// are we a new object?
 	if stateDoesNotExist {
-		resp.PlanValue = types.StringUnknown() // we are a new object. the batch id is not knowable
+		if planHasChildren {
+			resp.PlanValue = types.StringUnknown()
+		} else {
+			resp.PlanValue = types.StringNull()
+		}
 		return
 	}
-
-	planHasChildren := len(plan.RoutingPolicies.Elements()) > 0
 
 	stateHasChildren := len(state.RoutingPolicies.Elements()) > 0
 

--- a/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
+++ b/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
@@ -363,7 +363,7 @@ func (o bgpPeeringGenericSystemBatchIdPlanModifier) MarkdownDescription(ctx cont
 func (o bgpPeeringGenericSystemBatchIdPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	var plan, state BgpPeeringGenericSystem
 
-	// unpacking the parent object's planed value should always work
+	// unpacking the parent object's planned value should always work
 	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.ParentPath(), &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -390,6 +390,7 @@ func (o bgpPeeringGenericSystemBatchIdPlanModifier) PlanModifyString(ctx context
 	if planHasChildren == stateHasChildren {
 		// state and plan agree about whether a batch ID is required. Reuse the old value.
 		resp.PlanValue = req.StateValue
+		return
 	}
 
 	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.

--- a/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
+++ b/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
@@ -373,18 +373,25 @@ func (o bgpPeeringGenericSystemBatchIdPlanModifier) PlanModifyString(ctx context
 	d := req.State.GetAttribute(ctx, req.Path.ParentPath(), &state)
 	stateDoesNotExist := d.HasError()
 
-	// do we have zero children?
-	if len(plan.RoutingPolicies.Elements()) == 0 {
-		resp.PlanValue = types.StringNull() // with no children the batch id should be null
-		return
-	}
-
 	// are we a new object?
 	if stateDoesNotExist {
 		resp.PlanValue = types.StringUnknown() // we are a new object. the batch id is not knowable
 		return
 	}
 
-	// we're not new, and we have children. use the old value
-	resp.PlanValue = req.StateValue
+	planHasChildren := len(plan.RoutingPolicies.Elements()) > 0
+
+	stateHasChildren := len(state.RoutingPolicies.Elements()) > 0
+
+	if planHasChildren == stateHasChildren {
+		// state and plan agree about whether a batch ID is required. Reuse the old value.
+		resp.PlanValue = req.StateValue
+	}
+
+	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.
+	if planHasChildren {
+		resp.PlanValue = types.StringUnknown()
+	} else {
+		resp.PlanValue = types.StringNull()
+	}
 }

--- a/apstra/blueprint/connectivity_templates/primitives/bgp_peering_ip_endpoint.go
+++ b/apstra/blueprint/connectivity_templates/primitives/bgp_peering_ip_endpoint.go
@@ -328,7 +328,7 @@ func (o bgpPeeringIpEndpointBatchIdPlanModifier) MarkdownDescription(ctx context
 func (o bgpPeeringIpEndpointBatchIdPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	var plan, state BgpPeeringIpEndpoint
 
-	// unpacking the parent object's planed value should always work
+	// unpacking the parent object's planned value should always work
 	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.ParentPath(), &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -355,6 +355,7 @@ func (o bgpPeeringIpEndpointBatchIdPlanModifier) PlanModifyString(ctx context.Co
 	if planHasChildren == stateHasChildren {
 		// state and plan agree about whether a batch ID is required. Reuse the old value.
 		resp.PlanValue = req.StateValue
+		return
 	}
 
 	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.

--- a/apstra/blueprint/connectivity_templates/primitives/dynamic_bgp_peering.go
+++ b/apstra/blueprint/connectivity_templates/primitives/dynamic_bgp_peering.go
@@ -339,7 +339,7 @@ func (o dynamicBgpPeeringBatchIdPlanModifier) MarkdownDescription(ctx context.Co
 func (o dynamicBgpPeeringBatchIdPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	var plan, state DynamicBgpPeering
 
-	// unpacking the parent object's planed value should always work
+	// unpacking the parent object's planned value should always work
 	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.ParentPath(), &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -366,6 +366,7 @@ func (o dynamicBgpPeeringBatchIdPlanModifier) PlanModifyString(ctx context.Conte
 	if planHasChildren == stateHasChildren {
 		// state and plan agree about whether a batch ID is required. Reuse the old value.
 		resp.PlanValue = req.StateValue
+		return
 	}
 
 	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.

--- a/apstra/blueprint/connectivity_templates/primitives/dynamic_bgp_peering.go
+++ b/apstra/blueprint/connectivity_templates/primitives/dynamic_bgp_peering.go
@@ -349,18 +349,25 @@ func (o dynamicBgpPeeringBatchIdPlanModifier) PlanModifyString(ctx context.Conte
 	d := req.State.GetAttribute(ctx, req.Path.ParentPath(), &state)
 	stateDoesNotExist := d.HasError()
 
-	// do we have zero children?
-	if len(plan.RoutingPolicies.Elements()) == 0 {
-		resp.PlanValue = types.StringNull() // with no children the batch id should be null
-		return
-	}
-
 	// are we a new object?
 	if stateDoesNotExist {
 		resp.PlanValue = types.StringUnknown() // we are a new object. the batch id is not knowable
 		return
 	}
 
-	// we're not new, and we have children. use the old value
-	resp.PlanValue = req.StateValue
+	planHasChildren := len(plan.RoutingPolicies.Elements()) > 0
+
+	stateHasChildren := len(state.RoutingPolicies.Elements()) > 0
+
+	if planHasChildren == stateHasChildren {
+		// state and plan agree about whether a batch ID is required. Reuse the old value.
+		resp.PlanValue = req.StateValue
+	}
+
+	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.
+	if planHasChildren {
+		resp.PlanValue = types.StringUnknown()
+	} else {
+		resp.PlanValue = types.StringNull()
+	}
 }

--- a/apstra/blueprint/connectivity_templates/primitives/ip_link.go
+++ b/apstra/blueprint/connectivity_templates/primitives/ip_link.go
@@ -337,7 +337,7 @@ func (o ipLinkBatchIdPlanModifier) MarkdownDescription(ctx context.Context) stri
 func (o ipLinkBatchIdPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	var plan, state IpLink
 
-	// unpacking the parent object's planed value should always work
+	// unpacking the parent object's planned value should always work
 	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.ParentPath(), &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -370,6 +370,7 @@ func (o ipLinkBatchIdPlanModifier) PlanModifyString(ctx context.Context, req pla
 	if planHasChildren == stateHasChildren {
 		// state and plan agree about whether a batch ID is required. Reuse the old value.
 		resp.PlanValue = req.StateValue
+		return
 	}
 
 	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.

--- a/apstra/blueprint/connectivity_templates/primitives/virtual_network_single.go
+++ b/apstra/blueprint/connectivity_templates/primitives/virtual_network_single.go
@@ -213,7 +213,7 @@ func (o virtualNetworkSingleBatchIdPlanModifier) MarkdownDescription(ctx context
 func (o virtualNetworkSingleBatchIdPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	var plan, state VirtualNetworkSingle
 
-	// unpacking the parent object's planed value should always work
+	// unpacking the parent object's planned value should always work
 	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path.ParentPath(), &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -242,6 +242,7 @@ func (o virtualNetworkSingleBatchIdPlanModifier) PlanModifyString(ctx context.Co
 	if planHasChildren == stateHasChildren {
 		// state and plan agree about whether a batch ID is required. Reuse the old value.
 		resp.PlanValue = req.StateValue
+		return
 	}
 
 	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.

--- a/apstra/blueprint/connectivity_templates/primitives/virtual_network_single.go
+++ b/apstra/blueprint/connectivity_templates/primitives/virtual_network_single.go
@@ -223,19 +223,27 @@ func (o virtualNetworkSingleBatchIdPlanModifier) PlanModifyString(ctx context.Co
 	d := req.State.GetAttribute(ctx, req.Path.ParentPath(), &state)
 	stateDoesNotExist := d.HasError()
 
-	// do we have zero children?
-	if len(plan.BgpPeeringGenericSystems.Elements())+
-		len(plan.StaticRoutes.Elements()) == 0 {
-		resp.PlanValue = types.StringNull() // with no children the batch id should be null
-		return
-	}
-
 	// are we a new object?
 	if stateDoesNotExist {
 		resp.PlanValue = types.StringUnknown() // we are a new object. the batch id is not knowable
 		return
 	}
 
-	// we're not new, and we have children. use the old value
-	resp.PlanValue = req.StateValue
+	planHasChildren := len(plan.BgpPeeringGenericSystems.Elements())+
+		len(plan.StaticRoutes.Elements()) > 0
+
+	stateHasChildren := len(state.BgpPeeringGenericSystems.Elements())+
+		len(state.StaticRoutes.Elements()) > 0
+
+	if planHasChildren == stateHasChildren {
+		// state and plan agree about whether a batch ID is required. Reuse the old value.
+		resp.PlanValue = req.StateValue
+	}
+
+	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.
+	if planHasChildren {
+		resp.PlanValue = types.StringUnknown()
+	} else {
+		resp.PlanValue = types.StringNull()
+	}
 }


### PR DESCRIPTION
The `batch_id` attribute represents the ID of the "batch" policy object associated with a Connectivity Template primitive.

Primitives which have children keep their child IDs in the "batch" policy object.

Primitives which do not have children do not have a "batch" policy object.

So, the state (null or not) of `batch_id` of a given primitive depends on whether that primitive has any child primitives.

Each primitive has a plan modifier which detected deletion of the last child, and set the `batch_id` from some value to `null`.

The original description is accurate: "preserves the the state value unless all child primitives have been removed, in which case null is planned"

The problem is we're only detecting the transition from value -> null. We don't detect the other side of it: Creation of the first child, in which case the `batch_id` needs to be updated from `null` to some known value.

This PR modifies the string plan modification logic of each child-capable primitive to ensure they handle switching between `known` and `null` and back again.

- `IpLink`
- `BgpPeeringGenericSystem`
- `BgpPeeringIpEndpoint`
- `DynamicBgpPeering`
- `VirtualNetworkSingle`