### PR TITLE
Detect unknown links during plan modification

### DIFF
--- a/apstra/resource_datacenter_generic_system.go
+++ b/apstra/resource_datacenter_generic_system.go
@@ -109,11 +109,24 @@ func (o *resourceDatacenterGenericSystem) ModifyPlan(ctx context.Context, req re
 		return
 	}
 
-	// extract links from plan and state
+	// if possible, extract links from plan and state
+	if plan.Links.IsUnknown() {
+		return
+	}
 	planLinks := plan.GetLinks(ctx, &resp.Diagnostics)
 	stateLinks := state.GetLinks(ctx, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// ensure that each planned link has known values for the attributes we'll be inspecting
+	for _, link := range planLinks {
+		if link.TargetSwitchId.IsUnknown() ||
+			link.TargetSwitchIfName.IsUnknown() ||
+			link.TargetSwitchIfTransformId.IsUnknown() ||
+			link.LagMode.IsUnknown() {
+			return
+		}
 	}
 
 	// digests uniquely identify an endpoint. Make a map for quick lookup by digest


### PR DESCRIPTION
This PR covers a situation where the the `links` set in the `apstra_datacenter_generic_system` resource is either entirely _unknown_, or one link contains a critical _unknown_ attribute during the _update_ lifecycle phase.

Prior to this update, we'd produce an error unpacking `links` or miscalculate the plan due relying on an uninitialized zero value.

With this PR, the plan modifier simply returns (no plan modification) if an unknown value is encountered.

There is still room for improvement: With this change we will not attempt plan modification if _any_ unknown attribute appears. It is possible that we can still make useful plan modifications based on known data, even with some unknown attributes.