### PR TITLE
Test BlueprintF: Send `anti_affinity_policy` if apstra 4.2.0

### DIFF
--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -5,11 +5,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
-	"github.com/hashicorp/go-version"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/stretchr/testify/require"
 )

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
+	"github.com/hashicorp/go-version"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -228,6 +230,14 @@ func BlueprintF(t testing.TB, ctx context.Context) *apstra.TwoStageL3ClosClient 
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, client.DeleteRackType(ctx, rackId)) })
 
+	var aap *apstra.AntiAffinityPolicy
+	if compatibility.TemplateRequiresAntiAffinityPolicy.Check(version.Must(version.NewVersion(client.ApiVersion()))) {
+		aap = &apstra.AntiAffinityPolicy{
+			Algorithm: apstra.AlgorithmHeuristic,
+			Mode:      apstra.AntiAffinityModeDisabled,
+		}
+	}
+
 	templateId, err := client.CreateRackBasedTemplate(ctx, &apstra.CreateRackBasedTemplateRequest{
 		DisplayName: acctest.RandString(6),
 		Spine: &apstra.TemplateElementSpineRequest{
@@ -237,6 +247,7 @@ func BlueprintF(t testing.TB, ctx context.Context) *apstra.TwoStageL3ClosClient 
 		RackInfos:            map[apstra.ObjectId]apstra.TemplateRackBasedRackInfo{rackId: {Count: 1}},
 		AsnAllocationPolicy:  &apstra.AsnAllocationPolicy{SpineAsnScheme: apstra.AsnAllocationSchemeDistinct},
 		VirtualNetworkPolicy: &apstra.VirtualNetworkPolicy{OverlayControlProtocol: apstra.OverlayControlProtocolEvpn},
+		AntiAffinityPolicy:   aap,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, client.DeleteTemplate(ctx, templateId)) })


### PR DESCRIPTION
The `BlueprintF()` test function creates its own Template, but fails with Apstra 4.2.0, where templates require an AntiAffinityPolicy.

This PR detects Apstra 4.2.0 and sends the AntiAffinityPolicy as needed.