### PR TITLE
Resource `apstra_datacenter_virtual_network`: Check for _unknown_ values in `ModifyPlan()`

### DIFF
--- a/apstra/resource_datacenter_virtual_network.go
+++ b/apstra/resource_datacenter_virtual_network.go
@@ -128,7 +128,7 @@ func (o *resourceDatacenterVirtualNetwork) ModifyPlan(ctx context.Context, req r
 	}
 
 	// Updating the routing_zone_id attribute is only permitted with Apstra >= 5.0.0
-	if !plan.RoutingZoneId.Equal(state.RoutingZoneId) {
+	if !plan.RoutingZoneId.IsUnknown() && !plan.RoutingZoneId.Equal(state.RoutingZoneId) {
 		// routing_zone_id attribute has been changed
 		if o.client != nil && compatibility.ChangeVnRzIdForbidden.Check(version.Must(version.NewVersion(o.client.ApiVersion()))) {
 			resp.RequiresReplace.Append(path.Root("routing_zone_id"))


### PR DESCRIPTION
This fixes a bug similar to the one reported in #1110.

In this case, if the planned value for the `routing_zone_id` attribute was _unknown_ in `ModifyPlan()` during the _update_ lifecycle phase, we'd wrongly assume that the value was being modified.