### PR TITLE
Update third party license compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,47 +4,7 @@ check-repo-clean:
 	git update-index --refresh && git diff-index --quiet HEAD --
 
 compliance:
-    # golang.org/x/sys ignored to avoid producing different results on different platforms (x/sys vs. x/sys/unix, etc...)
-    # The license details, if it were included in the Third_Party_Code directory, would look something like this, depending
-    # on the build platform:
-
-    ### golang.org/x/sys/unix
-    #
-    #* Name: golang.org/x/sys/unix
-    #* Version: v0.17.0
-    #* License: [BSD-3-Clause](https://cs.opensource.google/go/x/sys/+/v0.17.0:LICENSE)
-    #
-    #
-    #Copyright (c) 2009 The Go Authors. All rights reserved.
-    #
-    #Redistribution and use in source and binary forms, with or without
-    #modification, are permitted provided that the following conditions are
-    #met:
-    #
-    #   * Redistributions of source code must retain the above copyright
-    #notice, this list of conditions and the following disclaimer.
-    #   * Redistributions in binary form must reproduce the above
-    #copyright notice, this list of conditions and the following disclaimer
-    #in the documentation and/or other materials provided with the
-    #distribution.
-    #   * Neither the name of Google Inc. nor the names of its
-    #contributors may be used to endorse or promote products derived from
-    #this software without specific prior written permission.
-    #
-    #THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    #"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    #LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-    #A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-    #OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-    #SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-    #LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-    #DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-    #THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    #(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    #OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-	go run github.com/chrismarget-j/go-licenses save   --ignore github.com/Juniper --ignore golang.org/x/sys --save_path Third_Party_Code --force ./... || exit 1 ;\
-	go run github.com/chrismarget-j/go-licenses report --ignore github.com/Juniper --ignore golang.org/x/sys --template .notices.tpl ./... > Third_Party_Code/NOTICES.md || exit 1 ;\
+	bash scripts/compliance.sh
 
 compliance-check: compliance check-repo-clean
 

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ go 1.24.3
 require (
 	github.com/IBM/netaddr v1.5.0
 	github.com/Juniper/apstra-go-sdk v0.0.0-20250819171901-813475f05355
-	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
 	github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820
 	github.com/google/go-cmp v0.7.0
+	github.com/google/go-licenses/v2 v2.0.0-alpha.1
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
@@ -118,3 +118,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 )
+
+tool github.com/google/go-licenses/v2

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,6 @@ github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTS
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4 h1:nFogSDBo0cmCwO2JX2gl+2onPk4Fw63VreG+HX9U5n0=
-github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4/go.mod h1:RxJksUf3IJIwpKhrrGOUOVD7qQQj1tlJtXYhmsyLVlE=
 github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820 h1:ca2TIBMAj9Czul/4WUN0sLWqn1Wmicm81Ke0m6HR8+s=
 github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820/go.mod h1:lD9yQKzccrnkg2Xx/9kKzrlW9OWP61bRRLjec0l4Wok=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -130,6 +128,8 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-licenses/v2 v2.0.0-alpha.1 h1:2EMzW/1PWYvgOxBXsWl7b350vI0c/kf5Fh7z4AR1skM=
+github.com/google/go-licenses/v2 v2.0.0-alpha.1/go.mod h1:HlMUpsa+mbs8EqdlY0BDfCn0ZK7Y7NQoRCGYhNoox64=
 github.com/google/go-replayers/httpreplay v1.2.0 h1:VM1wEyyjaoU53BwrOnaf9VhAyQQEEioJvFYxYcLRKzk=
 github.com/google/go-replayers/httpreplay v1.2.0/go.mod h1:WahEFFZZ7a1P4VM1qEeHy+tME4bwyqPcwWbNlUI1Mcg=
 github.com/google/licenseclassifier/v2 v2.0.0 h1:1Y57HHILNf4m0ABuMVb6xk4vAJYEUO0gDxNpog0pyeA=

--- a/scripts/compliance.sh
+++ b/scripts/compliance.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TPC=Third_Party_Code
+
+IGNORE=()
+IGNORE+=(--ignore)
+IGNORE+=(github.com/Juniper) # don't bother with Juniper licenses
+IGNORE+=(--ignore)
+IGNORE+=(golang.org/x/sys) # explained below
+
+# golang.org/x/sys is ignored to avoid producing different results on different platforms (x/sys vs. x/sys/unix, etc...)
+# The license details for this package, if they were included in the Third_Party_Code directory, would look something
+# like this, depending on the build platform:
+
+    ### golang.org/x/sys/unix
+    #
+    #* Name: golang.org/x/sys/unix
+    #* Version: v0.17.0
+    #* License: [BSD-3-Clause](https://cs.opensource.google/go/x/sys/+/v0.17.0:LICENSE)
+    #
+    #
+    #Copyright (c) 2009 The Go Authors. All rights reserved.
+    #
+    #Redistribution and use in source and binary forms, with or without
+    #modification, are permitted provided that the following conditions are
+    #met:
+    #
+    #   * Redistributions of source code must retain the above copyright
+    #notice, this list of conditions and the following disclaimer.
+    #   * Redistributions in binary form must reproduce the above
+    #copyright notice, this list of conditions and the following disclaimer
+    #in the documentation and/or other materials provided with the
+    #distribution.
+    #   * Neither the name of Google Inc. nor the names of its
+    #contributors may be used to endorse or promote products derived from
+    #this software without specific prior written permission.
+    #
+    #THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    #"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    #LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    #A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    #OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    #SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    #LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    #DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    #THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    #(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    #OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+go run github.com/google/go-licenses/v2 save   ${IGNORE[@]} --save_path "${TPC}" --force ./...
+go run github.com/google/go-licenses/v2 report ${IGNORE[@]} --template .notices.tpl ./... > "${TPC}/NOTICES.md"
+
+# The `save` command above collects only license and notice files from packages with licenses identified as
+# `RestrictionsShareLicense` and collects the entire source tree when the license is identified as
+# `RestrictionsShareCode`.
+#
+# It's true that some licenses require us to "make available" the upstream source code, but I'm not sure
+# that doing so as *part of this repository* is appropriate.
+# 1. The go package system makes it perfectly clear what we're using and where we got it.
+# 2. If somebody wants to really push the issue, we'll find a way to deliver the source independent of this repository.
+#
+# The line below deletes "saved" files other than those beginning with "LICENSE" and "NOTICE"
+find "$TPC" -type f ! -name 'LICENSE*' ! -name 'NOTICE*' -print0 | xargs -0 rm --
+
+# We now likely have some empty directories. Get rid of 'em.
+find "$TPC" -depth -type d -empty -exec rmdir -- "{}" \;

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -7,7 +7,7 @@ import (
 	_ "github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs"
 
 	// license compliance
-	_ "github.com/chrismarget-j/go-licenses"
+	_ "github.com/google/go-licenses/v2"
 
 	// staticcheck
 	_ "honnef.co/go/tools/cmd/staticcheck"


### PR DESCRIPTION
We'd been using `github.com/chrismarget-j/go-licenses` to collect 3rd party licenses. It is a custom fork of `github.com/google/go-licenses`.

The main difference between them: The fork doesn't collect the 3rd party source code, even when the license might require us to "make available" the source.

This PR drops the dependency on the custom fork and instead uses the latest upstream `github.com/google/go-licenses/v2`.

After running the `save` command, a new script deletes the unwanted source which may have been downloaded, so the end result is the same.