### PR TITLE
Add 5.1 to supported releases

### DIFF
--- a/apstra/api_versions/versions.go
+++ b/apstra/api_versions/versions.go
@@ -10,6 +10,7 @@ const (
 	Apstra422  = "4.2.2"
 	Apstra500  = "5.0.0"
 	Apstra501  = "5.0.1"
+	Apstra510  = "5.1.0"
 
 	GeApstra421 = ">" + Apstra421
 

--- a/apstra/compatibility/api_versions.go
+++ b/apstra/compatibility/api_versions.go
@@ -18,6 +18,7 @@ func SupportedApiVersions() []string {
 		apiversions.Apstra422,
 		apiversions.Apstra500,
 		apiversions.Apstra501,
+		apiversions.Apstra510,
 	}
 
 	sdkVersions := compatibility.SupportedApiVersions()

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -5,11 +5,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
-	"github.com/hashicorp/go-version"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/stretchr/testify/require"
 )

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
+	"github.com/hashicorp/go-version"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -228,6 +230,14 @@ func BlueprintF(t testing.TB, ctx context.Context) *apstra.TwoStageL3ClosClient 
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, client.DeleteRackType(ctx, rackId)) })
 
+	var aap *apstra.AntiAffinityPolicy
+	if compatibility.TemplateRequiresAntiAffinityPolicy.Check(version.Must(version.NewVersion(client.ApiVersion()))) {
+		aap = &apstra.AntiAffinityPolicy{
+			Algorithm: apstra.AlgorithmHeuristic,
+			Mode:      apstra.AntiAffinityModeDisabled,
+		}
+	}
+
 	templateId, err := client.CreateRackBasedTemplate(ctx, &apstra.CreateRackBasedTemplateRequest{
 		DisplayName: acctest.RandString(6),
 		Spine: &apstra.TemplateElementSpineRequest{
@@ -237,6 +247,7 @@ func BlueprintF(t testing.TB, ctx context.Context) *apstra.TwoStageL3ClosClient 
 		RackInfos:            map[apstra.ObjectId]apstra.TemplateRackBasedRackInfo{rackId: {Count: 1}},
 		AsnAllocationPolicy:  &apstra.AsnAllocationPolicy{SpineAsnScheme: apstra.AsnAllocationSchemeDistinct},
 		VirtualNetworkPolicy: &apstra.VirtualNetworkPolicy{OverlayControlProtocol: apstra.OverlayControlProtocolEvpn},
+		AntiAffinityPolicy:   aap,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, client.DeleteTemplate(ctx, templateId)) })

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ It covers day 0 and day 1 operations (design and deployment), and a growing list
 
 Use the navigation tree on the left to read about the available resources and data sources.
 
-This release has been tested with Apstra versions 4.2.0, 4.2.1, 4.2.1.1, 4.2.2, 5.0.0, and 5.0.1.
+This release has been tested with Apstra versions 4.2.0, 4.2.1, 4.2.1.1, 4.2.2, 5.0.0, 5.0.1, and 5.1.0.
 
 Some example projects which make use of this provider can be found [here](https://github.com/Juniper/terraform-apstra-examples).
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ toolchain go1.22.10
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20250207014126-202e8b829f30
+	github.com/Juniper/apstra-go-sdk v0.0.0-20250226193605-5f4b352705fd
 	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
 	github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20250207014126-202e8b829f30 h1:pXdgnEAY1p/qk8SNDdjHvjHSwsWPuqdr95+mOV1xsXY=
-github.com/Juniper/apstra-go-sdk v0.0.0-20250207014126-202e8b829f30/go.mod h1:j0XhEo0IoltyST4cqdLwrDUNLDHC7JWJxBPDVffeSCg=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250226193605-5f4b352705fd h1:Pf2K2FhpQRajnlYlGzeBXqO8Y0GafJ6tseDWatgZwOY=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250226193605-5f4b352705fd/go.mod h1:j0XhEo0IoltyST4cqdLwrDUNLDHC7JWJxBPDVffeSCg=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
This PR was tested with:
- 4.2.0 (tests need #1049)
- 4.2.1
- 4.2.1.1
- 4.2.2
- 5.0.0
- 5.0.1
- 5.1.0