### PR TITLE
Catch up with SDK changes to configlet types

### DIFF
--- a/apstra/blueprint/blueprint.go
+++ b/apstra/blueprint/blueprint.go
@@ -708,7 +708,7 @@ func (o *Blueprint) Request(ctx context.Context, diags *diag.Diagnostics) *apstr
 	fabricSettings.Ipv6Enabled = nil
 
 	result := apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:      apstra.RefDesignTwoStageL3Clos,
+		RefDesign:      enum.RefDesignDatacenter,
 		Label:          o.Name.ValueString(),
 		TemplateId:     apstra.ObjectId(o.TemplateId.ValueString()),
 		FabricSettings: fabricSettings,

--- a/apstra/data_source_blueprints.go
+++ b/apstra/data_source_blueprints.go
@@ -2,6 +2,7 @@ package tfapstra
 
 import (
 	"context"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -13,8 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ datasource.DataSourceWithConfigure = &dataSourceBlueprints{}
-var _ datasourceWithSetClient = &dataSourceBlueprints{}
+var (
+	_ datasource.DataSourceWithConfigure = &dataSourceBlueprints{}
+	_ datasourceWithSetClient            = &dataSourceBlueprints{}
+)
 
 type dataSourceBlueprints struct {
 	client *apstra.Client

--- a/apstra/data_source_blueprints.go
+++ b/apstra/data_source_blueprints.go
@@ -3,6 +3,7 @@ package tfapstra
 import (
 	"context"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -40,8 +41,8 @@ func (o *dataSourceBlueprints) Schema(_ context.Context, _ datasource.SchemaRequ
 				MarkdownDescription: "Optional filter to select only Blueprints matching the specified Reference Design.",
 				Optional:            true,
 				Validators: []validator.String{stringvalidator.OneOf(
-					utils.StringersToFriendlyString(apstra.RefDesignTwoStageL3Clos),
-					apstra.RefDesignFreeform.String(),
+					utils.StringersToFriendlyString(enum.RefDesignDatacenter),
+					enum.RefDesignFreeform.String(),
 				)},
 			},
 		},

--- a/apstra/data_source_configlets.go
+++ b/apstra/data_source_configlets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -80,7 +81,7 @@ func (o *dataSourceConfiglets) Read(ctx context.Context, req datasource.ReadRequ
 			return
 		}
 
-		platforms := make([]apstra.PlatformOS, len(platformStrings))
+		platforms := make([]enum.ConfigletStyle, len(platformStrings))
 		for i := range platformStrings {
 			err := platforms[i].FromString(platformStrings[i])
 			if err != nil {

--- a/apstra/data_source_configlets.go
+++ b/apstra/data_source_configlets.go
@@ -3,6 +3,7 @@ package tfapstra
 import (
 	"context"
 	"fmt"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -14,8 +15,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ datasource.DataSourceWithConfigure = &dataSourceConfiglets{}
-var _ datasourceWithSetClient = &dataSourceConfiglets{}
+var (
+	_ datasource.DataSourceWithConfigure = &dataSourceConfiglets{}
+	_ datasourceWithSetClient            = &dataSourceConfiglets{}
+)
 
 type dataSourceConfiglets struct {
 	client *apstra.Client

--- a/apstra/data_source_datacenter_blueprint_test.go
+++ b/apstra/data_source_datacenter_blueprint_test.go
@@ -204,7 +204,7 @@ func TestDatasourceDatacenterBlueprint(t *testing.T) {
 
 			// create the blueprint
 			id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-				RefDesign:      apstra.RefDesignTwoStageL3Clos,
+				RefDesign:      enum.RefDesignDatacenter,
 				Label:          tCase.label,
 				TemplateId:     tCase.templateId,
 				FabricSettings: &tCase.fabricSettings,

--- a/apstra/data_source_datacenter_configlets.go
+++ b/apstra/data_source_datacenter_configlets.go
@@ -3,6 +3,7 @@ package tfapstra
 import (
 	"context"
 	"fmt"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -14,8 +15,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ datasource.DataSourceWithConfigure = &dataSourceDatacenterConfiglets{}
-var _ datasourceWithSetDcBpClientFunc = &dataSourceDatacenterConfiglets{}
+var (
+	_ datasource.DataSourceWithConfigure = &dataSourceDatacenterConfiglets{}
+	_ datasourceWithSetDcBpClientFunc    = &dataSourceDatacenterConfiglets{}
+)
 
 type dataSourceDatacenterConfiglets struct {
 	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)

--- a/apstra/data_source_datacenter_configlets.go
+++ b/apstra/data_source_datacenter_configlets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -96,7 +97,7 @@ func (o *dataSourceDatacenterConfiglets) Read(ctx context.Context, req datasourc
 			return
 		}
 
-		platforms := make([]apstra.PlatformOS, len(platformStrings))
+		platforms := make([]enum.ConfigletStyle, len(platformStrings))
 		for i := range platformStrings {
 			err := platforms[i].FromString(platformStrings[i])
 			if err != nil {

--- a/apstra/design/configlet.go
+++ b/apstra/design/configlet.go
@@ -3,6 +3,7 @@ package design
 import (
 	"context"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -80,7 +81,7 @@ func (o *Configlet) Request(ctx context.Context, diags *diag.Diagnostics) *apstr
 	var d diag.Diagnostics
 
 	// We only use the Datacenter Reference Design
-	refArchs := []apstra.RefDesign{apstra.RefDesignTwoStageL3Clos}
+	refArchs := []enum.RefDesign{enum.RefDesignDatacenter}
 
 	// Extract configlet generators
 	tfGenerators := make([]ConfigletGenerator, len(o.Generators.Elements()))

--- a/apstra/design/configlet.go
+++ b/apstra/design/configlet.go
@@ -2,6 +2,7 @@ package design
 
 import (
 	"context"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/design/configlet_generator.go
+++ b/apstra/design/configlet_generator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -101,13 +102,13 @@ func (o *ConfigletGenerator) LoadApiData(ctx context.Context, in *apstra.Configl
 func (o *ConfigletGenerator) Request(_ context.Context, diags *diag.Diagnostics) *apstra.ConfigletGenerator {
 	var err error
 
-	var configStyle apstra.PlatformOS
+	var configStyle enum.ConfigletStyle
 	err = configStyle.FromString(o.ConfigStyle.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("error parsing configlet config_style %q", o.ConfigStyle.ValueString()), err.Error())
 	}
 
-	var section apstra.ConfigletSection
+	var section enum.ConfigletSection
 	err = utils.ApiStringerFromFriendlyString(&section, o.Section.ValueString(), o.ConfigStyle.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("error parsing configlet section %q", o.Section.ValueString()), err.Error())

--- a/apstra/design/configlet_generator.go
+++ b/apstra/design/configlet_generator.go
@@ -3,6 +3,8 @@ package design
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -13,7 +15,6 @@ import (
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"strings"
 )
 
 type ConfigletGenerator struct {

--- a/apstra/design/configlet_generator_validator.go
+++ b/apstra/design/configlet_generator_validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,7 +40,7 @@ func (o ConfigletGeneratorValidator) ValidateObject(ctx context.Context, req val
 		return
 	}
 
-	if !utils.ItemInSlice(request.Section, request.ConfigStyle.ValidSections()) {
+	if !utils.ItemInSlice(request.Section, apstra.ValidConfigletSections(request.ConfigStyle)) {
 		resp.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
 			req.Path.AtName("section"),
 			fmt.Sprintf("Section %q not valid with config_style %q",
@@ -47,11 +48,11 @@ func (o ConfigletGeneratorValidator) ValidateObject(ctx context.Context, req val
 		))
 	}
 
-	if !generator.FileName.IsNull() && request.Section != apstra.ConfigletSectionFile {
+	if !generator.FileName.IsNull() && request.Section != enum.ConfigletSectionFile {
 		resp.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
 			req.Path.AtName("filename"),
 			fmt.Sprintf("'filename' attribute permitted only when section == %q",
-				apstra.ConfigletSectionFile.String()),
+				enum.ConfigletSectionFile.String()),
 		))
 	}
 }

--- a/apstra/design/configlet_generator_validator.go
+++ b/apstra/design/configlet_generator_validator.go
@@ -3,6 +3,7 @@ package design
 import (
 	"context"
 	"fmt"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -13,8 +14,7 @@ import (
 
 var _ validator.Object = ConfigletGeneratorValidator{}
 
-type ConfigletGeneratorValidator struct {
-}
+type ConfigletGeneratorValidator struct{}
 
 func (o ConfigletGeneratorValidator) Description(_ context.Context) string {
 	return "Ensures that the section names matches the config style."

--- a/apstra/resource_configlet.go
+++ b/apstra/resource_configlet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/design"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
@@ -38,37 +39,37 @@ func (o *resourceConfiglet) Schema(_ context.Context, _ resource.SchemaRequest, 
 }
 func (o *resourceConfiglet) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	// create a map of each friendly (aligned with the web UI) config section names keyed by platform
-	platformToAllowedSectionsMap := map[apstra.PlatformOS][]string{
-		apstra.PlatformOSJunos: {
-			utils.StringersToFriendlyString(apstra.ConfigletSectionSystem, apstra.PlatformOSJunos),
-			utils.StringersToFriendlyString(apstra.ConfigletSectionSetBasedSystem, apstra.PlatformOSJunos),
-			utils.StringersToFriendlyString(apstra.ConfigletSectionSetBasedInterface, apstra.PlatformOSJunos),
-			utils.StringersToFriendlyString(apstra.ConfigletSectionDeleteBasedInterface, apstra.PlatformOSJunos),
-			utils.StringersToFriendlyString(apstra.ConfigletSectionInterface, apstra.PlatformOSJunos),
+	platformToAllowedSectionsMap := map[enum.ConfigletStyle][]string{
+		enum.ConfigletStyleJunos: {
+			utils.StringersToFriendlyString(enum.ConfigletSectionSystem, enum.ConfigletStyleJunos),
+			utils.StringersToFriendlyString(enum.ConfigletSectionSetBasedSystem, enum.ConfigletStyleJunos),
+			utils.StringersToFriendlyString(enum.ConfigletSectionSetBasedInterface, enum.ConfigletStyleJunos),
+			utils.StringersToFriendlyString(enum.ConfigletSectionDeleteBasedInterface, enum.ConfigletStyleJunos),
+			utils.StringersToFriendlyString(enum.ConfigletSectionInterface, enum.ConfigletStyleJunos),
 		},
-		apstra.PlatformOSCumulus: {
-			apstra.ConfigletSectionFRR.String(),
-			apstra.ConfigletSectionInterface.String(),
-			apstra.ConfigletSectionFile.String(),
-			apstra.ConfigletSectionOSPF.String(),
+		enum.ConfigletStyleCumulus: {
+			enum.ConfigletSectionFrr.String(),
+			enum.ConfigletSectionInterface.String(),
+			enum.ConfigletSectionFile.String(),
+			enum.ConfigletSectionOspf.String(),
 		},
-		apstra.PlatformOSNxos: {
-			apstra.ConfigletSectionSystem.String(),
-			apstra.ConfigletSectionInterface.String(),
-			apstra.ConfigletSectionSystemTop.String(),
-			apstra.ConfigletSectionOSPF.String(),
+		enum.ConfigletStyleNxos: {
+			enum.ConfigletSectionSystem.String(),
+			enum.ConfigletSectionInterface.String(),
+			enum.ConfigletSectionSystemTop.String(),
+			enum.ConfigletSectionOspf.String(),
 		},
-		apstra.PlatformOSEos: {
-			apstra.ConfigletSectionSystem.String(),
-			apstra.ConfigletSectionInterface.String(),
-			apstra.ConfigletSectionSystemTop.String(),
-			apstra.ConfigletSectionOSPF.String(),
+		enum.ConfigletStyleEos: {
+			enum.ConfigletSectionSystem.String(),
+			enum.ConfigletSectionInterface.String(),
+			enum.ConfigletSectionSystemTop.String(),
+			enum.ConfigletSectionOspf.String(),
 		},
-		apstra.PlatformOSSonic: {
-			apstra.ConfigletSectionSystem.String(),
-			apstra.ConfigletSectionFile.String(),
-			apstra.ConfigletSectionOSPF.String(),
-			apstra.ConfigletSectionFRR.String(),
+		enum.ConfigletStyleSonic: {
+			enum.ConfigletSectionSystem.String(),
+			enum.ConfigletSectionFile.String(),
+			enum.ConfigletSectionOspf.String(),
+			enum.ConfigletSectionFrr.String(),
 		},
 	}
 
@@ -97,8 +98,8 @@ func (o *resourceConfiglet) ValidateConfig(ctx context.Context, req resource.Val
 			continue // cannot validate with unknown value
 		}
 
-		// extract the platform/config_style from the generator object as an SDK iota type
-		var platform apstra.PlatformOS
+		// extract the platform/config_style from the generator object as an SDK enum type
+		var platform enum.ConfigletStyle
 		err := platform.FromString(generator.ConfigStyle.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(

--- a/apstra/resource_configlet.go
+++ b/apstra/resource_configlet.go
@@ -3,6 +3,8 @@ package tfapstra
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/design"
@@ -12,12 +14,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"strings"
 )
 
-var _ resource.ResourceWithConfigure = &resourceConfiglet{}
-var _ resource.ResourceWithValidateConfig = &resourceConfiglet{}
-var _ resourceWithSetClient = &resourceConfiglet{}
+var (
+	_ resource.ResourceWithConfigure      = &resourceConfiglet{}
+	_ resource.ResourceWithValidateConfig = &resourceConfiglet{}
+	_ resourceWithSetClient               = &resourceConfiglet{}
+)
 
 type resourceConfiglet struct {
 	client *apstra.Client
@@ -37,6 +40,7 @@ func (o *resourceConfiglet) Schema(_ context.Context, _ resource.SchemaRequest, 
 		Attributes:          design.Configlet{}.ResourceAttributes(),
 	}
 }
+
 func (o *resourceConfiglet) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	// create a map of each friendly (aligned with the web UI) config section names keyed by platform
 	platformToAllowedSectionsMap := map[enum.ConfigletStyle][]string{

--- a/apstra/resource_freeform_link_integration_test.go
+++ b/apstra/resource_freeform_link_integration_test.go
@@ -785,7 +785,7 @@ func TestResourceFreeformLinkWithIpAllocationEnabled(t *testing.T) {
 	}
 
 	testCases := map[string]testCase{
-		"int_int_start_minimal_ip_allocation_enabled": {
+		"int_int_start_minimal": {
 			ipAllocationEnabled: true,
 			steps: []testStep{
 				{
@@ -887,7 +887,7 @@ func TestResourceFreeformLinkWithIpAllocationEnabled(t *testing.T) {
 				},
 			},
 		},
-		"int_int_start_maximal_ip_allocation_enabled": {
+		"int_int_start_maximal": {
 			ipAllocationEnabled: true,
 			steps: []testStep{
 				{

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -2,11 +2,11 @@ package testutils
 
 import (
 	"context"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"sync"
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/stretchr/testify/require"

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"sync"
 	"testing"
 
@@ -54,7 +55,7 @@ func BlueprintA(t testing.TB, ctx context.Context, name ...string) *apstra.TwoSt
 	}
 
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignTwoStageL3Clos,
+		RefDesign:  enum.RefDesignDatacenter,
 		Label:      bpname,
 		TemplateId: "L2_Virtual_EVPN",
 		FabricSettings: &apstra.FabricSettings{
@@ -78,7 +79,7 @@ func BlueprintB(t testing.TB, ctx context.Context) (*apstra.TwoStageL3ClosClient
 	template := TemplateA(t, ctx)
 	name := acctest.RandString(10)
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignTwoStageL3Clos,
+		RefDesign:  enum.RefDesignDatacenter,
 		Label:      name,
 		TemplateId: template.Id,
 		FabricSettings: &apstra.FabricSettings{
@@ -102,7 +103,7 @@ func BlueprintC(t testing.TB, ctx context.Context) *apstra.TwoStageL3ClosClient 
 	template := TemplateB(t, ctx)
 	name := acctest.RandString(10)
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignTwoStageL3Clos,
+		RefDesign:  enum.RefDesignDatacenter,
 		Label:      name,
 		TemplateId: template.Id,
 		FabricSettings: &apstra.FabricSettings{
@@ -124,7 +125,7 @@ func BlueprintD(t testing.TB, ctx context.Context) *apstra.TwoStageL3ClosClient 
 	template := TemplateC(t, ctx)
 	name := acctest.RandString(10)
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignTwoStageL3Clos,
+		RefDesign:  enum.RefDesignDatacenter,
 		Label:      name,
 		TemplateId: template.Id,
 		FabricSettings: &apstra.FabricSettings{
@@ -201,7 +202,7 @@ func BlueprintF(t testing.TB, ctx context.Context) *apstra.TwoStageL3ClosClient 
 	client := GetTestClient(t, ctx)
 	template := TemplateE(t, ctx)
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignTwoStageL3Clos,
+		RefDesign:  enum.RefDesignDatacenter,
 		Label:      acctest.RandString(10),
 		TemplateId: template.Id,
 		FabricSettings: &apstra.FabricSettings{
@@ -224,7 +225,7 @@ func BlueprintG(t testing.TB, ctx context.Context, cleanup bool) *apstra.TwoStag
 	client := GetTestClient(t, ctx)
 
 	id, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignTwoStageL3Clos,
+		RefDesign:  enum.RefDesignDatacenter,
 		Label:      acctest.RandString(8),
 		TemplateId: "L2_Virtual_EVPN",
 		FabricSettings: &apstra.FabricSettings{
@@ -252,7 +253,7 @@ func BlueprintI(t testing.TB, ctx context.Context) *apstra.TwoStageL3ClosClient 
 	client := GetTestClient(t, ctx)
 
 	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
-		RefDesign:  apstra.RefDesignTwoStageL3Clos,
+		RefDesign:  enum.RefDesignDatacenter,
 		Label:      acctest.RandString(6),
 		TemplateId: "L3_Collapsed_ESI",
 	})

--- a/apstra/test_utils/blueprint_configlet.go
+++ b/apstra/test_utils/blueprint_configlet.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/stretchr/testify/require"
 )

--- a/apstra/test_utils/blueprint_configlet.go
+++ b/apstra/test_utils/blueprint_configlet.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
@@ -21,10 +22,10 @@ func CatalogConfigletA(t testing.TB, ctx context.Context, client *apstra.Client)
 
 		configletData := apstra.ConfigletData{
 			DisplayName: name,
-			RefArchs:    []apstra.RefDesign{apstra.RefDesignTwoStageL3Clos},
+			RefArchs:    []enum.RefDesign{enum.RefDesignDatacenter},
 			Generators: []apstra.ConfigletGenerator{{
-				ConfigStyle:  apstra.PlatformOSJunos,
-				Section:      apstra.ConfigletSectionSystem,
+				ConfigStyle:  enum.ConfigletStyleJunos,
+				Section:      enum.ConfigletSectionSystem,
 				TemplateText: "interfaces {\n   {% if 'leaf1' in hostname %}\n    xe-0/0/3 {\n      disable;\n    }\n   {% endif %}\n   {% if 'leaf2' in hostname %}\n    xe-0/0/2 {\n      disable;\n    }\n   {% endif %}\n}",
 			}},
 		}

--- a/apstra/test_utils/blueprint_configlet.go
+++ b/apstra/test_utils/blueprint_configlet.go
@@ -2,9 +2,9 @@ package testutils
 
 import (
 	"context"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"testing"
 
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/stretchr/testify/require"

--- a/apstra/utils/configlets.go
+++ b/apstra/utils/configlets.go
@@ -89,5 +89,6 @@ func AllPlatformOSNames() []string {
 	for i, configletStyle := range configletStyles {
 		result[i] = configletStyle.String()
 	}
+	sort.Strings(result)
 	return result
 }

--- a/apstra/utils/configlets.go
+++ b/apstra/utils/configlets.go
@@ -44,20 +44,20 @@ func AllConfigletSectionNames() []string {
 	return result
 }
 
-func ConfigletSectionNamesByOS(os enum.ConfigletStyle) []string {
-	var r []string
-	for _, v := range apstra.ValidConfigletSections(os) {
-		r = append(r, StringersToFriendlyString(v, os))
+func ConfigletSectionNamesByStyle(style enum.ConfigletStyle) []string {
+	var result []string
+	for _, v := range apstra.ValidConfigletSections(style) {
+		result = append(result, StringersToFriendlyString(v, style))
 	}
-	return r
+	return result
 }
 
 func ConfigletValidSectionsMap() map[string][]string {
-	m := make(map[string][]string)
+	result := make(map[string][]string)
 	for _, i := range enum.ConfigletStyles.Members() {
-		m[i.String()] = ConfigletSectionNamesByOS(i)
+		result[i.String()] = ConfigletSectionNamesByStyle(i)
 	}
-	return m
+	return result
 }
 
 func ValidSectionsAsTable() string {

--- a/apstra/utils/configlets.go
+++ b/apstra/utils/configlets.go
@@ -3,12 +3,13 @@ package utils
 import (
 	"fmt"
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"sort"
 	"strings"
 )
 
-func ConfigletSupportsPlatforms(configletdata *apstra.ConfigletData, platforms []apstra.PlatformOS) bool {
-	supportedPlatforms := make(map[apstra.PlatformOS]struct{})
+func ConfigletSupportsPlatforms(configletdata *apstra.ConfigletData, platforms []enum.ConfigletStyle) bool {
+	supportedPlatforms := make(map[enum.ConfigletStyle]struct{})
 	for _, generator := range configletdata.Generators {
 		supportedPlatforms[generator.ConfigStyle] = struct{}{}
 	}
@@ -42,9 +43,9 @@ func AllConfigletSectionNames() []string {
 	return result
 }
 
-func ConfigletSectionNamesByOS(os apstra.PlatformOS) []string {
+func ConfigletSectionNamesByOS(os enum.ConfigletStyle) []string {
 	var r []string
-	for _, v := range os.ValidSections() {
+	for _, v := range apstra.ValidConfigletSections(os) {
 		r = append(r, StringersToFriendlyString(v, os))
 	}
 	return r
@@ -52,7 +53,7 @@ func ConfigletSectionNamesByOS(os apstra.PlatformOS) []string {
 
 func ConfigletValidSectionsMap() map[string][]string {
 	var m = make(map[string][]string)
-	for _, i := range apstra.AllPlatformOSes() {
+	for _, i := range enum.ConfigletStyles.Members() {
 		m[i.String()] = ConfigletSectionNamesByOS(i)
 	}
 	return m
@@ -82,10 +83,10 @@ func ValidSectionsAsTable() string {
 }
 
 func AllPlatformOSNames() []string {
-	platforms := apstra.AllPlatformOSes()
-	result := make([]string, len(platforms))
-	for i := range platforms {
-		result[i] = platforms[i].String()
+	configletStyles := enum.ConfigletStyles.Members()
+	result := make([]string, len(configletStyles))
+	for i, configletStyle := range configletStyles {
+		result[i] = configletStyle.String()
 	}
 	return result
 }

--- a/apstra/utils/configlets.go
+++ b/apstra/utils/configlets.go
@@ -2,10 +2,11 @@ package utils
 
 import (
 	"fmt"
-	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"sort"
 	"strings"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 )
 
 func ConfigletSupportsPlatforms(configletdata *apstra.ConfigletData, platforms []enum.ConfigletStyle) bool {
@@ -52,7 +53,7 @@ func ConfigletSectionNamesByOS(os enum.ConfigletStyle) []string {
 }
 
 func ConfigletValidSectionsMap() map[string][]string {
-	var m = make(map[string][]string)
+	m := make(map[string][]string)
 	for _, i := range enum.ConfigletStyles.Members() {
 		m[i.String()] = ConfigletSectionNamesByOS(i)
 	}

--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -71,7 +71,7 @@ func StringersToFriendlyString(in ...fmt.Stringer) string {
 	switch in0 := in[0].(type) {
 	case apstra.AsnAllocationScheme:
 		return asnAllocationSchemeToFriendlyString(in0)
-	case apstra.ConfigletSection:
+	case enum.ConfigletSection:
 		return configletSectionToFriendlyString(in0, in[1:]...)
 	case apstra.CtPrimitiveIPv4AddressingType:
 		return ctPrimitiveIPv4AddressingTypeToFriendlyString(in0)
@@ -89,7 +89,7 @@ func StringersToFriendlyString(in ...fmt.Stringer) string {
 		return overlayControlProtocolToFriendlyString(in0)
 	case enum.PolicyRuleProtocol:
 		return policyRuleProtocolToFriendlyString(in0)
-	case apstra.RefDesign:
+	case enum.RefDesign:
 		return refDesignToFriendlyString(in0)
 	case apstra.ResourceGroupName:
 		return resourceGroupNameToFriendlyString(in0)
@@ -117,7 +117,7 @@ func ApiStringerFromFriendlyString(target StringerWithFromString, in ...string) 
 	switch target := target.(type) {
 	case *apstra.AsnAllocationScheme:
 		return asnAllocationSchemeFromFriendlyString(target, in...)
-	case *apstra.ConfigletSection:
+	case *enum.ConfigletSection:
 		return configletSectionFromFriendlyString(target, in...)
 	case *apstra.CtPrimitiveIPv4AddressingType:
 		return ctPrimitiveIPv4AddressingTypeFromFriendlyString(target, in...)
@@ -135,7 +135,7 @@ func ApiStringerFromFriendlyString(target StringerWithFromString, in ...string) 
 		return overlayControlProtocolFromFriendlyString(target, in...)
 	case *enum.PolicyRuleProtocol:
 		return policyRuleProtocolFromFriendlyString(target, in[0])
-	case *apstra.RefDesign:
+	case *enum.RefDesign:
 		return refDesignFromFriendlyString(target, in...)
 	case *apstra.ResourceGroupName:
 		return resourceGroupNameFromFriendlyString(target, in...)
@@ -157,28 +157,28 @@ func asnAllocationSchemeToFriendlyString(in apstra.AsnAllocationScheme) string {
 	return in.String()
 }
 
-func configletSectionToFriendlyString(in apstra.ConfigletSection, additionalInfo ...fmt.Stringer) string {
+func configletSectionToFriendlyString(in enum.ConfigletSection, additionalInfo ...fmt.Stringer) string {
 	if len(additionalInfo) == 0 {
 		return in.String()
 	}
 
-	os, ok := additionalInfo[0].(apstra.PlatformOS)
+	os, ok := additionalInfo[0].(enum.ConfigletStyle)
 	if !ok {
 		return in.String()
 	}
 
 	switch os {
-	case apstra.PlatformOSJunos:
+	case enum.ConfigletStyleJunos:
 		switch in {
-		case apstra.ConfigletSectionSystem:
+		case enum.ConfigletSectionSystem:
 			return junOSTopLevelHierarchical
-		case apstra.ConfigletSectionSetBasedSystem:
+		case enum.ConfigletSectionSetBasedSystem:
 			return junOSTopLevelSetDelete
-		case apstra.ConfigletSectionSetBasedInterface:
+		case enum.ConfigletSectionSetBasedInterface:
 			return junOSInterfaceLevelSet
-		case apstra.ConfigletSectionDeleteBasedInterface:
+		case enum.ConfigletSectionDeleteBasedInterface:
 			return junOSInterfaceLevelDelete
-		case apstra.ConfigletSectionInterface:
+		case enum.ConfigletSectionInterface:
 			return junOSInterfaceLevelHierarchical
 		}
 	}
@@ -255,9 +255,9 @@ func policyRuleProtocolToFriendlyString(in enum.PolicyRuleProtocol) string {
 	return strings.ToLower(in.String())
 }
 
-func refDesignToFriendlyString(in apstra.RefDesign) string {
+func refDesignToFriendlyString(in enum.RefDesign) string {
 	switch in {
-	case apstra.RefDesignTwoStageL3Clos:
+	case enum.RefDesignDatacenter:
 		return refDesignDataCenter
 	}
 
@@ -312,7 +312,7 @@ func asnAllocationSchemeFromFriendlyString(target *apstra.AsnAllocationScheme, i
 	return nil
 }
 
-func configletSectionFromFriendlyString(target *apstra.ConfigletSection, in ...string) error {
+func configletSectionFromFriendlyString(target *enum.ConfigletSection, in ...string) error {
 	switch len(in) {
 	case 0:
 		return target.FromString("")
@@ -323,21 +323,21 @@ func configletSectionFromFriendlyString(target *apstra.ConfigletSection, in ...s
 	section := in[0]
 	platform := in[1]
 
-	if platform != apstra.PlatformOSJunos.String() {
+	if platform != enum.ConfigletStyleJunos.String() {
 		return target.FromString(section)
 	}
 
 	switch section {
 	case junOSTopLevelHierarchical:
-		*target = apstra.ConfigletSectionSystem
+		*target = enum.ConfigletSectionSystem
 	case junOSInterfaceLevelHierarchical:
-		*target = apstra.ConfigletSectionInterface
+		*target = enum.ConfigletSectionInterface
 	case junOSTopLevelSetDelete:
-		*target = apstra.ConfigletSectionSetBasedSystem
+		*target = enum.ConfigletSectionSetBasedSystem
 	case junOSInterfaceLevelDelete:
-		*target = apstra.ConfigletSectionDeleteBasedInterface
+		*target = enum.ConfigletSectionDeleteBasedInterface
 	case junOSInterfaceLevelSet:
-		*target = apstra.ConfigletSectionSetBasedInterface
+		*target = enum.ConfigletSectionSetBasedInterface
 	default:
 		return target.FromString(section)
 	}
@@ -461,14 +461,14 @@ func policyRuleProtocolFromFriendlyString(target *enum.PolicyRuleProtocol, s str
 	return nil
 }
 
-func refDesignFromFriendlyString(target *apstra.RefDesign, in ...string) error {
+func refDesignFromFriendlyString(target *enum.RefDesign, in ...string) error {
 	if len(in) == 0 {
 		return target.FromString("")
 	}
 
 	switch in[0] {
 	case refDesignDataCenter:
-		*target = apstra.RefDesignTwoStageL3Clos
+		*target = enum.RefDesignDatacenter
 	default:
 		return target.FromString(in[0])
 	}

--- a/apstra/utils/rosetta_test.go
+++ b/apstra/utils/rosetta_test.go
@@ -19,14 +19,14 @@ func TestRosetta(t *testing.T) {
 		{string: "unique", stringers: []fmt.Stringer{apstra.AsnAllocationSchemeDistinct}},
 		{string: "single", stringers: []fmt.Stringer{apstra.AsnAllocationSchemeSingle}},
 
-		{string: "delete_based_interface", stringers: []fmt.Stringer{apstra.ConfigletSectionDeleteBasedInterface, apstra.PlatformOSCumulus}},
-		{string: "file", stringers: []fmt.Stringer{apstra.ConfigletSectionFile}},
+		{string: "delete_based_interface", stringers: []fmt.Stringer{enum.ConfigletSectionDeleteBasedInterface, enum.ConfigletStyleCumulus}},
+		{string: "file", stringers: []fmt.Stringer{enum.ConfigletSectionFile}},
 
-		{string: "top_level_hierarchical", stringers: []fmt.Stringer{apstra.ConfigletSectionSystem, apstra.PlatformOSJunos}},
-		{string: "top_level_set_delete", stringers: []fmt.Stringer{apstra.ConfigletSectionSetBasedSystem, apstra.PlatformOSJunos}},
-		{string: "interface_level_hierarchical", stringers: []fmt.Stringer{apstra.ConfigletSectionInterface, apstra.PlatformOSJunos}},
-		{string: "interface_level_set", stringers: []fmt.Stringer{apstra.ConfigletSectionSetBasedInterface, apstra.PlatformOSJunos}},
-		{string: "interface_level_delete", stringers: []fmt.Stringer{apstra.ConfigletSectionDeleteBasedInterface, apstra.PlatformOSJunos}},
+		{string: "top_level_hierarchical", stringers: []fmt.Stringer{enum.ConfigletSectionSystem, enum.ConfigletStyleJunos}},
+		{string: "top_level_set_delete", stringers: []fmt.Stringer{enum.ConfigletSectionSetBasedSystem, enum.ConfigletStyleJunos}},
+		{string: "interface_level_hierarchical", stringers: []fmt.Stringer{enum.ConfigletSectionInterface, enum.ConfigletStyleJunos}},
+		{string: "interface_level_set", stringers: []fmt.Stringer{enum.ConfigletSectionSetBasedInterface, enum.ConfigletStyleJunos}},
+		{string: "interface_level_delete", stringers: []fmt.Stringer{enum.ConfigletSectionDeleteBasedInterface, enum.ConfigletStyleJunos}},
 
 		{string: "static", stringers: []fmt.Stringer{apstra.OverlayControlProtocolNone}},
 		{string: "evpn", stringers: []fmt.Stringer{apstra.OverlayControlProtocolEvpn}},
@@ -36,8 +36,8 @@ func TestRosetta(t *testing.T) {
 		{string: "tcp", stringers: []fmt.Stringer{enum.PolicyRuleProtocolTcp}},
 		{string: "udp", stringers: []fmt.Stringer{enum.PolicyRuleProtocolUdp}},
 
-		{string: "datacenter", stringers: []fmt.Stringer{apstra.RefDesignTwoStageL3Clos}},
-		{string: "freeform", stringers: []fmt.Stringer{apstra.RefDesignFreeform}},
+		{string: "datacenter", stringers: []fmt.Stringer{enum.RefDesignDatacenter}},
+		{string: "freeform", stringers: []fmt.Stringer{enum.RefDesignFreeform}},
 
 		{string: "vni_virtual_network_ids", stringers: []fmt.Stringer{apstra.ResourceGroupNameVxlanVnIds}},
 		{string: "leaf_l3_peer_links", stringers: []fmt.Stringer{apstra.ResourceGroupNameLeafL3PeerLinkLinkIp4}},
@@ -66,8 +66,8 @@ func TestRosetta(t *testing.T) {
 		// test creating iota/stringer type from friendly string
 		var target StringerWithFromString
 		switch tc.stringers[0].(type) {
-		case apstra.ConfigletSection:
-			x := apstra.ConfigletSection(-1)
+		case enum.ConfigletSection:
+			x := enum.ConfigletSection{}
 			target = &x
 		case apstra.CtPrimitiveIPv4AddressingType:
 			x := apstra.CtPrimitiveIPv4AddressingType(-1)
@@ -90,8 +90,8 @@ func TestRosetta(t *testing.T) {
 		case enum.PolicyRuleProtocol:
 			x := enum.PolicyRuleProtocol{}
 			target = &x
-		case apstra.RefDesign:
-			x := apstra.RefDesign(-1)
+		case enum.RefDesign:
+			x := enum.RefDesign{}
 			target = &x
 		case apstra.ResourceGroupName:
 			x := apstra.ResourceGroupName(-1)

--- a/docs/resources/configlet.md
+++ b/docs/resources/configlet.md
@@ -55,7 +55,7 @@ resource "apstra_configlet" "example" {
 
 Required:
 
-- `config_style` (String) Specifies the switch platform, must be one of 'cumulus', 'nxos', 'eos', 'junos', 'sonic'.
+- `config_style` (String) Specifies the switch platform, must be one of 'cumulus', 'eos', 'junos', 'nxos', 'sonic'.
 - `section` (String) Specifies where in the target device the configlet should be  applied. Varies by network OS:
 
   | **Config Style**  | **Valid Sections** |

--- a/docs/resources/datacenter_configlet.md
+++ b/docs/resources/datacenter_configlet.md
@@ -175,7 +175,7 @@ output "created" {
 
 Required:
 
-- `config_style` (String) Specifies the switch platform, must be one of 'cumulus', 'nxos', 'eos', 'junos', 'sonic'.
+- `config_style` (String) Specifies the switch platform, must be one of 'cumulus', 'eos', 'junos', 'nxos', 'sonic'.
 - `section` (String) Specifies where in the target device the configlet should be  applied. Varies by network OS:
 
   | **Config Style**  | **Valid Sections** |

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ toolchain go1.22.10
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20241220010754-e4f59ed93cd7
+	github.com/Juniper/apstra-go-sdk v0.0.0-20250124024246-27a77ad9192d
 	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
 	github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20241220010754-e4f59ed93cd7 h1:HE5NqogM/GBkUOcM6qgwoNpZa6sgf6co8Juee4UMZKM=
-github.com/Juniper/apstra-go-sdk v0.0.0-20241220010754-e4f59ed93cd7/go.mod h1:j0XhEo0IoltyST4cqdLwrDUNLDHC7JWJxBPDVffeSCg=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250124024246-27a77ad9192d h1:VlD2iLW6XPfPXZrhmy5YggGImaV5+5J0n+GZVLkfjO8=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250124024246-27a77ad9192d/go.mod h1:j0XhEo0IoltyST4cqdLwrDUNLDHC7JWJxBPDVffeSCg=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
This PR bumps the SDK version and absorbs breaking changes to configlet types in [SDK #485](https://github.com/Juniper/apstra-go-sdk/pull/485).

Changes in here include:
- swap old `iota` types to `enum` types
- renaming of some variables and functions for clarity (s/platform/configlet style/)

Odds and Ends:

The test in `apstra/resource_freeform_link_integration_test.go` had some complicated logic for concurrent handling of test cases requiring automatic IP allocation disabled along with those requiring it enabled. There was wait group logic which ran "disabled" test cases first (blocking others), then enabled IP allocation and un-blocked the remaining test cases.

This was too complicated and error prone. Now the test cases are split into two tests in separate blueprints: one with IP allocation enabled, and one with IP allocation disabled.