### PR TITLE
Bugfix #1055 handling omitted `reserved_vlan_id` values in `apstra_datacenter_virtual_network` resource

### DIFF
--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -624,7 +624,7 @@ func (o *DatacenterVirtualNetwork) Request(ctx context.Context, diags *diag.Diag
 
 	var reservedVlanId *apstra.Vlan
 	if o.ReserveVlan.ValueBool() {
-		if !o.ReservedVlanId.IsNull() {
+		if utils.HasValue(o.ReservedVlanId) {
 			reservedVlanId = utils.ToPtr(apstra.Vlan(o.ReservedVlanId.ValueInt64()))
 		} else {
 			reservedVlanId = vnBindings[0].VlanId

--- a/apstra/resource_datacenter_virtual_network_integration_test.go
+++ b/apstra/resource_datacenter_virtual_network_integration_test.go
@@ -628,6 +628,25 @@ func TestAccDatacenterVirtualNetwork(t *testing.T) {
 				},
 			},
 		},
+		"issue_1055": {
+			steps: []testStep{
+				{
+					config: resourceDatacenterVirtualNetworkTemplate{
+						blueprintId:   bp.Id(),
+						name:          acctest.RandString(6),
+						vnType:        enum.VnTypeVxlan.String(),
+						routingZoneId: szId,
+						reserveVlan:   utils.ToPtr(true),
+						bindings: []resourceDatacenterVirtualNetworkTemplateBinding{
+							{
+								leafId: nodesByLabel["l2_one_access_001_leaf1"],
+								vlanId: utils.ToPtr(1101),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	resourceType := tfapstra.ResourceName(ctx, &tfapstra.ResourceDatacenterVirtualNetwork)


### PR DESCRIPTION
Fix a logic issue related to the fact that the new `reserved_vlan_id` attribute has the `Computed` flag.

Because the attribute is `Computed` and `Optional`, when the practitioner omits the value it will be `Unknown` rather than `Null` in the plan.

We were checking for user-supplied values with `!o.ReservedVlanId.IsNull()` (value is not null)

A better check would have been `!o.ReservedVlanId.IsUnknown()` (value is not unknown) or `utils.HasValue(o.ReservedVlanId)` (value is present).

Closes #1055