### PR TITLE
Improve validation of `apstra_datacenter_virtual_network` resource `dhcp_service_enabled` attribute.

### DIFF
--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -448,14 +448,6 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 			Optional:            true,
 			Computed:            true,
 			Default:             booldefault.StaticBool(false),
-			Validators: []validator.Bool{
-				apstravalidator.WhenValueIsBool(types.BoolValue(true),
-					apstravalidator.AlsoRequiresNOf(1,
-						path.MatchRelative().AtParent().AtName("ipv4_connectivity_enabled"),
-						path.MatchRelative().AtParent().AtName("ipv6_connectivity_enabled"),
-					),
-				),
-			},
 		},
 		"ipv4_connectivity_enabled": resourceSchema.BoolAttribute{
 			MarkdownDescription: "Enables IPv4 within the Virtual Network. Default: true",


### PR DESCRIPTION
The `apstra_datacenter_virtual_network` validation of the `dhcp_service_enabled` previously required only that an IP service be *configured*, but not that it be *enabled*.

This PR removes the old attribute-based validation and replaces it with a config validator which ensures that IPv4 or IPv6 service is actually enabled when DHCP is enabled.

Also extended the test code to include both the DHCP configuration and expected errors.

Closes #86