### PR TITLE
Update CT resource `batch_id` plan modifiers to handle `unknown` children

### DIFF
--- a/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
+++ b/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
@@ -375,9 +375,11 @@ func (o bgpPeeringGenericSystemBatchIdPlanModifier) PlanModifyString(ctx context
 
 	planHasChildren := len(plan.RoutingPolicies.Elements()) > 0
 
+	planChildrenUnknown := plan.RoutingPolicies.IsUnknown()
+
 	// are we a new object?
 	if stateDoesNotExist {
-		if planHasChildren {
+		if planHasChildren || planChildrenUnknown {
 			resp.PlanValue = types.StringUnknown()
 		} else {
 			resp.PlanValue = types.StringNull()
@@ -387,14 +389,14 @@ func (o bgpPeeringGenericSystemBatchIdPlanModifier) PlanModifyString(ctx context
 
 	stateHasChildren := len(state.RoutingPolicies.Elements()) > 0
 
-	if planHasChildren == stateHasChildren {
+	if (planHasChildren || planChildrenUnknown) == stateHasChildren {
 		// state and plan agree about whether a batch ID is required. Reuse the old value.
 		resp.PlanValue = req.StateValue
 		return
 	}
 
 	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.
-	if planHasChildren {
+	if planHasChildren || planChildrenUnknown {
 		resp.PlanValue = types.StringUnknown()
 	} else {
 		resp.PlanValue = types.StringNull()

--- a/apstra/blueprint/connectivity_templates/primitives/bgp_peering_ip_endpoint.go
+++ b/apstra/blueprint/connectivity_templates/primitives/bgp_peering_ip_endpoint.go
@@ -340,9 +340,11 @@ func (o bgpPeeringIpEndpointBatchIdPlanModifier) PlanModifyString(ctx context.Co
 
 	planHasChildren := len(plan.RoutingPolicies.Elements()) > 0
 
+	planChildrenUnknown := plan.RoutingPolicies.IsUnknown()
+
 	// are we a new object?
 	if stateDoesNotExist {
-		if planHasChildren {
+		if planHasChildren || planChildrenUnknown {
 			resp.PlanValue = types.StringUnknown()
 		} else {
 			resp.PlanValue = types.StringNull()
@@ -352,14 +354,14 @@ func (o bgpPeeringIpEndpointBatchIdPlanModifier) PlanModifyString(ctx context.Co
 
 	stateHasChildren := len(state.RoutingPolicies.Elements()) > 0
 
-	if planHasChildren == stateHasChildren {
+	if (planHasChildren || planChildrenUnknown) == stateHasChildren {
 		// state and plan agree about whether a batch ID is required. Reuse the old value.
 		resp.PlanValue = req.StateValue
 		return
 	}
 
 	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.
-	if planHasChildren {
+	if planHasChildren || planChildrenUnknown {
 		resp.PlanValue = types.StringUnknown()
 	} else {
 		resp.PlanValue = types.StringNull()

--- a/apstra/blueprint/connectivity_templates/primitives/dynamic_bgp_peering.go
+++ b/apstra/blueprint/connectivity_templates/primitives/dynamic_bgp_peering.go
@@ -351,9 +351,11 @@ func (o dynamicBgpPeeringBatchIdPlanModifier) PlanModifyString(ctx context.Conte
 
 	planHasChildren := len(plan.RoutingPolicies.Elements()) > 0
 
+	planChildrenUnknown := plan.RoutingPolicies.IsUnknown()
+
 	// are we a new object?
 	if stateDoesNotExist {
-		if planHasChildren {
+		if planHasChildren || planChildrenUnknown {
 			resp.PlanValue = types.StringUnknown()
 		} else {
 			resp.PlanValue = types.StringNull()
@@ -363,14 +365,14 @@ func (o dynamicBgpPeeringBatchIdPlanModifier) PlanModifyString(ctx context.Conte
 
 	stateHasChildren := len(state.RoutingPolicies.Elements()) > 0
 
-	if planHasChildren == stateHasChildren {
+	if (planHasChildren || planChildrenUnknown) == stateHasChildren {
 		// state and plan agree about whether a batch ID is required. Reuse the old value.
 		resp.PlanValue = req.StateValue
 		return
 	}
 
 	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.
-	if planHasChildren {
+	if planHasChildren || planChildrenUnknown {
 		resp.PlanValue = types.StringUnknown()
 	} else {
 		resp.PlanValue = types.StringNull()

--- a/apstra/blueprint/connectivity_templates/primitives/ip_link.go
+++ b/apstra/blueprint/connectivity_templates/primitives/ip_link.go
@@ -352,9 +352,14 @@ func (o ipLinkBatchIdPlanModifier) PlanModifyString(ctx context.Context, req pla
 		len(plan.DynamicBgpPeerings.Elements())+
 		len(plan.StaticRoutes.Elements()) > 0
 
+	planChildrenUnknown := plan.BgpPeeringGenericSystems.IsUnknown() ||
+		plan.BgpPeeringIpEndpoints.IsUnknown() ||
+		plan.DynamicBgpPeerings.IsUnknown() ||
+		plan.StaticRoutes.IsUnknown()
+
 	// are we a new object?
 	if stateDoesNotExist {
-		if planHasChildren {
+		if planHasChildren || planChildrenUnknown {
 			resp.PlanValue = types.StringUnknown()
 		} else {
 			resp.PlanValue = types.StringNull()
@@ -367,14 +372,14 @@ func (o ipLinkBatchIdPlanModifier) PlanModifyString(ctx context.Context, req pla
 		len(state.DynamicBgpPeerings.Elements())+
 		len(state.StaticRoutes.Elements()) > 0
 
-	if planHasChildren == stateHasChildren {
+	if (planHasChildren || planChildrenUnknown) == stateHasChildren {
 		// state and plan agree about whether a batch ID is required. Reuse the old value.
 		resp.PlanValue = req.StateValue
 		return
 	}
 
 	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.
-	if planHasChildren {
+	if planHasChildren || planChildrenUnknown {
 		resp.PlanValue = types.StringUnknown()
 	} else {
 		resp.PlanValue = types.StringNull()

--- a/apstra/blueprint/connectivity_templates/primitives/virtual_network_single.go
+++ b/apstra/blueprint/connectivity_templates/primitives/virtual_network_single.go
@@ -226,9 +226,12 @@ func (o virtualNetworkSingleBatchIdPlanModifier) PlanModifyString(ctx context.Co
 	planHasChildren := len(plan.BgpPeeringGenericSystems.Elements())+
 		len(plan.StaticRoutes.Elements()) > 0
 
+	planChildrenUnknown := plan.BgpPeeringGenericSystems.IsUnknown() ||
+		plan.StaticRoutes.IsUnknown()
+
 	// are we a new object?
 	if stateDoesNotExist {
-		if planHasChildren {
+		if planHasChildren || planChildrenUnknown {
 			resp.PlanValue = types.StringUnknown()
 		} else {
 			resp.PlanValue = types.StringNull()
@@ -239,14 +242,14 @@ func (o virtualNetworkSingleBatchIdPlanModifier) PlanModifyString(ctx context.Co
 	stateHasChildren := len(state.BgpPeeringGenericSystems.Elements())+
 		len(state.StaticRoutes.Elements()) > 0
 
-	if planHasChildren == stateHasChildren {
+	if (planHasChildren || planChildrenUnknown) == stateHasChildren {
 		// state and plan agree about whether a batch ID is required. Reuse the old value.
 		resp.PlanValue = req.StateValue
 		return
 	}
 
 	// We've either gained our first, or lost our last child primitive. Set the plan value accordingly.
-	if planHasChildren {
+	if planHasChildren || planChildrenUnknown {
 		resp.PlanValue = types.StringUnknown()
 	} else {
 		resp.PlanValue = types.StringNull()


### PR DESCRIPTION
It turns out that #1017 fixed a related issue, but not the exact problem faced by @coterv in #1012.

Both issues are in the plan modifier for the CT primitive `batch_id` attribute.

@coterv's configuration causes the plan modifier to run while the details of child primitives are in `Unknown` state.

Prior to these changes, the plan modifier counts those not-yet-available child primitives, concludes that *none exist*, and sets the `batch_id` attribute to `null` (there are no children, so there won't be a child container, so the ID is moot).

Later, when the child primitives are fully fleshed out (upstream dependencies are satisfied), the plan modifier runs again. This time, when it counts the child primitives, it finds a non-zero number and sets the `batch_id` to `Unknown` (there *will be* a child container object, and it *will have* an ID).

Terraform complains about this inconsistent planning behavior:  `batch_id: was null, but now cty.UnknownVal(cty.String)`

Closes #1012