### PR TITLE
Invert `apstra_datacenter_virtual_network` resource validation logic

### DIFF
--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -378,18 +378,17 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 			Computed:            true,
 		},
 		"reserve_vlan": resourceSchema.BoolAttribute{
-			MarkdownDescription: fmt.Sprintf("For use only with `%s` type Virtual networks "+
-				"when all `bindings` use the same VLAN ID. This option reserves the VLAN fabric-wide, "+
-				"even on switches to which the Virtual Network has not yet been deployed. The only "+
-				"accepted values is `true`.", enum.VnTypeVxlan.String()),
+			MarkdownDescription: fmt.Sprintf("For use only with `%s` type Virtual networks when all "+
+				"`bindings` use the same VLAN ID. This option reserves the VLAN fabric-wide, even on "+
+				"switches to which the Virtual Network has not yet been deployed.", enum.VnTypeVxlan.String()),
 			Optional: true,
 			Computed: true,
 			Validators: []validator.Bool{
-				apstravalidator.WhenValueIsBool(types.BoolValue(true),
-					apstravalidator.ValueAtMustBeBool(
+				apstravalidator.WhenValueIsBool(
+					types.BoolValue(true),
+					apstravalidator.ForbiddenWhenValueIs(
 						path.MatchRelative().AtParent().AtName("type"),
-						types.StringValue(enum.VnTypeVxlan.String()),
-						false,
+						types.StringValue(enum.VnTypeVlan.String()),
 					),
 				),
 				apstravalidator.AlsoRequiresNOf(1,

--- a/docs/resources/datacenter_virtual_network.md
+++ b/docs/resources/datacenter_virtual_network.md
@@ -69,7 +69,7 @@ resource "apstra_datacenter_virtual_network" "test" {
 - `ipv6_virtual_gateway` (String) Specifies the IPv6 virtual gateway address within the Virtual Network. The configured value must be a valid IPv6 host address configured value within range specified by `ipv6_subnet`
 - `ipv6_virtual_gateway_enabled` (Boolean) Controls and indicates whether the IPv6 gateway within the Virtual Network is enabled. Requires `ipv6_connectivity_enabled` to be `true`
 - `l3_mtu` (Number) L3 MTU used by the L3 switch interfaces participating in the Virtual Network. Must be an even number between 1280 and 9216. Requires Apstra 4.2.0 or later.
-- `reserve_vlan` (Boolean) For use only with `vxlan` type Virtual networks when all `bindings` use the same VLAN ID. This option reserves the VLAN fabric-wide, even on switches to which the Virtual Network has not yet been deployed. The only accepted values is `true`.
+- `reserve_vlan` (Boolean) For use only with `vxlan` type Virtual networks when all `bindings` use the same VLAN ID. This option reserves the VLAN fabric-wide, even on switches to which the Virtual Network has not yet been deployed.
 - `reserved_vlan_id` (Number) Used to specify the reserved VLAN ID without specifying any *bindings*.
 - `routing_zone_id` (String) Routing Zone ID (required when `type == vxlan`
 - `type` (String) Virtual Network Type


### PR DESCRIPTION
The `apstra_datacenter_virtual_network` resource has an interaction between the `type` and `reserve_vlan` attributes.

`type` is an optional string attribute with two permissible values: `vxlan` (the default) and `vlan`.

`reserve_vlan` is an optional boolean attribute which must only be `true` when `type == "vxlan"`

Currently that's enforced with [this validator](https://github.com/Juniper/terraform-provider-apstra/blob/f4259dcbef0dea14a78164d47a9c3ea0754f13f6/apstra/blueprint/datacenter_virtual_network.go#L388C1-L395C1):

It says, more or less: When `reserve_vlan` is `true`, `type` must be `vxlan`.

The problem with this approach is that `reserve_vlan` cannot rely on the `type` attribute's default value. If we set `reserve_vlan`, we must also explicitly set `type` to its default value.

This PR inverts the logic so that `reserve_vlan` _cannot be set_ when `type == "vlan"`

```go
				apstravalidator.WhenValueIsBool(
					types.BoolValue(true),
					apstravalidator.ForbiddenWhenValueIs(
						path.MatchRelative().AtParent().AtName("type"),
						types.StringValue(enum.VnTypeVlan.String()),
					),
				),
```

This way, we can write HCL like this:

```terraform
resource "apstra_datacenter_virtual_network" "example" {
  blueprint_id    = local.blueprint_id
  name            = "example"
  routing_zone_id = local.routing_zone_id
  # type          = "vxlan"              <<<=== DEFAULT VALUE NOT REQUIRED
  reserve_vlan    = true
  bindings = {
    (local.leaf_id) = {
      vlan_id = 100
    }
  }
}
```

**Odds and Ends:**
- Removed a docstring assertion about the `reserve_vlan` attribute: "The only accepted values is `true`". This wasn't correct. `false` was also accepted.