### PR TITLE
Add `loopback_ids` attribute to `apstra_datacenter_routing_zone_loop back_addresses` resource

### DIFF
--- a/apstra/resource_datacenter_routing_zone_loopback_addresses_integration_test.go
+++ b/apstra/resource_datacenter_routing_zone_loopback_addresses_integration_test.go
@@ -88,6 +88,8 @@ func (o resourceDatacenterRoutingZoneLoopbackAddresses) testChecks(t testing.TB,
 		} else {
 			result.append(t, "TestCheckNoResourceAttr", fmt.Sprintf("loopbacks.%s.ipv6_addr", k))
 		}
+
+		result.append(t, "TestCheckResourceAttrSet", fmt.Sprintf("loopback_ids.%s", k))
 	}
 
 	return result

--- a/docs/resources/datacenter_routing_zone_loopback_addresses.md
+++ b/docs/resources/datacenter_routing_zone_loopback_addresses.md
@@ -60,6 +60,10 @@ resource "apstra_datacenter_routing_zone_loopback_addresses" "example" {
 - `loopbacks` (Attributes Map) Map of Loopback IPv4 and IPv6 addresses, keyed by System (switch) Node ID. (see [below for nested schema](#nestedatt--loopbacks))
 - `routing_zone_id` (String) Routing Zone ID.
 
+### Read-Only
+
+- `loopback_ids` (Map of String) Map of Loopback interface Node IDs configured by this resource, keyed by System (switch) Node ID.
+
 <a id="nestedatt--loopbacks"></a>
 ### Nested Schema for `loopbacks`
 


### PR DESCRIPTION
This PR adds the `loopback_ids` attribute to `apstra_datacenter_routing_zone_loop back_addresses` resource.

The attribute is a map of loopback interface IDs, keyed by system ID.

Knowing the loopback interface ID is useful when attaching a `apstra_datacenter_connectivity_template_loopback` resource.

Closes #979