### PR TITLE
Handle CT assignment errors in the `apstra_datacenter_connectivity_template_assignments` resource

### DIFF
--- a/apstra/blueprint/connectivity_template_assignments_test.go
+++ b/apstra/blueprint/connectivity_template_assignments_test.go
@@ -1,0 +1,202 @@
+package blueprint_test
+
+import (
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+func TestTrimSetApplicationPointsConnectivityTemplatesRequestBasedOnError(t *testing.T) {
+	compare := func(t testing.TB, a, b map[apstra.ObjectId]map[apstra.ObjectId]bool) {
+		t.Helper()
+
+		require.Equal(t, len(a), len(b))
+		keysA := maps.Keys(a)
+		keysB := maps.Keys(b)
+		for _, k := range keysA {
+			require.Contains(t, keysB, k)
+			require.Equal(t, len(a[k]), len(b[k]))
+			keysKA := maps.Keys(a[k])
+			keysKB := maps.Keys(b[k])
+			for _, ka := range keysKA {
+				require.Contains(t, keysKB, ka)
+				require.Equal(t, a[k][ka], b[k][ka])
+			}
+		}
+	}
+
+	type testCase struct {
+		request       map[apstra.ObjectId]map[apstra.ObjectId]bool
+		errDetail     apstra.ErrCtAssignmentFailedDetail
+		expected      map[apstra.ObjectId]map[apstra.ObjectId]bool
+		expectedCount int
+	}
+
+	testCases := map[string]testCase{
+		"empty": {
+			request:       map[apstra.ObjectId]map[apstra.ObjectId]bool{},
+			errDetail:     apstra.ErrCtAssignmentFailedDetail{},
+			expected:      map[apstra.ObjectId]map[apstra.ObjectId]bool{},
+			expectedCount: 0,
+		},
+		"none_invalid": {
+			request: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_1": {
+					"ct_id_1": true,
+					"ct_id_2": false,
+				},
+				"ap_id_2": {
+					"ct_id_3": true,
+					"ct_id_4": false,
+				},
+			},
+			errDetail: apstra.ErrCtAssignmentFailedDetail{},
+			expected: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_1": {
+					"ct_id_1": true,
+					"ct_id_2": false,
+				},
+				"ap_id_2": {
+					"ct_id_3": true,
+					"ct_id_4": false,
+				},
+			},
+			expectedCount: 0,
+		},
+		"one_invalid_ap": {
+			request: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_1": { // <--------    this will be removed
+					"ct_id_1": false, // <-- this will be removed
+					"ct_id_2": false, // <-- this will be removed
+				},
+				"ap_id_2": {
+					"ct_id_3": true,
+					"ct_id_4": false,
+				},
+			},
+			errDetail: apstra.ErrCtAssignmentFailedDetail{
+				InvalidApplicationPointIds: []apstra.ObjectId{"ap_id_1"},
+			},
+			expected: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_2": {
+					"ct_id_3": true,
+					"ct_id_4": false,
+				},
+			},
+			expectedCount: 3,
+		},
+		"one_invalid_ct": {
+			request: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_1": {
+					"ct_id_1": false, // <-- this will be removed
+					"ct_id_2": false,
+				},
+				"ap_id_2": {
+					"ct_id_3": true,
+					"ct_id_4": false,
+				},
+			},
+			errDetail: apstra.ErrCtAssignmentFailedDetail{
+				InvalidConnectivityTemplateIds: []apstra.ObjectId{"ct_id_1"},
+			},
+			expected: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_1": {
+					"ct_id_2": false,
+				},
+				"ap_id_2": {
+					"ct_id_3": true,
+					"ct_id_4": false,
+				},
+			},
+			expectedCount: 1,
+		},
+		"one_invalid_ct_used_multiple_times": {
+			request: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_1": {
+					"ct_id_1": false, // <-- this will be removed
+					"ct_id_2": false,
+				},
+				"ap_id_2": {
+					"ct_id_3": true,
+					"ct_id_1": false, // <-- this will be removed
+				},
+			},
+			errDetail: apstra.ErrCtAssignmentFailedDetail{
+				InvalidConnectivityTemplateIds: []apstra.ObjectId{"ct_id_1"},
+			},
+			expected: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_1": {
+					"ct_id_2": false,
+				},
+				"ap_id_2": {
+					"ct_id_3": true,
+				},
+			},
+			expectedCount: 2,
+		},
+		"one_invalid_ct_cannot_be_removed": {
+			request: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_1": {
+					"ct_id_1": true, // <-- this cannot be removed
+					"ct_id_2": false,
+				},
+				"ap_id_2": {
+					"ct_id_3": true,
+					"ct_id_4": false,
+				},
+			},
+			errDetail: apstra.ErrCtAssignmentFailedDetail{
+				InvalidConnectivityTemplateIds: []apstra.ObjectId{"ct_id_1"},
+			},
+			expected: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_1": {
+					"ct_id_1": true,
+					"ct_id_2": false,
+				},
+				"ap_id_2": {
+					"ct_id_3": true,
+					"ct_id_4": false,
+				},
+			},
+			expectedCount: 0,
+		},
+		"one_invalid_ap_cannot_be_removed": {
+			request: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_1": { // <--------    this cannot be removed
+					"ct_id_1": true,  // <-- this cannot be removed
+					"ct_id_2": false, // <-- this will be removed
+				},
+				"ap_id_2": {
+					"ct_id_3": true,
+					"ct_id_4": false,
+				},
+			},
+			errDetail: apstra.ErrCtAssignmentFailedDetail{
+				InvalidApplicationPointIds: []apstra.ObjectId{"ap_id_1"},
+			},
+			expected: map[apstra.ObjectId]map[apstra.ObjectId]bool{
+				"ap_id_1": {
+					"ct_id_1": true,
+				},
+				"ap_id_2": {
+					"ct_id_3": true,
+					"ct_id_4": false,
+				},
+			},
+			expectedCount: 1,
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+
+			i := blueprint.TrimSetApplicationPointsConnectivityTemplatesRequestBasedOnError(tCase.request, &tCase.errDetail)
+			require.Equal(t, tCase.expectedCount, i)
+			compare(t, tCase.expected, tCase.request)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/hashicorp/terraform-plugin-framework-nettypes => github.com/c
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20250612212135-890449ff8fab
+	github.com/Juniper/apstra-go-sdk v0.0.0-20250814185125-ae8596bc8b5d
 	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
 	github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20250612212135-890449ff8fab h1:uWbgq0+A5DrAxj9cu1KH3oCSuRQ7WjhuQrANT2AjrkE=
-github.com/Juniper/apstra-go-sdk v0.0.0-20250612212135-890449ff8fab/go.mod h1:vLQLsexyAAKRtIxwVtdiFtJ99IlZ6HKjnmvdNs27itM=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250814185125-ae8596bc8b5d h1:CMts6WxNqlsiCzf73H5ypwu1fac1WSUovTfsVIqdTsI=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250814185125-ae8596bc8b5d/go.mod h1:vLQLsexyAAKRtIxwVtdiFtJ99IlZ6HKjnmvdNs27itM=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
This PR depends on [SDK #540](https://github.com/Juniper/apstra-go-sdk/pull/540).

Clearing CTs from an application point is an "un-check the box" operation. Sometimes, due to complex operations and timing issues, we might plan to un-check a box which no longer exists by the time we get around to it. ...And you can't un-check a box which doesn't exist.

The "box" (a literal checkbox in the web UI) might not exist because either the Application Point or Connectivity Template associated with the box has been removed. In such a case, there's really no need to un-check these boxes.

This PR uses the new detailed error from the `/api/blueprints/%s/obj-policy-batch-apply` API to detect errors resulting from attempts to un-check non-existent boxes and resubmit the transaction with references to those boxes removed from the request.

Closes #1120