### PR TITLE
bump go 1.24.3 -> 1.24.6; bump SDK

### DIFF
--- a/.github/workflows/go_tools.yml
+++ b/.github/workflows/go_tools.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.24.3'
+          go-version: '1.24.6'
 
       - name: go fmt
         run: make gofmt

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/Juniper/terraform-provider-apstra
 
-go 1.24.3
+go 1.24.6
 
 //replace github.com/Juniper/apstra-go-sdk => ../apstra-go-sdk
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20250819171901-813475f05355
+	github.com/Juniper/apstra-go-sdk v0.0.0-20250826132330-334465c4f8cb
 	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
 	github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20250819171901-813475f05355 h1:w2zaxq7WJMOweLpHheWxovbYpQyI//Aohs1jPA/Rvm4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20250819171901-813475f05355/go.mod h1:vLQLsexyAAKRtIxwVtdiFtJ99IlZ6HKjnmvdNs27itM=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250826132330-334465c4f8cb h1:dvcNPSa1Ju9XoSBgvjn/IP4tws153U1fpJSy0Vu1IjE=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250826132330-334465c4f8cb/go.mod h1:dVlfX4xdNyRwYJHn6813nzcekX7S66o6VJXhY/vMQ5o=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
Bump the SDK version to the one rolled back from 1.25.0 to 1.24.6.

Bump our own Go dependency from 1.24.3 to 1.24.6.