### PR TITLE
Detailed error handling for `apstra_datacenter_connectivity_templates_assignment` resource

### DIFF
--- a/apstra/export_test.go
+++ b/apstra/export_test.go
@@ -23,6 +23,7 @@ var (
 	ResourceDatacenterConnectivityTemplateProtocolEndpoint = resourceDatacenterConnectivityTemplateProtocolEndpoint{}
 	ResourceDatacenterConnectivityTemplateSvi              = resourceDatacenterConnectivityTemplateSvi{}
 	ResourceDatacenterConnectivityTemplateSystem           = resourceDatacenterConnectivityTemplateSystem{}
+	ResourceDatacenterConnectivityTemplatesAssignment      = resourceDatacenterConnectivityTemplatesAssignment{}
 	ResourceDatacenterExternalGateway                      = resourceDatacenterExternalGateway{}
 	ResourceDatacenterGenericSystem                        = resourceDatacenterGenericSystem{}
 	ResourceDatacenterInterconnectDomain                   = resourceDatacenterInterconnectDomain{}

--- a/apstra/resource_datacenter_connectivity_template_assignments.go
+++ b/apstra/resource_datacenter_connectivity_template_assignments.go
@@ -284,7 +284,7 @@ func (o *resourceDatacenterConnectivityTemplateAssignments) Delete(ctx context.C
 			break // success!
 		}
 
-		// err is not nil
+		// err is not nil -- can we parse it?
 		var ace apstra.ClientErr
 		if !errors.As(err, &ace) {
 			resp.Diagnostics.AddError(

--- a/apstra/resource_datacenter_connectivity_templates_assignment.go
+++ b/apstra/resource_datacenter_connectivity_templates_assignment.go
@@ -2,8 +2,10 @@ package tfapstra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"golang.org/x/exp/slices"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -173,26 +175,101 @@ func (o *resourceDatacenterConnectivityTemplatesAssignment) Update(ctx context.C
 	}
 
 	// calculate the add/del sets
-	addIds, delIds := plan.AddDelRequest(ctx, &state, &resp.Diagnostics)
+	addCtIds, delCtIds := plan.AddDelRequest(ctx, &state, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	apId := apstra.ObjectId(plan.ApplicationPointId.ValueString())
+
 	// add any required CTs
-	err = bp.SetApplicationPointConnectivityTemplates(ctx, apstra.ObjectId(plan.ApplicationPointId.ValueString()), addIds)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("failed while assigning Connectivity Templates %s to Application Point %s", plan.ConnectivityTemplateIds, plan.ApplicationPointId),
-			err.Error(),
-		)
-		return
+	if len(addCtIds) > 0 {
+		err = bp.SetApplicationPointConnectivityTemplates(ctx, apId, addCtIds)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("failed while assigning Connectivity Templates %s to Application Point %s", plan.ConnectivityTemplateIds, plan.ApplicationPointId),
+				err.Error(),
+			)
+			return
+		}
 	}
 
-	// clear any undesired CTs
-	err = bp.DelApplicationPointConnectivityTemplates(ctx, apstra.ObjectId(plan.ApplicationPointId.ValueString()), delIds)
-	if err != nil {
-		resp.Diagnostics.AddError("failed clearing connectivity template assignments", err.Error())
-		return
+	// clear any undesired CTs -- and keep trying until we find a reason to stop
+	for {
+		if len(delCtIds) == 0 {
+			break // nothing to do
+		}
+
+		err = bp.DelApplicationPointConnectivityTemplates(ctx, apId, delCtIds)
+		if err == nil {
+			break // success!
+		}
+
+		// the error is not nil -- can we parse it?
+		var ace apstra.ClientErr
+		if !errors.As(err, &ace) {
+			resp.Diagnostics.AddError(
+				"Failed clearing Connectivity Templates assignment and cannot parse error",
+				err.Error(),
+			)
+			break
+		}
+
+		if ace.Type() != apstra.ErrCtAssignmentFailed {
+			// cannot handle this error
+			resp.Diagnostics.AddError(
+				"Failed clearing Connectivity Templates assignment",
+				err.Error(),
+			)
+			break
+		}
+
+		// error is type ErrCtAssignmentFailed
+		errDetail := ace.Detail().(*apstra.ErrCtAssignmentFailedDetail)
+
+		// perhaps the error is complaining about invalid AP IDs?
+		switch len(errDetail.InvalidApplicationPointIds) {
+		case 0: // do nothing because the error doesn't mention AP IDs
+		case 1:
+			if errDetail.InvalidApplicationPointIds[0] == apId {
+				break // our AP doesn't exist. Can't un-check boxes which don't exist, so we're done.
+			} else {
+				resp.Diagnostics.AddError( // weird. the error was about a *different* AP?
+					errApiError,
+					fmt.Sprintf("attempt to delete CTs from node %q elicited an error about node %q",
+						apId,
+						errDetail.InvalidApplicationPointIds[0],
+					),
+				)
+				break
+			}
+		default:
+			resp.Diagnostics.AddError( // weird. the error was about *multiple* APs?
+				errApiError,
+				fmt.Sprintf("attempt to delete CTs from node %q elicited an error about multiple nodes %s",
+					apId,
+					errDetail.InvalidApplicationPointIds,
+				),
+			)
+			break
+		}
+
+		var ctListIsModified bool // we'll try again if this comes up true
+		for _, invalidCtId := range errDetail.InvalidConnectivityTemplateIds {
+			if slices.Contains(delCtIds, invalidCtId) {
+				idx := slices.Index(delCtIds, invalidCtId)
+				delCtIds = slices.Delete(delCtIds, idx, idx+1)
+				ctListIsModified = true
+			}
+		}
+
+		if ctListIsModified {
+			continue // we removed an invalid CT from the list, so try the request again
+		}
+
+		resp.Diagnostics.AddError("failed clearing connectivity templates assignment", err.Error())
+		break
+
 	}
 
 	// Fetch IP link IDs
@@ -237,13 +314,87 @@ func (o *resourceDatacenterConnectivityTemplatesAssignment) Delete(ctx context.C
 		return
 	}
 
-	err = bp.DelApplicationPointConnectivityTemplates(ctx, apstra.ObjectId(state.ApplicationPointId.ValueString()), delIds)
-	if err != nil {
-		if utils.IsApstra404(err) {
-			return // 404 is okay
+	apId := apstra.ObjectId(state.ApplicationPointId.ValueString())
+
+	// attempt to clear CTs from the AP until we find a reason to stop
+	for {
+		if len(delIds) == 0 {
+			break // the request is empty
 		}
-		resp.Diagnostics.AddError("failed clearing connectivity template assignments", err.Error())
-		return
+
+		err = bp.DelApplicationPointConnectivityTemplates(ctx, apId, delIds)
+		if err == nil {
+			break // success!
+		}
+
+		// the error is not nil -- can we parse it?
+		var ace apstra.ClientErr
+		if !errors.As(err, &ace) {
+			resp.Diagnostics.AddError(
+				"Failed clearing Connectivity Templates assignment and cannot parse error",
+				err.Error(),
+			)
+			break
+		}
+
+		if ace.Type() == apstra.ErrNotfound {
+			break // 404 is okay in this context - the blueprint doesn't exist, so there's nothing to do
+		}
+
+		if ace.Type() != apstra.ErrCtAssignmentFailed {
+			// cannot handle this error
+			resp.Diagnostics.AddError(
+				"Failed clearing Connectivity Templates assignment",
+				err.Error(),
+			)
+			break
+		}
+
+		// error is type ErrCtAssignmentFailed
+		errDetail := ace.Detail().(*apstra.ErrCtAssignmentFailedDetail)
+
+		// perhaps the error is complaining about invalid AP IDs?
+		switch len(errDetail.InvalidApplicationPointIds) {
+		case 0: // do nothing because the error doesn't mention AP IDs
+		case 1:
+			if errDetail.InvalidApplicationPointIds[0] == apId {
+				break // our AP doesn't exist. Can't un-check boxes which don't exist, so we're done.
+			} else {
+				resp.Diagnostics.AddError( // weird. the error was about a *different* AP?
+					errApiError,
+					fmt.Sprintf("attempt to delete CTs from node %q elicited an error about node %q",
+						apId,
+						errDetail.InvalidApplicationPointIds[0],
+					),
+				)
+				break
+			}
+		default:
+			resp.Diagnostics.AddError( // weird. the error was about *multiple* APs?
+				errApiError,
+				fmt.Sprintf("attempt to delete CTs from node %q elicited an error about multiple nodes %s",
+					apId,
+					errDetail.InvalidApplicationPointIds,
+				),
+			)
+			break
+		}
+
+		var ctListIsModified bool // we'll try again if this comes up true
+		for _, invalidCtId := range errDetail.InvalidConnectivityTemplateIds {
+			if slices.Contains(delIds, invalidCtId) {
+				idx := slices.Index(delIds, invalidCtId)
+				delIds = slices.Delete(delIds, idx, idx+1)
+				ctListIsModified = true
+			}
+		}
+
+		if ctListIsModified {
+			continue // we removed an invalid CT from the list, so try the request again
+		}
+
+		resp.Diagnostics.AddError("failed clearing connectivity templates assignment", err.Error())
+		break
 	}
 }
 

--- a/apstra/resource_datacenter_connectivity_templates_assignment_integration_test.go
+++ b/apstra/resource_datacenter_connectivity_templates_assignment_integration_test.go
@@ -1,0 +1,172 @@
+//go:build integration
+
+package tfapstra_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
+	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
+	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
+)
+
+const resourceDatacenterConnectivityTemplatesAssignmentTemplateHCL = `
+resource %q %q {
+  blueprint_id              = %q
+  application_point_id      = %q
+  connectivity_template_ids = %s
+  fetch_ip_link_ids         = %s
+}`
+
+type resourceDatacenterConnectivityTemplatesAssignment struct {
+	blueprintId             apstra.ObjectId
+	applicationPointId      apstra.ObjectId
+	connectivityTemplateIds []apstra.ObjectId
+	fetchIpLinkIds          *bool
+}
+
+func (o resourceDatacenterConnectivityTemplatesAssignment) render(rType, rName string) string {
+	return fmt.Sprintf(resourceDatacenterConnectivityTemplatesAssignmentTemplateHCL,
+		rType, rName,
+		o.blueprintId,
+		o.applicationPointId,
+		stringSliceOrNull(o.connectivityTemplateIds),
+		boolPtrOrNull(o.fetchIpLinkIds),
+	)
+}
+
+func (o resourceDatacenterConnectivityTemplatesAssignment) testChecks(t testing.TB, ctx context.Context, rType, rName string, bp *apstra.TwoStageL3ClosClient) testChecks {
+	result := newTestChecks(rType + "." + rName)
+
+	// required and computed attributes can always be checked
+	result.append(t, "TestCheckResourceAttr", "blueprint_id", o.blueprintId.String())
+	result.append(t, "TestCheckResourceAttr", "application_point_id", o.applicationPointId.String())
+	result.append(t, "TestCheckResourceAttr", "connectivity_template_ids.#", strconv.Itoa(len(o.connectivityTemplateIds)))
+
+	for _, connectivityTemplateId := range o.connectivityTemplateIds {
+		result.append(t, "TestCheckTypeSetElemAttr", "connectivity_template_ids.*", connectivityTemplateId.String())
+	}
+
+	if o.fetchIpLinkIds == nil {
+		result.append(t, "TestCheckNoResourceAttr", "fetch_ip_link_ids")
+	} else {
+		result.append(t, "TestCheckResourceAttr", "fetch_ip_link_ids", strconv.FormatBool(*o.fetchIpLinkIds))
+
+		for _, connectivityTemplateId := range o.connectivityTemplateIds {
+			ctVlans := testutils.DatacenterIpLinkConnectivityTemplateVlans(t, ctx, bp, connectivityTemplateId)
+			for _, ctVlan := range ctVlans {
+				result.append(t, "TestCheckResourceAttrSet", fmt.Sprintf(`ip_link_ids.%s.%d`, connectivityTemplateId, ctVlan))
+			}
+		}
+	}
+
+	return result
+}
+
+func TestAccDatacenterConnectivityTemplatesAssignment(t *testing.T) {
+	ctx := context.Background()
+
+	ctCount := 5
+
+	// Create blueprint, routing zones and connectivity templates
+	bp := testutils.BlueprintA(t, ctx)
+	ctIds := make([]apstra.ObjectId, ctCount)
+	for i := range ctIds {
+		szId := testutils.SecurityZoneA(t, ctx, bp, true)
+		ctId := testutils.DatacenterConnectivityTemplateA(t, ctx, bp, szId, 101+i)
+		ctIds[i] = ctId
+	}
+
+	applicationPointIds := testutils.LeafSwitchGenericSystemInterfaces(t, ctx, bp)
+	require.Equal(t, 8, len(applicationPointIds)) // BlueprintA should have 8 single-homed generic systems
+
+	type testCase struct {
+		steps []resourceDatacenterConnectivityTemplatesAssignment
+	}
+
+	testCases := map[string]testCase{
+		"single_one_step": {
+			steps: []resourceDatacenterConnectivityTemplatesAssignment{
+				{
+					blueprintId:             bp.Id(),
+					connectivityTemplateIds: []apstra.ObjectId{ctIds[0]},
+					applicationPointId:      applicationPointIds[0],
+				},
+			},
+		},
+		"multiple_one_step": {
+			steps: []resourceDatacenterConnectivityTemplatesAssignment{
+				{
+					blueprintId:             bp.Id(),
+					connectivityTemplateIds: ctIds,
+					applicationPointId:      applicationPointIds[0],
+				},
+			},
+		},
+		"single_with_fetch": {
+			steps: []resourceDatacenterConnectivityTemplatesAssignment{
+				{
+					blueprintId:             bp.Id(),
+					connectivityTemplateIds: ctIds,
+					applicationPointId:      applicationPointIds[0],
+					fetchIpLinkIds:          utils.ToPtr(true),
+				},
+			},
+		},
+		"simple": {
+			steps: []resourceDatacenterConnectivityTemplatesAssignment{
+				{
+					blueprintId:             bp.Id(),
+					connectivityTemplateIds: ctIds[0:1],
+					applicationPointId:      applicationPointIds[1],
+				},
+				{
+					blueprintId:             bp.Id(),
+					connectivityTemplateIds: ctIds[1:3],
+					applicationPointId:      applicationPointIds[1],
+				},
+				{
+					blueprintId:             bp.Id(),
+					connectivityTemplateIds: ctIds[3:4],
+					applicationPointId:      applicationPointIds[1],
+				},
+			},
+		},
+	}
+
+	resourceType := tfapstra.ResourceName(ctx, &tfapstra.ResourceDatacenterConnectivityTemplatesAssignment)
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			// t.Parallel() // do not use - all test data works with limited set of application points and connectivity templates
+
+			steps := make([]resource.TestStep, len(tCase.steps))
+			for i, step := range tCase.steps {
+				config := step.render(resourceType, tName)
+				checks := step.testChecks(t, ctx, resourceType, tName, bp)
+
+				chkLog := checks.string()
+				stepName := fmt.Sprintf("test case %q step %d", tName, i+1)
+
+				t.Logf("\n// ------ begin config for %s ------\n%s// -------- end config for %s ------\n\n", stepName, config, stepName)
+				t.Logf("\n// ------ begin checks for %s ------\n%s// -------- end checks for %s ------\n\n", stepName, chkLog, stepName)
+
+				steps[i] = resource.TestStep{
+					Config: insecureProviderConfigHCL + config,
+					Check:  resource.ComposeAggregateTestCheckFunc(checks.checks...),
+				}
+			}
+
+			resource.Test(t, resource.TestCase{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps:                    steps,
+			})
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces parsing of the `apstra.ErrCtAssignmentFailedDetail` error detail to the `apstra_datacenter_connectivity_templates_assignment` resource.

It ensures that any failures of un-assignments of Connectivity Templates to Application Points caused by an object having been removed do not surface an error to the user.

In the case of an invalid Application Point ID, the error is ignored. In the case of invalid Connectivity Template IDs, the transaction is retried with any remaining (valid) CT IDs.

Long story short: There's no point in trying to un-check a box which no longer exists.

Also, this PR introduces tests for the `apstra_datacenter_connectivity_templates_assignment` resource.

Closes #1122