### PR TITLE
Mark bgp session passwords as _sensitive_

### DIFF
--- a/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
+++ b/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
@@ -93,6 +93,7 @@ func (o BgpPeeringGenericSystem) ResourceAttributes() map[string]resourceSchema.
 		"password": resourceSchema.StringAttribute{
 			MarkdownDescription: "Password used to secure the BGP session.",
 			Optional:            true,
+			Sensitive:           true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"keepalive_time": resourceSchema.Int64Attribute{

--- a/apstra/blueprint/connectivity_templates/primitives/bgp_peering_ip_endpoint.go
+++ b/apstra/blueprint/connectivity_templates/primitives/bgp_peering_ip_endpoint.go
@@ -93,6 +93,7 @@ func (o BgpPeeringIpEndpoint) ResourceAttributes() map[string]resourceSchema.Att
 		"password": resourceSchema.StringAttribute{
 			MarkdownDescription: "Password used to secure the BGP session.",
 			Optional:            true,
+			Sensitive:           true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"keepalive_time": resourceSchema.Int64Attribute{

--- a/apstra/blueprint/connectivity_templates/primitives/dynamic_bgp_peering.go
+++ b/apstra/blueprint/connectivity_templates/primitives/dynamic_bgp_peering.go
@@ -91,6 +91,7 @@ func (o DynamicBgpPeering) ResourceAttributes() map[string]resourceSchema.Attrib
 		"password": resourceSchema.StringAttribute{
 			MarkdownDescription: "Password used to secure the BGP session.",
 			Optional:            true,
+			Sensitive:           true,
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"keepalive_time": resourceSchema.Int64Attribute{

--- a/docs/resources/datacenter_connectivity_template_interface.md
+++ b/docs/resources/datacenter_connectivity_template_interface.md
@@ -163,7 +163,7 @@ Optional:
 - `hold_time` (Number) BGP hold time (seconds).
 - `keepalive_time` (Number) BGP keepalive time (seconds).
 - `local_asn` (Number) This feature is configured on a per-peer basis. It allows a router to appear to be a member of a second autonomous system (AS) by prepending a local-as AS number, in addition to its real AS number, announced to its eBGP peer, resulting in an AS path length of two.
-- `password` (String) Password used to secure the BGP session.
+- `password` (String, Sensitive) Password used to secure the BGP session.
 - `routing_policies` (Attributes Map) Map of Routing Policy Primitives to be used with this *Protocol Endpoint*. (see [below for nested schema](#nestedatt--ip_links--bgp_peering_generic_systems--routing_policies))
 - `ttl` (Number) BGP Time To Live. Omit to use device defaults.
 
@@ -202,7 +202,7 @@ Optional:
 - `keepalive_time` (Number) BGP keepalive time (seconds).
 - `local_asn` (Number) This feature is configured on a per-peer basis. It allows a router to appear to be a member of a second autonomous system (AS) by prepending a local-as AS number, in addition to its real AS number, announced to its eBGP peer, resulting in an AS path length of two.
 - `neighbor_asn` (Number) Neighbor ASN. Omit for *Neighbor ASN Type Dynamic*.
-- `password` (String) Password used to secure the BGP session.
+- `password` (String, Sensitive) Password used to secure the BGP session.
 - `routing_policies` (Attributes Map) Map of Routing Policy Primitives to be used with this *Protocol Endpoint*. (see [below for nested schema](#nestedatt--ip_links--bgp_peering_ip_endpoints--routing_policies))
 - `ttl` (Number) BGP Time To Live. Omit to use device defaults.
 
@@ -242,7 +242,7 @@ Optional:
 - `ipv6_peer_prefix` (String) IPv6 Subnet for BGP Prefix Dynamic Neighbors. Leave blank to derive subnet from application point.
 - `keepalive_time` (Number) BGP keepalive time (seconds).
 - `local_asn` (Number) This feature is configured on a per-peer basis. It allows a router to appear to be a member of a second autonomous system (AS) by prepending a local-as AS number, in addition to its real AS number, announced to its eBGP peer, resulting in an AS path length of two.
-- `password` (String) Password used to secure the BGP session.
+- `password` (String, Sensitive) Password used to secure the BGP session.
 - `routing_policies` (Attributes Map) Map of Routing Policy Primitives to be used with this *Protocol Endpoint*. (see [below for nested schema](#nestedatt--ip_links--dynamic_bgp_peerings--routing_policies))
 - `ttl` (Number) BGP Time To Live. Omit to use device defaults.
 
@@ -352,7 +352,7 @@ Optional:
 - `hold_time` (Number) BGP hold time (seconds).
 - `keepalive_time` (Number) BGP keepalive time (seconds).
 - `local_asn` (Number) This feature is configured on a per-peer basis. It allows a router to appear to be a member of a second autonomous system (AS) by prepending a local-as AS number, in addition to its real AS number, announced to its eBGP peer, resulting in an AS path length of two.
-- `password` (String) Password used to secure the BGP session.
+- `password` (String, Sensitive) Password used to secure the BGP session.
 - `routing_policies` (Attributes Map) Map of Routing Policy Primitives to be used with this *Protocol Endpoint*. (see [below for nested schema](#nestedatt--virtual_network_singles--bgp_peering_generic_systems--routing_policies))
 - `ttl` (Number) BGP Time To Live. Omit to use device defaults.
 

--- a/docs/resources/datacenter_connectivity_template_loopback.md
+++ b/docs/resources/datacenter_connectivity_template_loopback.md
@@ -117,7 +117,7 @@ Optional:
 - `keepalive_time` (Number) BGP keepalive time (seconds).
 - `local_asn` (Number) This feature is configured on a per-peer basis. It allows a router to appear to be a member of a second autonomous system (AS) by prepending a local-as AS number, in addition to its real AS number, announced to its eBGP peer, resulting in an AS path length of two.
 - `neighbor_asn` (Number) Neighbor ASN. Omit for *Neighbor ASN Type Dynamic*.
-- `password` (String) Password used to secure the BGP session.
+- `password` (String, Sensitive) Password used to secure the BGP session.
 - `routing_policies` (Attributes Map) Map of Routing Policy Primitives to be used with this *Protocol Endpoint*. (see [below for nested schema](#nestedatt--bgp_peering_ip_endpoints--routing_policies))
 - `ttl` (Number) BGP Time To Live. Omit to use device defaults.
 

--- a/docs/resources/datacenter_connectivity_template_svi.md
+++ b/docs/resources/datacenter_connectivity_template_svi.md
@@ -121,7 +121,7 @@ Optional:
 - `keepalive_time` (Number) BGP keepalive time (seconds).
 - `local_asn` (Number) This feature is configured on a per-peer basis. It allows a router to appear to be a member of a second autonomous system (AS) by prepending a local-as AS number, in addition to its real AS number, announced to its eBGP peer, resulting in an AS path length of two.
 - `neighbor_asn` (Number) Neighbor ASN. Omit for *Neighbor ASN Type Dynamic*.
-- `password` (String) Password used to secure the BGP session.
+- `password` (String, Sensitive) Password used to secure the BGP session.
 - `routing_policies` (Attributes Map) Map of Routing Policy Primitives to be used with this *Protocol Endpoint*. (see [below for nested schema](#nestedatt--bgp_peering_ip_endpoints--routing_policies))
 - `ttl` (Number) BGP Time To Live. Omit to use device defaults.
 
@@ -161,7 +161,7 @@ Optional:
 - `ipv6_peer_prefix` (String) IPv6 Subnet for BGP Prefix Dynamic Neighbors. Leave blank to derive subnet from application point.
 - `keepalive_time` (Number) BGP keepalive time (seconds).
 - `local_asn` (Number) This feature is configured on a per-peer basis. It allows a router to appear to be a member of a second autonomous system (AS) by prepending a local-as AS number, in addition to its real AS number, announced to its eBGP peer, resulting in an AS path length of two.
-- `password` (String) Password used to secure the BGP session.
+- `password` (String, Sensitive) Password used to secure the BGP session.
 - `routing_policies` (Attributes Map) Map of Routing Policy Primitives to be used with this *Protocol Endpoint*. (see [below for nested schema](#nestedatt--dynamic_bgp_peerings--routing_policies))
 - `ttl` (Number) BGP Time To Live. Omit to use device defaults.
 


### PR DESCRIPTION
This PR adds `Sensitive: true` to the three BGP-centric resource building blocks used in Connectivity Template resources.