### PR TITLE
Detect when application point maps in `apstra_datacenter_generic_system` resource need update

### DIFF
--- a/apstra/utils/map.go
+++ b/apstra/utils/map.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"cmp"
+	"slices"
+)
+
+func MapKeys[K comparable, V interface{}](m map[K]V) []K {
+	keys := make([]K, len(m))
+	var i int
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
+func MapKeysSorted[K cmp.Ordered, V interface{}](m map[K]V) []K {
+	keys := MapKeys(m)
+	slices.Sort(keys)
+	return keys
+}

--- a/docs/resources/datacenter_generic_system.md
+++ b/docs/resources/datacenter_generic_system.md
@@ -102,7 +102,7 @@ resource "apstra_datacenter_generic_system" "example" {
 
 - `id` (String) Apstra graph node ID.
 - `link_application_point_ids_by_group_label` (Map of String) Map of application point ids keyed by `group_label`. The value at each key is a string representing the physical or logical (for LAG interfaces) switch port where the server is connected.
-- `link_application_point_ids_by_tag` (Map of Set of String) Map of application point ids keyed by `tag`. The value at each key is a set of strings representing the physical or logical (for LAG interfaces) switch ports where server links tagged with the map key are connected.
+- `link_application_point_ids_by_tag` (Map of Set of String) Map of application point ids keyed by `tag`. The value at each key is a set of strings representing the physical or logical (for LAG interfaces) switch ports where server links tagged with the map key are connected. Note that some link tag related config drift may not be reflected in this attribute until after an `apply` has corrected the drift.
 
 <a id="nestedatt--links"></a>
 ### Nested Schema for `links`


### PR DESCRIPTION
To cut down on unnecessary API calls in the (already time-consuming) `apstra_datacenter_generic_system` resource, the `Read()` method did not invoke `ReadSwitchInterfaceApplicationPoints()`. I thought the mapping was immutable, so calculating those maps was reserved for `Create()` and `Update()`.

But the maps are not immutable.

The most obvious reason: generic systems created with an earlier provider release will have `null` maps. An upgrade should populate this data, even if no config changes or drift detection lead us to `Update()`.

This PR adds out-of-date map detection and map recalculation to the `Read()` function.

There's still a sharp edge here where an added link tag may not be detected and the map corrected during `Read()`. The conditions for this are:

1. Existing server with multiple links.
2. A link tag is present on some link(s) and absent on other link(s)
3. The link tag is added to one of the other links in the terraform config
4. The link tag is added to the link via the Apstra web UI
5. Run `terraform apply`

Because the terraform configuration and API state are in agreement, `Update()` will not be called, and `Read()` won't notice the difference because it's comparing cumulative tags across all links -- not the unique mapping of tags to links.

It's a pretty narrow corner that only comes up with very specific and coordinated config drift. Leaving it for now.

Closes #1079