### PR TITLE
Absorb breaking API change: Package `github.com/Juniper/apstra-go-sdk/apstra/enum` is now `github.com/Juniper/apstra-go-sdk/enum`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Third_Party_Code.zip
 dist/
 test/terraform.tfstate*
 .testconfig.hcl

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,9 @@ before:
   hooks:
     - sh -c "[ \"$(git branch --show-current)\" = \"main\" ] || [ \"$RELEASE_TEST\" = \"1\" ] || (echo must be on branch main; false)"
     - sh -c "[ \"$(env -u GIT_SSH_COMMAND git pull)\" = \"Already up to date.\" ] || [ \"$RELEASE_TEST\" = \"1\" ] || (echo not in sync with origin; false)"
+    - make compliance-with-source
+    - rm -f Third_Party_Code.zip
+    - zip -r Third_Party_Code.zip Third_Party_Code
     - make compliance
     - make docs
     - git update-index --refresh && git diff-index --quiet HEAD --
@@ -39,7 +42,7 @@ archives:
   files:
     - LICENSE
     - README.md
-    - Third_Party_Code/NOTICES.md
+    - Third_Party_Code
 checksum:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
@@ -60,6 +63,8 @@ signs:
       - "${artifact}"
 release:
   extra_files:
+    - glob: 'Third_Party_Code.zip'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_Third_Party_Code.zip'
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # Setting `true` below allows us to manually examine the release before making it live.

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ check-repo-clean:
 	git update-index --refresh && git diff-index --quiet HEAD --
 
 compliance:
+	bash scripts/compliance.sh --minimal
+
+compliance-with-source:
 	bash scripts/compliance.sh
 
 compliance-check: compliance check-repo-clean
@@ -35,6 +38,11 @@ staticcheck:
 release:
 	printenv GITHUB_TOKEN > /dev/null || (echo "GITHUB_TOKEN not found in environment"; false)
 	GPG_FINGERPRINT=4EACB71B2FC20EC8499576BDCB9C922903A66F3F go run github.com/goreleaser/goreleaser@v1.26.2 release --clean
+	git clean -fd Third_Party_Code/
+
+release-dry-run:
+	GPG_FINGERPRINT=4EACB71B2FC20EC8499576BDCB9C922903A66F3F go run github.com/goreleaser/goreleaser@v1.26.2 release --clean --skip-publish
+	git clean -fd Third_Party_Code/
 
 gofumpt:
 	@sh -c "$(CURDIR)/scripts/gofumptcheck.sh"

--- a/Third_Party_Code/NOTICES.md
+++ b/Third_Party_Code/NOTICES.md
@@ -672,8 +672,8 @@ written authorization of the copyright holder.
 ## github.com/chrismarget-j/version-constraints
 
 * Name: github.com/chrismarget-j/version-constraints
-* Version: v0.0.0-20240925155624-26771a0a6820
-* License: [Apache-2.0](https://github.com/chrismarget-j/version-constraints/blob/26771a0a6820/LICENSE)
+* Version: v0.0.0-20250911132047-1122a37b27ae
+* License: [Apache-2.0](https://github.com/chrismarget-j/version-constraints/blob/1122a37b27ae/LICENSE)
 
 ```
 

--- a/apstra/analytics/telemetry_service_registry_entry.go
+++ b/apstra/analytics/telemetry_service_registry_entry.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/blueprint/blueprint.go
+++ b/apstra/blueprint/blueprint.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	apstraplanmodifier "github.com/Juniper/terraform-provider-apstra/apstra/plan_modifier"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/blueprint/configlet_generator.go
+++ b/apstra/blueprint/configlet_generator.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"

--- a/apstra/blueprint/connectivity_template_status.go
+++ b/apstra/blueprint/connectivity_template_status.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
+++ b/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"

--- a/apstra/blueprint/datacenter_generic_system.go
+++ b/apstra/blueprint/datacenter_generic_system.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/design"
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"

--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -6,7 +6,7 @@ import (
 	"net"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/design"
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"

--- a/apstra/blueprint/datacenter_security_policy_rule.go
+++ b/apstra/blueprint/datacenter_security_policy_rule.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"

--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	apiversions "github.com/Juniper/terraform-provider-apstra/apstra/api_versions"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"

--- a/apstra/blueprint/device_allocation_system_attributes.go
+++ b/apstra/blueprint/device_allocation_system_attributes.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"

--- a/apstra/blueprint/external_gateway.go
+++ b/apstra/blueprint/external_gateway.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/iptypes"

--- a/apstra/blueprint/ip_link_addressing.go
+++ b/apstra/blueprint/ip_link_addressing.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/private"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"

--- a/apstra/blueprint/routing_zone_constraint.go
+++ b/apstra/blueprint/routing_zone_constraint.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"

--- a/apstra/blueprint/utils.go
+++ b/apstra/blueprint/utils.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )

--- a/apstra/data_source_blueprint_device_rendered_config.go
+++ b/apstra/data_source_blueprint_device_rendered_config.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"

--- a/apstra/data_source_blueprints.go
+++ b/apstra/data_source_blueprints.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"

--- a/apstra/data_source_configlets.go
+++ b/apstra/data_source_configlets.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"

--- a/apstra/data_source_datacenter_blueprint_test.go
+++ b/apstra/data_source_datacenter_blueprint_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/data_source_datacenter_configlets.go
+++ b/apstra/data_source_datacenter_configlets.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"

--- a/apstra/data_source_datacenter_connectivity_templates_status_integration_test.go
+++ b/apstra/data_source_datacenter_connectivity_templates_status_integration_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/data_source_datacenter_security_policy_test.go
+++ b/apstra/data_source_datacenter_security_policy_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/require"

--- a/apstra/data_source_datacenter_virtual_network_test.go
+++ b/apstra/data_source_datacenter_virtual_network_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/apstra/design/configlet.go
+++ b/apstra/design/configlet.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"

--- a/apstra/design/configlet_generator.go
+++ b/apstra/design/configlet_generator.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"

--- a/apstra/design/rack_type.go
+++ b/apstra/design/rack_type.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"

--- a/apstra/design/rack_type_leaf_switch.go
+++ b/apstra/design/rack_type_leaf_switch.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"

--- a/apstra/freeform/allocation_group.go
+++ b/apstra/freeform/allocation_group.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"

--- a/apstra/freeform/resource.go
+++ b/apstra/freeform/resource.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"

--- a/apstra/freeform/resource_generator.go
+++ b/apstra/freeform/resource_generator.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"

--- a/apstra/iba/widget.gox
+++ b/apstra/iba/widget.gox
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/apstra/private/resource_datacenter_ip_link_addressing.go
+++ b/apstra/private/resource_datacenter_ip_link_addressing.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/apstra/resource_configlet.go
+++ b/apstra/resource_configlet.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/design"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"

--- a/apstra/resource_datacenter_configlet.go
+++ b/apstra/resource_datacenter_configlet.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"

--- a/apstra/resource_datacenter_connectivity_template_primitives_test.go
+++ b/apstra/resource_datacenter_connectivity_template_primitives_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/go-version"

--- a/apstra/resource_datacenter_external_gateway_integration_test.go
+++ b/apstra/resource_datacenter_external_gateway_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/resource_datacenter_generic_system_integration_test.go
+++ b/apstra/resource_datacenter_generic_system_integration_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"

--- a/apstra/resource_datacenter_interconnect_domain_gateway_integration_test.go
+++ b/apstra/resource_datacenter_interconnect_domain_gateway_integration_test.go
@@ -120,7 +120,7 @@ func TestResourceDatacenterInterconnectDomainGateway(t *testing.T) {
 	interconnectDomainIds := make([]apstra.ObjectId, 2)
 	for i := range interconnectDomainIds {
 		id, err := bp.CreateEvpnInterconnectGroup(ctx, &apstra.EvpnInterconnectGroupData{
-			Label:       acctest.RandString(6),
+			Label:       acctest.RandStringFromCharSet(6, acctest.CharSetAlpha),
 			RouteTarget: randomRT(t),
 		})
 		require.NoError(t, err)

--- a/apstra/resource_datacenter_routing_zone_constraint_integration_test.go
+++ b/apstra/resource_datacenter_routing_zone_constraint_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/resource_datacenter_routing_zone_loopback_addresses_integration_test.go
+++ b/apstra/resource_datacenter_routing_zone_loopback_addresses_integration_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/resource_datacenter_security_policy_test.go
+++ b/apstra/resource_datacenter_security_policy_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/go-version"

--- a/apstra/resource_datacenter_virtual_network_integration_test.go
+++ b/apstra/resource_datacenter_virtual_network_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"

--- a/apstra/resource_freeform_allocation_group_integration_test.go
+++ b/apstra/resource_freeform_allocation_group_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/resource_freeform_link_integration_test.go
+++ b/apstra/resource_freeform_link_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/resource_freeform_resource.go
+++ b/apstra/resource_freeform_resource.go
@@ -6,7 +6,7 @@ import (
 	"math"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/freeform"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/resource_freeform_resource_generator.go
+++ b/apstra/resource_freeform_resource_generator.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/freeform"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/apstra/resource_freeform_resource_generator_integraion_test.go
+++ b/apstra/resource_freeform_resource_generator_integraion_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/resource_freeform_resource_integraion_test.go
+++ b/apstra/resource_freeform_resource_integraion_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"

--- a/apstra/resource_freeform_system_integration_test.go
+++ b/apstra/resource_freeform_system_integration_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/hashicorp/go-version"

--- a/apstra/resource_interface_map.go
+++ b/apstra/resource_interface_map.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/go-version"

--- a/apstra/test_utils/blueprint_configlet.go
+++ b/apstra/test_utils/blueprint_configlet.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/stretchr/testify/require"
 )

--- a/apstra/test_utils/rack_type.go
+++ b/apstra/test_utils/rack_type.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/stretchr/testify/require"
 )

--- a/apstra/test_utils/telemetry_service_registry_entry.go
+++ b/apstra/test_utils/telemetry_service_registry_entry.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/stretchr/testify/require"
 )

--- a/apstra/test_utils/virtual_network.go
+++ b/apstra/test_utils/virtual_network.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/stretchr/testify/require"
 )

--- a/apstra/utils/configlets.go
+++ b/apstra/utils/configlets.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 )
 
 func ConfigletSupportsPlatforms(configletdata *apstra.ConfigletData, platforms []enum.ConfigletStyle) bool {

--- a/apstra/utils/freeform_resource.go
+++ b/apstra/utils/freeform_resource.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"sort"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 )
 
 func AllFFResourceTypes() []string {

--- a/apstra/utils/interface_numbering.go
+++ b/apstra/utils/interface_numbering.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"sort"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 )
 
 func AllInterfaceNumberingIpv4Types() []string {

--- a/apstra/utils/node.go
+++ b/apstra/utils/node.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 )
 
 func AllNodeDeployModes() []string {

--- a/apstra/utils/rack_type.go
+++ b/apstra/utils/rack_type.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 )
 
 func FcdModes() []string {

--- a/apstra/utils/resource_pool.go
+++ b/apstra/utils/resource_pool.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"sort"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 )
 
 func AllResourcePoolTypes() []string {

--- a/apstra/utils/rosetta.go
+++ b/apstra/utils/rosetta.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 )
 
 const (

--- a/apstra/utils/rosetta_test.go
+++ b/apstra/utils/rosetta_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 )
 
 func TestRosetta(t *testing.T) {

--- a/apstra/utils/telemetry_service_registry_entry.go
+++ b/apstra/utils/telemetry_service_registry_entry.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"sort"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 )
 
 func AllStorageSchemaPaths() []string {

--- a/apstra/validator/exactly_one_binding_when_vn_type_vlan.go
+++ b/apstra/validator/exactly_one_binding_when_vn_type_vlan.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/apstra/validator/rack_fcd_must_be.go
+++ b/apstra/validator/rack_fcd_must_be.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/apstra/validator/rack_fcd_must_be_when_null.go
+++ b/apstra/validator/rack_fcd_must_be_when_null.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/apstra/validator/rack_fcd_must_be_when_value.go
+++ b/apstra/validator/rack_fcd_must_be_when_value.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,7 @@ go 1.24.6
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20250826132330-334465c4f8cb
-	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
+	github.com/Juniper/apstra-go-sdk v0.0.0-20250907181845-372ec12778b0
 	github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-licenses/v2 v2.0.0-alpha.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.24.6
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20250907181845-372ec12778b0
+	github.com/Juniper/apstra-go-sdk v0.0.0-20250912145523-dc8ad41046bd
 	github.com/chrismarget-j/version-constraints v0.0.0-20250911132047-1122a37b27ae
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-licenses/v2 v2.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ go 1.24.6
 require (
 	github.com/IBM/netaddr v1.5.0
 	github.com/Juniper/apstra-go-sdk v0.0.0-20250907181845-372ec12778b0
-	github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820
+	github.com/chrismarget-j/version-constraints v0.0.0-20250911132047-1122a37b27ae
 	github.com/google/go-cmp v0.7.0
-	github.com/google/go-licenses/v2 v2.0.0-alpha.1
+	github.com/google/go-licenses/v2 v2.0.1
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20250907181845-372ec12778b0 h1:nmOEbKwBXHAu8MXTfKc8QTanTCjFossONAz/mL2RHPw=
-github.com/Juniper/apstra-go-sdk v0.0.0-20250907181845-372ec12778b0/go.mod h1:v+Zzwob0ZJJAsfFdyl+vblKKhHODoNlNh2y2yxkZSVY=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250912145523-dc8ad41046bd h1:xZxBokAGwSIOrT+hLYRxFaXANZUgqRbBVGNEd4a/xJs=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250912145523-dc8ad41046bd/go.mod h1:v+Zzwob0ZJJAsfFdyl+vblKKhHODoNlNh2y2yxkZSVY=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTS
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820 h1:ca2TIBMAj9Czul/4WUN0sLWqn1Wmicm81Ke0m6HR8+s=
-github.com/chrismarget-j/version-constraints v0.0.0-20240925155624-26771a0a6820/go.mod h1:lD9yQKzccrnkg2Xx/9kKzrlW9OWP61bRRLjec0l4Wok=
+github.com/chrismarget-j/version-constraints v0.0.0-20250911132047-1122a37b27ae h1:g/jzomHur4mcZvVcmN9V2fB3BcIUTgqzVdp002U4/3M=
+github.com/chrismarget-j/version-constraints v0.0.0-20250911132047-1122a37b27ae/go.mod h1:OZjTEcYJxi2393c5zsfMTXM+2ymDt9ju0n1X0jZoFPI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
@@ -128,8 +128,8 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-licenses/v2 v2.0.0-alpha.1 h1:2EMzW/1PWYvgOxBXsWl7b350vI0c/kf5Fh7z4AR1skM=
-github.com/google/go-licenses/v2 v2.0.0-alpha.1/go.mod h1:HlMUpsa+mbs8EqdlY0BDfCn0ZK7Y7NQoRCGYhNoox64=
+github.com/google/go-licenses/v2 v2.0.1 h1:ti+9bi5o7DKbeeg5eBb/uZTgsaPNoJaLCh93cRcXsW8=
+github.com/google/go-licenses/v2 v2.0.1/go.mod h1:efibo0EDNGkau6AIMOViGW+rTNPudhxX9rCxtfw5zKE=
 github.com/google/go-replayers/httpreplay v1.2.0 h1:VM1wEyyjaoU53BwrOnaf9VhAyQQEEioJvFYxYcLRKzk=
 github.com/google/go-replayers/httpreplay v1.2.0/go.mod h1:WahEFFZZ7a1P4VM1qEeHy+tME4bwyqPcwWbNlUI1Mcg=
 github.com/google/licenseclassifier/v2 v2.0.0 h1:1Y57HHILNf4m0ABuMVb6xk4vAJYEUO0gDxNpog0pyeA=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20250826132330-334465c4f8cb h1:dvcNPSa1Ju9XoSBgvjn/IP4tws153U1fpJSy0Vu1IjE=
-github.com/Juniper/apstra-go-sdk v0.0.0-20250826132330-334465c4f8cb/go.mod h1:dVlfX4xdNyRwYJHn6813nzcekX7S66o6VJXhY/vMQ5o=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250907181845-372ec12778b0 h1:nmOEbKwBXHAu8MXTfKc8QTanTCjFossONAz/mL2RHPw=
+github.com/Juniper/apstra-go-sdk v0.0.0-20250907181845-372ec12778b0/go.mod h1:v+Zzwob0ZJJAsfFdyl+vblKKhHODoNlNh2y2yxkZSVY=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/scripts/compliance.sh
+++ b/scripts/compliance.sh
@@ -3,6 +3,23 @@ set -euo pipefail
 
 TPC=Third_Party_Code
 
+# Default values
+minimal_mode=false
+
+# Loop over all arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --minimal)
+            minimal_mode=true
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 IGNORE=()
 IGNORE+=(--ignore)
 IGNORE+=(github.com/Juniper) # don't bother with Juniper licenses
@@ -59,10 +76,12 @@ go run github.com/google/go-licenses/v2 report ${IGNORE[@]} --template .notices.
 # It's true that some licenses require us to "make available" the upstream source code, but I'm not sure
 # that doing so as *part of this repository* is appropriate.
 # 1. The go package system makes it perfectly clear what we're using and where we got it.
-# 2. If somebody wants to really push the issue, we'll find a way to deliver the source independent of this repository.
-#
-# The line below deletes "saved" files other than those beginning with "LICENSE" and "NOTICE"
-find "$TPC" -type f ! -name 'LICENSE*' ! -name 'NOTICE*' -print0 | xargs -0 rm --
+# 2. We can deliver those libraries as part of our release .zip files
+if [[ "$minimal_mode" == true ]]; then
+    echo "Removing third party source files."
+    # The line below deletes "saved" files other than those beginning with "LICENSE" and "NOTICE"
+    find "$TPC" -type f ! -name 'LICENSE*' ! -name 'NOTICE*' -print0 | xargs -0 rm --
 
-# We now likely have some empty directories. Get rid of 'em.
-find "$TPC" -depth -type d -empty -exec rmdir -- "{}" \;
+    # We now likely have some empty directories. Get rid of 'em.
+    find "$TPC" -depth -type d -empty -exec rmdir -- "{}" \;
+fi


### PR DESCRIPTION
Package github.com/Juniper/apstra-go-sdk/apstra/enum moved to github.com/Juniper/apstra-go-sdk/enum with https://github.com/Juniper/apstra-go-sdk/pull/573.