### PR TITLE
Add `Third_Party_Code.zip` to release artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Third_Party_Code.zip
 dist/
 test/terraform.tfstate*
 .testconfig.hcl

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,9 @@ before:
   hooks:
     - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || [ \"$RELEASE_TEST\" = \"1\" ] || (echo must be on branch main; false)"
     - sh -c "[ \"$(env -u GIT_SSH_COMMAND git pull)\" = \"Already up to date.\" ] || [ \"$RELEASE_TEST\" = \"1\" ] || (echo not in sync with origin; false)"
+    - make compliance-with-source
+    - rm -f Third_Party_Code.zip
+    - zip -r Third_Party_Code.zip Third_Party_Code
     - make compliance
     - make docs
     - git update-index --refresh && git diff-index --quiet HEAD --
@@ -39,7 +42,7 @@ archives:
   files:
     - LICENSE
     - README.md
-    - Third_Party_Code/NOTICES.md
+    - Third_Party_Code
 checksum:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
@@ -60,6 +63,8 @@ signs:
       - "${artifact}"
 release:
   extra_files:
+    - glob: 'Third_Party_Code.zip'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_Third_Party_Code.zip'
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # Setting `true` below allows us to manually examine the release before making it live.

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ check-repo-clean:
 	git update-index --refresh && git diff-index --quiet HEAD --
 
 compliance:
+	bash scripts/compliance.sh --minimal
+
+compliance-with-source:
 	bash scripts/compliance.sh
 
 compliance-check: compliance check-repo-clean
@@ -35,6 +38,11 @@ staticcheck:
 release:
 	printenv GITHUB_TOKEN > /dev/null || (echo "GITHUB_TOKEN not found in environment"; false)
 	GPG_FINGERPRINT=4EACB71B2FC20EC8499576BDCB9C922903A66F3F go run github.com/goreleaser/goreleaser@v1.26.2 release --clean
+	git clean -fd Third_Party_Code/
+
+release-dry-run:
+	GPG_FINGERPRINT=4EACB71B2FC20EC8499576BDCB9C922903A66F3F go run github.com/goreleaser/goreleaser@v1.26.2 release --clean --skip-publish
+	git clean -fd Third_Party_Code/
 
 gofumpt:
 	@sh -c "$(CURDIR)/scripts/gofumptcheck.sh"

--- a/scripts/compliance.sh
+++ b/scripts/compliance.sh
@@ -3,6 +3,23 @@ set -euo pipefail
 
 TPC=Third_Party_Code
 
+# Default values
+minimal_mode=false
+
+# Loop over all arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --minimal)
+            minimal_mode=true
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 IGNORE=()
 IGNORE+=(--ignore)
 IGNORE+=(github.com/Juniper) # don't bother with Juniper licenses
@@ -59,10 +76,12 @@ go run github.com/google/go-licenses/v2 report ${IGNORE[@]} --template .notices.
 # It's true that some licenses require us to "make available" the upstream source code, but I'm not sure
 # that doing so as *part of this repository* is appropriate.
 # 1. The go package system makes it perfectly clear what we're using and where we got it.
-# 2. If somebody wants to really push the issue, we'll find a way to deliver the source independent of this repository.
-#
-# The line below deletes "saved" files other than those beginning with "LICENSE" and "NOTICE"
-find "$TPC" -type f ! -name 'LICENSE*' ! -name 'NOTICE*' -print0 | xargs -0 rm --
+# 2. We can deliver those libraries as part of our release .zip files
+if [[ "$minimal_mode" == true ]]; then
+    echo "Removing third party source files."
+    # The line below deletes "saved" files other than those beginning with "LICENSE" and "NOTICE"
+    find "$TPC" -type f ! -name 'LICENSE*' ! -name 'NOTICE*' -print0 | xargs -0 rm --
 
-# We now likely have some empty directories. Get rid of 'em.
-find "$TPC" -depth -type d -empty -exec rmdir -- "{}" \;
+    # We now likely have some empty directories. Get rid of 'em.
+    find "$TPC" -depth -type d -empty -exec rmdir -- "{}" \;
+fi


### PR DESCRIPTION
Prior to this PR we've been keeping in the repository and embedding in the release artifacts a list of 3rd party packages, versions, licenses, etc...

But we have not included the 3rd party source anywhere.

Some of the licenses require us to "make available" that third party code.

This PR introduces a file like `terraform-provider-apstra_x.x.x_Third_Party_Code.zip` to the release artifiacts without adding the ~67MB of source code to our repository or to the zip files indexed by the Terraform/OpenTofu registries.