### PR TITLE
Introduce `rosetta` package

### DIFF
--- a/apstra/analytics/telemetry_service_registry_entry.go
+++ b/apstra/analytics/telemetry_service_registry_entry.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"strings"
 
-	"github.com/Juniper/apstra-go-sdk/enum"
-
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -73,11 +73,11 @@ func (o TelemetryServiceRegistryEntry) ResourceAttributes() map[string]resourceS
 			Required:            true,
 		},
 		"storage_schema_path": resourceSchema.StringAttribute{
-			MarkdownDescription: "Storage Schema Path. Must be one of:\n  - " + strings.Join([]string{utils.StringersToFriendlyString(enum.StorageSchemaPathIbaStringData), utils.StringersToFriendlyString(enum.StorageSchemaPathIbaIntegerData)}, "\n  - ") + "\n",
+			MarkdownDescription: "Storage Schema Path. Must be one of:\n  - " + strings.Join([]string{rosetta.StringersToFriendlyString(enum.StorageSchemaPathIbaStringData), rosetta.StringersToFriendlyString(enum.StorageSchemaPathIbaIntegerData)}, "\n  - ") + "\n",
 			Required:            true,
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
-				stringvalidator.OneOf(utils.StringersToFriendlyString(enum.StorageSchemaPathIbaStringData), utils.StringersToFriendlyString(enum.StorageSchemaPathIbaIntegerData)),
+				stringvalidator.OneOf(rosetta.StringersToFriendlyString(enum.StorageSchemaPathIbaStringData), rosetta.StringersToFriendlyString(enum.StorageSchemaPathIbaIntegerData)),
 			},
 		},
 		"description": resourceSchema.StringAttribute{
@@ -102,12 +102,12 @@ func (o *TelemetryServiceRegistryEntry) LoadApiData(ctx context.Context, in *aps
 	o.Description = utils.StringValueOrNull(ctx, in.Description, diag)
 	o.Builtin = types.BoolValue(in.Builtin)
 	o.ApplicationSchema = jsontypes.NewNormalizedValue(string(in.ApplicationSchema))
-	o.StorageSchemaPath = types.StringValue(utils.StringersToFriendlyString(in.StorageSchemaPath))
+	o.StorageSchemaPath = types.StringValue(rosetta.StringersToFriendlyString(in.StorageSchemaPath))
 }
 
 func (o *TelemetryServiceRegistryEntry) Request(_ context.Context, diags *diag.Diagnostics) *apstra.TelemetryServiceRegistryEntry {
 	var storageSchemaPath enum.StorageSchemaPath
-	err := utils.ApiStringerFromFriendlyString(&storageSchemaPath, o.StorageSchemaPath.ValueString())
+	err := rosetta.ApiStringerFromFriendlyString(&storageSchemaPath, o.StorageSchemaPath.ValueString())
 	if err != nil {
 		diags.AddError("Failed to Parse Storage Schema Path", err.Error())
 		return nil

--- a/apstra/blueprint/configlet_generator.go
+++ b/apstra/blueprint/configlet_generator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -77,36 +78,36 @@ func (o ConfigletGenerator) ResourceAttributes() map[string]resourceSchema.Attri
 				"e.g. `role in [\"spine_leaf\"]`. Only applies to configlets for sections `%s`, `%s` and `%s`. See "+
 				"references to *Advanced Condition Editor* in the [Apstra User Guide]"+
 				"(https://www.juniper.net/documentation/us/en/software/apstra5.0/apstra-user-guide/topics/task/configlet-import-blueprint.html).",
-				utils.StringersToFriendlyString(enum.ConfigletSectionInterface),
-				utils.StringersToFriendlyString(enum.ConfigletSectionSetBasedInterface),
-				utils.StringersToFriendlyString(enum.ConfigletSectionDeleteBasedInterface),
+				rosetta.StringersToFriendlyString(enum.ConfigletSectionInterface),
+				rosetta.StringersToFriendlyString(enum.ConfigletSectionSetBasedInterface),
+				rosetta.StringersToFriendlyString(enum.ConfigletSectionDeleteBasedInterface),
 			),
 			Optional: true,
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionFile)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionFile)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionFrr)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionFrr)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionOspf)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionOspf)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionSetBasedSystem)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionSetBasedSystem)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionSystem)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionSystem)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionSystemTop)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionSystemTop)),
 				),
 			},
 		},
@@ -130,41 +131,41 @@ func (o ConfigletGenerator) ResourceAttributes() map[string]resourceSchema.Attri
 				// required by section file
 				apstravalidator.RequiredWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionFile)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionFile)),
 				),
 
 				// incompatible with sections other than file
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionDeleteBasedInterface)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionDeleteBasedInterface)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionInterface)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionInterface)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionFrr)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionFrr)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionOspf)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionOspf)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionSetBasedInterface)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionSetBasedInterface)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionSetBasedSystem)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionSetBasedSystem)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionSystem)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionSystem)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionSystemTop)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionSystemTop)),
 				),
 			},
 		},
@@ -183,8 +184,8 @@ func (o ConfigletGenerator) AttrTypes() map[string]attr.Type {
 }
 
 func (o *ConfigletGenerator) LoadApiData(ctx context.Context, in *apstra.ConfigletGenerator, diags *diag.Diagnostics) {
-	o.ConfigStyle = types.StringValue(utils.StringersToFriendlyString(in.ConfigStyle))
-	o.Section = types.StringValue(utils.StringersToFriendlyString(in.Section, in.ConfigStyle))
+	o.ConfigStyle = types.StringValue(rosetta.StringersToFriendlyString(in.ConfigStyle))
+	o.Section = types.StringValue(rosetta.StringersToFriendlyString(in.Section, in.ConfigStyle))
 	o.SectionCondition = utils.StringValueOrNull(ctx, in.SectionCondition, diags)
 	o.TemplateText = types.StringValue(in.TemplateText)
 	o.NegationTemplateText = utils.StringValueOrNull(ctx, in.NegationTemplateText, diags)
@@ -201,7 +202,7 @@ func (o *ConfigletGenerator) Request(_ context.Context, diags *diag.Diagnostics)
 	}
 
 	var section enum.ConfigletSection
-	err = utils.ApiStringerFromFriendlyString(&section, o.Section.ValueString(), o.ConfigStyle.ValueString())
+	err = rosetta.ApiStringerFromFriendlyString(&section, o.Section.ValueString(), o.ConfigStyle.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("error parsing configlet section %q", o.Section.ValueString()), err.Error())
 	}

--- a/apstra/blueprint/connectivity_template_status.go
+++ b/apstra/blueprint/connectivity_template_status.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -51,7 +52,7 @@ func (o ConnectivityTemplateStatus) DataSourceAttributes() map[string]schema.Att
 		"status": schema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf(
 				"Status of the Connectivity Template - One of: [`%s`]",
-				strings.Join(utils.StringersToFriendlyStrings(enum.EndpointPolicyStatuses.Members()), "`, `"),
+				strings.Join(rosetta.StringersToFriendlyStrings(enum.EndpointPolicyStatuses.Members()), "`, `"),
 			),
 			Computed: true,
 		},

--- a/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
+++ b/apstra/blueprint/connectivity_templates/primitives/bgp_peering_generic_sytem.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -115,26 +116,26 @@ func (o BgpPeeringGenericSystem) ResourceAttributes() map[string]resourceSchema.
 		},
 		"ipv4_addressing_type": resourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("Must be one of: \n  - %s\n", strings.Join([]string{
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv4ProtocolSessionAddressingNone),
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv4ProtocolSessionAddressingAddressed),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv4ProtocolSessionAddressingNone),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv4ProtocolSessionAddressingAddressed),
 			}, "\n  - ")),
 			Required: true,
 			Validators: []validator.String{stringvalidator.OneOf(
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv4ProtocolSessionAddressingNone),
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv4ProtocolSessionAddressingAddressed),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv4ProtocolSessionAddressingNone),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv4ProtocolSessionAddressingAddressed),
 			)},
 		},
 		"ipv6_addressing_type": resourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("Must be one of: \n  - %s\n", strings.Join([]string{
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingNone),
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingAddressed),
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingLinkLocal),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingNone),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingAddressed),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingLinkLocal),
 			}, "\n  - ")),
 			Required: true,
 			Validators: []validator.String{stringvalidator.OneOf(
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingNone),
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingAddressed),
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingLinkLocal),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingNone),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingAddressed),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6ProtocolSessionAddressingLinkLocal),
 			)},
 		},
 		"local_asn": resourceSchema.Int64Attribute{
@@ -188,21 +189,21 @@ func (o BgpPeeringGenericSystem) attributes(_ context.Context, diags *diag.Diagn
 	var err error
 
 	var peerTo apstra.CtPrimitiveBgpPeerTo
-	err = utils.ApiStringerFromFriendlyString(&peerTo, o.PeerTo.ValueString())
+	err = rosetta.ApiStringerFromFriendlyString(&peerTo, o.PeerTo.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("failed to parse peer_to value %s", o.PeerTo), err.Error())
 		return nil
 	}
 
 	var sessionAddressingIpv4 apstra.CtPrimitiveIPv4ProtocolSessionAddressing
-	err = utils.ApiStringerFromFriendlyString(&sessionAddressingIpv4, o.Ipv4AddressingType.ValueString())
+	err = rosetta.ApiStringerFromFriendlyString(&sessionAddressingIpv4, o.Ipv4AddressingType.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("failed to parse peer_to value %s", o.Ipv4AddressingType), err.Error())
 		return nil
 	}
 
 	var sessionAddressingIpv6 apstra.CtPrimitiveIPv6ProtocolSessionAddressing
-	err = utils.ApiStringerFromFriendlyString(&sessionAddressingIpv6, o.Ipv6AddressingType.ValueString())
+	err = rosetta.ApiStringerFromFriendlyString(&sessionAddressingIpv6, o.Ipv6AddressingType.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("failed to parse peer_to value %s", o.Ipv6AddressingType), err.Error())
 		return nil
@@ -211,8 +212,8 @@ func (o BgpPeeringGenericSystem) attributes(_ context.Context, diags *diag.Diagn
 	return &apstra.ConnectivityTemplatePrimitiveAttributesAttachBgpOverSubinterfacesOrSvi{
 		Bfd:                   o.BfdEnabled.ValueBool(),
 		Holdtime:              holdTime,
-		Ipv4Safi:              o.Ipv4AddressingType.ValueString() != utils.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNone),
-		Ipv6Safi:              o.Ipv6AddressingType.ValueString() != utils.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNone),
+		Ipv4Safi:              o.Ipv4AddressingType.ValueString() != rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNone),
+		Ipv6Safi:              o.Ipv6AddressingType.ValueString() != rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNone),
 		Keepalive:             keepaliveTime,
 		LocalAsn:              localAsn,
 		NeighborAsnDynamic:    o.NeighborAsnDynamic.ValueBool(),
@@ -272,12 +273,12 @@ func newBgpPeeringGenericSystem(_ context.Context, in *apstra.ConnectivityTempla
 		Password:           types.StringPointerValue(in.Password),
 		KeepaliveTime:      utils.Int64PointerValue(in.Keepalive),
 		HoldTime:           utils.Int64PointerValue(in.Holdtime),
-		Ipv4AddressingType: types.StringValue(utils.StringersToFriendlyString(in.SessionAddressingIpv4)),
-		Ipv6AddressingType: types.StringValue(utils.StringersToFriendlyString(in.SessionAddressingIpv6)),
+		Ipv4AddressingType: types.StringValue(rosetta.StringersToFriendlyString(in.SessionAddressingIpv4)),
+		Ipv6AddressingType: types.StringValue(rosetta.StringersToFriendlyString(in.SessionAddressingIpv6)),
 		// LocalAsn:        // handled below
 		NeighborAsnDynamic: types.BoolValue(in.NeighborAsnDynamic),
 		PeerFromLoopback:   types.BoolValue(in.PeerFromLoopback),
-		PeerTo:             types.StringValue(utils.StringersToFriendlyString(in.PeerTo)),
+		PeerTo:             types.StringValue(rosetta.StringersToFriendlyString(in.PeerTo)),
 		// RoutingPolicies: handled by caller
 	}
 

--- a/apstra/blueprint/connectivity_templates/primitives/ip_link.go
+++ b/apstra/blueprint/connectivity_templates/primitives/ip_link.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -97,29 +98,29 @@ func (o IpLink) ResourceAttributes() map[string]resourceSchema.Attribute {
 		"ipv4_addressing_type": resourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("One of `%s`",
 				strings.Join([]string{
-					utils.StringersToFriendlyString(apstra.CtPrimitiveIPv4AddressingTypeNone),
-					utils.StringersToFriendlyString(apstra.CtPrimitiveIPv4AddressingTypeNumbered),
+					rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv4AddressingTypeNone),
+					rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv4AddressingTypeNumbered),
 				}, "`, `"),
 			),
 			Required: true,
 			Validators: []validator.String{stringvalidator.OneOf(
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv4AddressingTypeNone),
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv4AddressingTypeNumbered),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv4AddressingTypeNone),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv4AddressingTypeNumbered),
 			)},
 		},
 		"ipv6_addressing_type": resourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("One of `%s`",
 				strings.Join([]string{
-					utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeNone),
-					utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeLinkLocal),
-					utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeNumbered),
+					rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeNone),
+					rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeLinkLocal),
+					rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeNumbered),
 				}, "`, `"),
 			),
 			Required: true,
 			Validators: []validator.String{stringvalidator.OneOf(
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeNone),
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeLinkLocal),
-				utils.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeNumbered),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeNone),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeLinkLocal),
+				rosetta.StringersToFriendlyString(apstra.CtPrimitiveIPv6AddressingTypeNumbered),
 			)},
 		},
 		"bgp_peering_generic_systems": resourceSchema.MapNestedAttribute{
@@ -164,14 +165,14 @@ func (o IpLink) attributes(_ context.Context, diags *diag.Diagnostics) *apstra.C
 	var err error
 
 	var ipv4AddressingType apstra.CtPrimitiveIPv4AddressingType
-	err = utils.ApiStringerFromFriendlyString(&ipv4AddressingType, o.Ipv4AddressingType.ValueString())
+	err = rosetta.ApiStringerFromFriendlyString(&ipv4AddressingType, o.Ipv4AddressingType.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("failed to parse ipv4_addressing_type value %s", o.Ipv4AddressingType), err.Error())
 		return nil
 	}
 
 	var ipv6AddressingType apstra.CtPrimitiveIPv6AddressingType
-	err = utils.ApiStringerFromFriendlyString(&ipv6AddressingType, o.Ipv6AddressingType.ValueString())
+	err = rosetta.ApiStringerFromFriendlyString(&ipv6AddressingType, o.Ipv6AddressingType.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("failed to parse ipv6_addressing_type value %s", o.Ipv6AddressingType), err.Error())
 		return nil
@@ -240,8 +241,8 @@ func newIpLink(_ context.Context, in *apstra.ConnectivityTemplatePrimitiveAttrib
 		RoutingZoneId: types.StringPointerValue((*string)(in.SecurityZone)),
 		// VlanId:      // handled below
 		// L3Mtu:       // handled below
-		Ipv4AddressingType: types.StringValue(utils.StringersToFriendlyString(in.IPv4AddressingType)),
-		Ipv6AddressingType: types.StringValue(utils.StringersToFriendlyString(in.IPv6AddressingType)),
+		Ipv4AddressingType: types.StringValue(rosetta.StringersToFriendlyString(in.IPv4AddressingType)),
+		Ipv6AddressingType: types.StringValue(rosetta.StringersToFriendlyString(in.IPv6AddressingType)),
 		// StaticRoutes:             handled by caller
 		// BgpPeeringGenericSystems: handled by caller
 		// BgpPeeringIpEndpoints:    handled by caller

--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -12,6 +12,7 @@ import (
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -309,7 +310,7 @@ func (o *DatacenterRoutingZone) Request(ctx context.Context, client *apstra.Clie
 		diags.AddAttributeError(
 			path.Root("blueprint_id"),
 			constants.ErrInvalidConfig,
-			fmt.Sprintf("cannot create routing zone in blueprints with overlay control protocol %q", utils.StringersToFriendlyString(ocp)))
+			fmt.Sprintf("cannot create routing zone in blueprints with overlay control protocol %q", rosetta.StringersToFriendlyString(ocp)))
 	}
 
 	var importRTs, exportRTs []string

--- a/apstra/blueprint/datacenter_security_policy_rule.go
+++ b/apstra/blueprint/datacenter_security_policy_rule.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -70,8 +71,8 @@ func (o DatacenterSecurityPolicyRule) DataSourceAttributes() map[string]dataSour
 		"source_ports": dataSourceSchema.SetNestedAttribute{
 			MarkdownDescription: fmt.Sprintf("Set of TCP/UDP source ports matched by this rule. A `null` "+
 				"set matches any port. Applies only when `protocol` is `%s` or `%s`.",
-				utils.StringersToFriendlyString(enum.PolicyRuleProtocolTcp),
-				utils.StringersToFriendlyString(enum.PolicyRuleProtocolUdp),
+				rosetta.StringersToFriendlyString(enum.PolicyRuleProtocolTcp),
+				rosetta.StringersToFriendlyString(enum.PolicyRuleProtocolUdp),
 			),
 			Computed: true,
 			NestedObject: dataSourceSchema.NestedAttributeObject{
@@ -81,8 +82,8 @@ func (o DatacenterSecurityPolicyRule) DataSourceAttributes() map[string]dataSour
 		"destination_ports": dataSourceSchema.SetNestedAttribute{
 			MarkdownDescription: fmt.Sprintf("Set of TCP/UDP destination ports matched by this rule. A `null` "+
 				"set matches any port. Applies only when `protocol` is `%s` or `%s`.",
-				utils.StringersToFriendlyString(enum.PolicyRuleProtocolTcp),
-				utils.StringersToFriendlyString(enum.PolicyRuleProtocolUdp),
+				rosetta.StringersToFriendlyString(enum.PolicyRuleProtocolTcp),
+				rosetta.StringersToFriendlyString(enum.PolicyRuleProtocolUdp),
 			),
 			Computed: true,
 			NestedObject: dataSourceSchema.NestedAttributeObject{
@@ -178,8 +179,8 @@ func (o DatacenterSecurityPolicyRule) ResourceAttributes() map[string]resourceSc
 		"source_ports": resourceSchema.SetNestedAttribute{
 			MarkdownDescription: fmt.Sprintf("Set of TCP/UDP source ports matched by this rule. A `null` "+
 				"set matches any port. Valid only when `protocol` is `%s` or `%s`.",
-				utils.StringersToFriendlyString(enum.PolicyRuleProtocolTcp),
-				utils.StringersToFriendlyString(enum.PolicyRuleProtocolUdp),
+				rosetta.StringersToFriendlyString(enum.PolicyRuleProtocolTcp),
+				rosetta.StringersToFriendlyString(enum.PolicyRuleProtocolUdp),
 			),
 			Optional: true,
 			Validators: []validator.Set{
@@ -193,8 +194,8 @@ func (o DatacenterSecurityPolicyRule) ResourceAttributes() map[string]resourceSc
 		"destination_ports": resourceSchema.SetNestedAttribute{
 			MarkdownDescription: fmt.Sprintf("Set of TCP/UDP destination ports matched by this rule. A `null` "+
 				"set matches any port. Valid only when `protocol` is `%s` or `%s`.",
-				utils.StringersToFriendlyString(enum.PolicyRuleProtocolTcp),
-				utils.StringersToFriendlyString(enum.PolicyRuleProtocolUdp),
+				rosetta.StringersToFriendlyString(enum.PolicyRuleProtocolTcp),
+				rosetta.StringersToFriendlyString(enum.PolicyRuleProtocolUdp),
 			),
 			Optional: true,
 			Validators: []validator.Set{
@@ -237,7 +238,7 @@ func (o *DatacenterSecurityPolicyRule) loadApiData(ctx context.Context, in *apst
 
 	o.Name = types.StringValue(in.Label)
 	o.Description = utils.StringValueOrNull(ctx, in.Description, diags)
-	o.Protocol = types.StringValue(utils.StringersToFriendlyString(in.Protocol))
+	o.Protocol = types.StringValue(rosetta.StringersToFriendlyString(in.Protocol))
 	o.Action = types.StringValue(in.Action.Value)
 	o.SrcPorts = newDatacenterPolicyRulePortRangeSet(ctx, in.SrcPort, diags)
 	o.DstPorts = newDatacenterPolicyRulePortRangeSet(ctx, in.DstPort, diags)
@@ -246,7 +247,7 @@ func (o *DatacenterSecurityPolicyRule) loadApiData(ctx context.Context, in *apst
 
 func (o *DatacenterSecurityPolicyRule) request(ctx context.Context, path path.Path, diags *diag.Diagnostics) *apstra.PolicyRuleData {
 	var protocol enum.PolicyRuleProtocol
-	err := utils.ApiStringerFromFriendlyString(&protocol, o.Protocol.ValueString())
+	err := rosetta.ApiStringerFromFriendlyString(&protocol, o.Protocol.ValueString())
 	if err != nil {
 		diags.AddAttributeError(path, fmt.Sprintf("failed to parse policy rule protocol %s", o.Protocol), err.Error())
 		return nil

--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -16,6 +16,7 @@ import (
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -374,7 +375,7 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 			MarkdownDescription: fmt.Sprintf("EVPN Virtual Network ID to be associated with this Virtual "+
 				"Network.  When omitted, Apstra chooses a VNI from the Resource Pool [allocated]"+
 				"(../resources/datacenter_resource_pool_allocation) to role `%s`.",
-				utils.StringersToFriendlyString(apstra.ResourceGroupNameVxlanVnIds)),
+				rosetta.StringersToFriendlyString(apstra.ResourceGroupNameVxlanVnIds)),
 			Optional: true,
 			Computed: true,
 			Validators: []validator.Int64{

--- a/apstra/blueprint/device_allocation_system_attributes.go
+++ b/apstra/blueprint/device_allocation_system_attributes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -309,7 +310,7 @@ func (o *DeviceAllocationSystemAttributes) getProperties(ctx context.Context, bp
 	}
 
 	if !utils.HasValue(o.DeployMode) {
-		o.DeployMode = types.StringValue(utils.StringersToFriendlyString(deployMode))
+		o.DeployMode = types.StringValue(rosetta.StringersToFriendlyString(deployMode))
 	}
 	if !utils.HasValue(o.Hostname) {
 		o.Hostname = types.StringValue(node.Hostname)
@@ -511,7 +512,7 @@ func (o *DeviceAllocationSystemAttributes) setProperties(ctx context.Context, bp
 
 	if utils.HasValue(o.DeployMode) {
 		var deployMode enum.DeployMode
-		err := utils.ApiStringerFromFriendlyString(&deployMode, o.DeployMode.ValueString())
+		err := rosetta.ApiStringerFromFriendlyString(&deployMode, o.DeployMode.ValueString())
 		if err != nil {
 			diags.AddError(fmt.Sprintf("error in rosetta function with deploy_mode = %s", o.DeployMode), err.Error())
 			return

--- a/apstra/blueprint/ip_link_addressing.go
+++ b/apstra/blueprint/ip_link_addressing.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Juniper/terraform-provider-apstra/apstra/private"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -57,7 +58,7 @@ func (o IpLinkAddressing) ResourceAttributes() map[string]resourceSchema.Attribu
 			MarkdownDescription: fmt.Sprintf("Allowed values: [`%s`]", strings.Join(utils.AllInterfaceNumberingIpv4Types(), "`,`")),
 			Optional:            true,
 			Computed:            true,
-			Default:             stringdefault.StaticString(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNone)),
+			Default:             stringdefault.StaticString(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNone)),
 			Validators:          []validator.String{stringvalidator.OneOf(utils.AllInterfaceNumberingIpv4Types()...)},
 		},
 		"switch_ipv4_address": resourceSchema.StringAttribute{
@@ -65,8 +66,8 @@ func (o IpLinkAddressing) ResourceAttributes() map[string]resourceSchema.Attribu
 			Optional:            true,
 			CustomType:          cidrtypes.IPv4PrefixType{},
 			Validators: []validator.String{
-				apstravalidator.RequiredWhenValueIs(path.MatchRoot("switch_ipv4_address_type"), types.StringValue(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNumbered))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("switch_ipv4_address_type"), types.StringValue(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNone))),
+				apstravalidator.RequiredWhenValueIs(path.MatchRoot("switch_ipv4_address_type"), types.StringValue(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNumbered))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("switch_ipv4_address_type"), types.StringValue(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNone))),
 				stringvalidator.AlsoRequires(path.MatchRoot("switch_ipv4_address_type")),
 			},
 		},
@@ -74,7 +75,7 @@ func (o IpLinkAddressing) ResourceAttributes() map[string]resourceSchema.Attribu
 			MarkdownDescription: fmt.Sprintf("Allowed values: [`%s`]", strings.Join(utils.AllInterfaceNumberingIpv6Types(), "`,`")),
 			Optional:            true,
 			Computed:            true,
-			Default:             stringdefault.StaticString(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNone)),
+			Default:             stringdefault.StaticString(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNone)),
 			Validators:          []validator.String{stringvalidator.OneOf(utils.AllInterfaceNumberingIpv6Types()...)},
 		},
 		"switch_ipv6_address": resourceSchema.StringAttribute{
@@ -82,9 +83,9 @@ func (o IpLinkAddressing) ResourceAttributes() map[string]resourceSchema.Attribu
 			Optional:            true,
 			CustomType:          cidrtypes.IPv6PrefixType{},
 			Validators: []validator.String{
-				apstravalidator.RequiredWhenValueIs(path.MatchRoot("switch_ipv6_address_type"), types.StringValue(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNumbered))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("switch_ipv6_address_type"), types.StringValue(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNone))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("switch_ipv6_address_type"), types.StringValue(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeLinkLocal))),
+				apstravalidator.RequiredWhenValueIs(path.MatchRoot("switch_ipv6_address_type"), types.StringValue(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNumbered))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("switch_ipv6_address_type"), types.StringValue(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNone))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("switch_ipv6_address_type"), types.StringValue(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeLinkLocal))),
 				stringvalidator.AlsoRequires(path.MatchRoot("switch_ipv6_address_type")),
 			},
 		},
@@ -92,7 +93,7 @@ func (o IpLinkAddressing) ResourceAttributes() map[string]resourceSchema.Attribu
 			MarkdownDescription: fmt.Sprintf("Allowed values: [`%s`]", strings.Join(utils.AllInterfaceNumberingIpv4Types(), "`,`")),
 			Optional:            true,
 			Computed:            true,
-			Default:             stringdefault.StaticString(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNone)),
+			Default:             stringdefault.StaticString(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNone)),
 			Validators:          []validator.String{stringvalidator.OneOf(utils.AllInterfaceNumberingIpv4Types()...)},
 		},
 		"generic_ipv4_address": resourceSchema.StringAttribute{
@@ -100,8 +101,8 @@ func (o IpLinkAddressing) ResourceAttributes() map[string]resourceSchema.Attribu
 			Optional:            true,
 			CustomType:          cidrtypes.IPv4PrefixType{},
 			Validators: []validator.String{
-				apstravalidator.RequiredWhenValueIs(path.MatchRoot("generic_ipv4_address_type"), types.StringValue(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNumbered))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("generic_ipv4_address_type"), types.StringValue(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNone))),
+				apstravalidator.RequiredWhenValueIs(path.MatchRoot("generic_ipv4_address_type"), types.StringValue(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNumbered))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("generic_ipv4_address_type"), types.StringValue(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv4TypeNone))),
 				stringvalidator.AlsoRequires(path.MatchRoot("generic_ipv4_address_type")),
 			},
 		},
@@ -109,7 +110,7 @@ func (o IpLinkAddressing) ResourceAttributes() map[string]resourceSchema.Attribu
 			MarkdownDescription: fmt.Sprintf("Allowed values: [`%s`]", strings.Join(utils.AllInterfaceNumberingIpv6Types(), "`,`")),
 			Optional:            true,
 			Computed:            true,
-			Default:             stringdefault.StaticString(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNone)),
+			Default:             stringdefault.StaticString(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNone)),
 			Validators:          []validator.String{stringvalidator.OneOf(utils.AllInterfaceNumberingIpv6Types()...)},
 		},
 		"generic_ipv6_address": resourceSchema.StringAttribute{
@@ -117,9 +118,9 @@ func (o IpLinkAddressing) ResourceAttributes() map[string]resourceSchema.Attribu
 			Optional:            true,
 			CustomType:          cidrtypes.IPv6PrefixType{},
 			Validators: []validator.String{
-				apstravalidator.RequiredWhenValueIs(path.MatchRoot("generic_ipv6_address_type"), types.StringValue(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNumbered))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("generic_ipv6_address_type"), types.StringValue(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNone))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("generic_ipv6_address_type"), types.StringValue(utils.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeLinkLocal))),
+				apstravalidator.RequiredWhenValueIs(path.MatchRoot("generic_ipv6_address_type"), types.StringValue(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNumbered))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("generic_ipv6_address_type"), types.StringValue(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeNone))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("generic_ipv6_address_type"), types.StringValue(rosetta.StringersToFriendlyString(enum.InterfaceNumberingIpv6TypeLinkLocal))),
 				stringvalidator.AlsoRequires(path.MatchRoot("generic_ipv6_address_type")),
 			},
 		},
@@ -130,14 +131,14 @@ func requestEndpoint(v4type, v6type types.String, v4addr cidrtypes.IPv4Prefix, v
 	var result apstra.TwoStageL3ClosSubinterface
 
 	if !v4type.IsNull() {
-		err := utils.ApiStringerFromFriendlyString(&result.Ipv4AddrType, v4type.ValueString())
+		err := rosetta.ApiStringerFromFriendlyString(&result.Ipv4AddrType, v4type.ValueString())
 		if err != nil {
 			diags.AddAttributeError(path.Root(attrPrefix+"_ipv4_address_type"), "Cannot parse ipv4 address type", err.Error())
 		}
 	}
 
 	if !v6type.IsNull() {
-		err := utils.ApiStringerFromFriendlyString(&result.Ipv6AddrType, v6type.ValueString())
+		err := rosetta.ApiStringerFromFriendlyString(&result.Ipv6AddrType, v6type.ValueString())
 		if err != nil {
 			diags.AddAttributeError(path.Root(attrPrefix+"_ipv6_address_type"), "Cannot parse ipv6 address type", err.Error())
 		}
@@ -230,23 +231,23 @@ func (o *IpLinkAddressing) LoadApiData(_ context.Context, in *apstra.TwoStageL3C
 	}
 
 	// load the API data from each endpoint
-	o.SwitchIpv4Type = types.StringValue(utils.StringersToFriendlyString(switchEp.Subinterface.Ipv4AddrType))
+	o.SwitchIpv4Type = types.StringValue(rosetta.StringersToFriendlyString(switchEp.Subinterface.Ipv4AddrType))
 	o.SwitchIpv4Addr = cidrtypes.NewIPv4PrefixNull()
 	if switchEp.Subinterface.Ipv4Addr != nil {
 		o.SwitchIpv4Addr = cidrtypes.NewIPv4PrefixValue(switchEp.Subinterface.Ipv4Addr.String())
 	}
-	o.SwitchIpv6Type = types.StringValue(utils.StringersToFriendlyString(switchEp.Subinterface.Ipv6AddrType))
+	o.SwitchIpv6Type = types.StringValue(rosetta.StringersToFriendlyString(switchEp.Subinterface.Ipv6AddrType))
 	o.SwitchIpv6Addr = cidrtypes.NewIPv6PrefixNull()
 	if switchEp.Subinterface.Ipv6Addr != nil {
 		o.SwitchIpv6Addr = cidrtypes.NewIPv6PrefixValue(switchEp.Subinterface.Ipv6Addr.String())
 	}
 
-	o.GenericIpv4Type = types.StringValue(utils.StringersToFriendlyString(genericEp.Subinterface.Ipv4AddrType))
+	o.GenericIpv4Type = types.StringValue(rosetta.StringersToFriendlyString(genericEp.Subinterface.Ipv4AddrType))
 	o.GenericIpv4Addr = cidrtypes.NewIPv4PrefixNull()
 	if genericEp.Subinterface.Ipv4Addr != nil {
 		o.GenericIpv4Addr = cidrtypes.NewIPv4PrefixValue(genericEp.Subinterface.Ipv4Addr.String())
 	}
-	o.GenericIpv6Type = types.StringValue(utils.StringersToFriendlyString(genericEp.Subinterface.Ipv6AddrType))
+	o.GenericIpv6Type = types.StringValue(rosetta.StringersToFriendlyString(genericEp.Subinterface.Ipv6AddrType))
 	o.GenericIpv6Addr = cidrtypes.NewIPv6PrefixNull()
 	if genericEp.Subinterface.Ipv6Addr != nil {
 		o.GenericIpv6Addr = cidrtypes.NewIPv6PrefixValue(genericEp.Subinterface.Ipv6Addr.String())

--- a/apstra/blueprint/pool_allocation.go
+++ b/apstra/blueprint/pool_allocation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -44,7 +45,7 @@ func (o PoolAllocation) ResourceAttributes() map[string]resourceSchema.Attribute
 		// use two strategies when parsing the state value to apstra.ResourceGroupName
 		err = state.FromString(req.StateValue.ValueString())
 		if err != nil {
-			err = utils.ApiStringerFromFriendlyString(&state, req.StateValue.ValueString())
+			err = rosetta.ApiStringerFromFriendlyString(&state, req.StateValue.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError(fmt.Sprintf("failed to parse state value %q", req.StateValue.ValueString()), err.Error())
 				return
@@ -54,7 +55,7 @@ func (o PoolAllocation) ResourceAttributes() map[string]resourceSchema.Attribute
 		// use two strategies when parsing the plan value to apstra.ResourceGroupName
 		err = plan.FromString(req.PlanValue.ValueString())
 		if err != nil {
-			err = utils.ApiStringerFromFriendlyString(&plan, req.PlanValue.ValueString())
+			err = rosetta.ApiStringerFromFriendlyString(&plan, req.PlanValue.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError(fmt.Sprintf("failed to parse plan value %q", req.PlanValue.ValueString()), err.Error())
 				return
@@ -129,7 +130,7 @@ func (o *PoolAllocation) LoadApiData(ctx context.Context, in *apstra.ResourceGro
 func (o *PoolAllocation) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.ResourceGroupAllocation {
 	// Parse 'role' into a ResourceGroupName
 	var rgName apstra.ResourceGroupName
-	err := utils.ApiStringerFromFriendlyString(&rgName, o.Role.ValueString())
+	err := rosetta.ApiStringerFromFriendlyString(&rgName, o.Role.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("error parsing role %q", o.Role.ValueString()), err.Error())
 		return nil

--- a/apstra/blueprint/routing_zone_constraint.go
+++ b/apstra/blueprint/routing_zone_constraint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -64,9 +65,9 @@ func (o DatacenterRoutingZoneConstraint) DataSourceAttributes() map[string]dataS
 			MarkdownDescription: fmt.Sprintf(
 				"Routing Zone constraint mode. One of: %s.", strings.Join(
 					[]string{
-						"`" + utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow) + "`",
-						"`" + utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeDeny) + "`",
-						"`" + utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone) + "`",
+						"`" + rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow) + "`",
+						"`" + rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeDeny) + "`",
+						"`" + rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone) + "`",
 					}, ", "),
 			),
 			Computed: true,
@@ -75,7 +76,7 @@ func (o DatacenterRoutingZoneConstraint) DataSourceAttributes() map[string]dataS
 			MarkdownDescription: fmt.Sprintf("When `%s` instance constraint mode is chosen, only VNs from selected "+
 				"Routing Zones are allowed to have endpoints on the interface(s) the policy is applied to. The permitted "+
 				"Routing Zones may be specified directly or indirectly (via Routing Zone Groups)",
-				utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow),
+				rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow),
 			),
 			Computed:    true,
 			ElementType: types.StringType,
@@ -105,16 +106,16 @@ func (o DatacenterRoutingZoneConstraint) DataSourceFilterAttributes() map[string
 			MarkdownDescription: fmt.Sprintf(
 				"Routing Zone constraint mode. One of: %s.", strings.Join(
 					[]string{
-						"`" + utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow) + "`",
-						"`" + utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeDeny) + "`",
-						"`" + utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone) + "`",
+						"`" + rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow) + "`",
+						"`" + rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeDeny) + "`",
+						"`" + rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone) + "`",
 					}, ", "),
 			),
 			Optional: true,
 			Validators: []validator.String{stringvalidator.OneOf( // validated b/c this runs through rosetta
-				utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow),
-				utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeDeny),
-				utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone),
+				rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow),
+				rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeDeny),
+				rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone),
 			)},
 		},
 		"constraints": dataSourceSchema.SetAttribute{
@@ -156,29 +157,29 @@ func (o DatacenterRoutingZoneConstraint) ResourceAttributes() map[string]resourc
 				"- `%s` - only allow the specified routing zones (add specific routing zones to allow)\n"+
 				"- `%s` - denies allocation of specified routing zones (add specific routing zones to deny)\n"+
 				"- `%s` - no additional constraints on routing zones (any routing zones)",
-				utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow),
-				utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeDeny),
-				utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone),
+				rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow),
+				rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeDeny),
+				rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone),
 			),
 			Required: true,
 			Validators: []validator.String{stringvalidator.OneOf(
-				utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow),
-				utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeDeny),
-				utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone),
+				rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow),
+				rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeDeny),
+				rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone),
 			)},
 		},
 		"constraints": resourceSchema.SetAttribute{
 			MarkdownDescription: fmt.Sprintf("When `%s` instance constraint mode is chosen, only VNs from selected "+
 				"Routing Zones are allowed to have endpoints on the interface(s) the policy is applied to. The permitted "+
 				"Routing Zones may be specified directly or indirectly (via Routing Zone Groups)",
-				utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow),
+				rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeAllow),
 			),
 			Optional:    true,
 			ElementType: types.StringType,
 			Validators: []validator.Set{
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRoot("routing_zones_list_constraint"),
-					types.StringValue(utils.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.RoutingZoneConstraintModeNone)),
 				),
 			},
 		},
@@ -191,7 +192,7 @@ func (o DatacenterRoutingZoneConstraint) Request(ctx context.Context, diags *dia
 	}
 
 	// set result.Mode
-	err := utils.ApiStringerFromFriendlyString(&result.Mode, o.RoutingZonesListConstraint.ValueString())
+	err := rosetta.ApiStringerFromFriendlyString(&result.Mode, o.RoutingZonesListConstraint.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("failed converting %s to API type", o.RoutingZonesListConstraint), err.Error())
 		return nil
@@ -236,7 +237,7 @@ func (o DatacenterRoutingZoneConstraint) Query(ctx context.Context, rzcResultNam
 	// add the mode to the match, if any
 	if !o.RoutingZonesListConstraint.IsNull() {
 		var rzcm enum.RoutingZoneConstraintMode
-		err := utils.ApiStringerFromFriendlyString(&rzcm, o.RoutingZonesListConstraint.ValueString())
+		err := rosetta.ApiStringerFromFriendlyString(&rzcm, o.RoutingZonesListConstraint.ValueString())
 		if err != nil {
 			diags.AddError(fmt.Sprintf("failed converting %s to API type", o.RoutingZonesListConstraint), err.Error())
 			return nil

--- a/apstra/blueprint/utils.go
+++ b/apstra/blueprint/utils.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/enum"
-	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
@@ -49,7 +49,7 @@ func friendlyPolicyRuleProtocols() []string {
 	friendlyStrings := make([]string, len(enums))
 
 	for i, enum := range enums {
-		friendlyStrings[i] = utils.StringersToFriendlyString(enum)
+		friendlyStrings[i] = rosetta.StringersToFriendlyString(enum)
 	}
 
 	return friendlyStrings

--- a/apstra/data_source_blueprints.go
+++ b/apstra/data_source_blueprints.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/enum"
-	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -44,7 +44,7 @@ func (o *dataSourceBlueprints) Schema(_ context.Context, _ datasource.SchemaRequ
 				MarkdownDescription: "Optional filter to select only Blueprints matching the specified Reference Design.",
 				Optional:            true,
 				Validators: []validator.String{stringvalidator.OneOf(
-					utils.StringersToFriendlyString(enum.RefDesignDatacenter),
+					rosetta.StringersToFriendlyString(enum.RefDesignDatacenter),
 					enum.RefDesignFreeform.String(),
 				)},
 			},
@@ -78,7 +78,7 @@ func (o *dataSourceBlueprints) Read(ctx context.Context, req datasource.ReadRequ
 		}
 
 		for _, bpStatus := range bpStatuses {
-			if utils.StringersToFriendlyString(bpStatus.Design) == config.RefDesign.ValueString() {
+			if rosetta.StringersToFriendlyString(bpStatus.Design) == config.RefDesign.ValueString() {
 				ids = append(ids, bpStatus.Id)
 			}
 		}

--- a/apstra/data_source_telemetry_service_registry_entry_test.go
+++ b/apstra/data_source_telemetry_service_registry_entry_test.go
@@ -9,6 +9,7 @@ import (
 
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -53,7 +54,7 @@ func TestAccDataSourceTelemetryServiceRegistryEntry(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify data source/resource fields match
 					resource.TestCheckResourceAttr("data.apstra_telemetry_service_registry_entry.test", "name", ts.ServiceName),
-					resource.TestCheckResourceAttr("data.apstra_telemetry_service_registry_entry.test", "storage_schema_path", utils.StringersToFriendlyString(ts.StorageSchemaPath)),
+					resource.TestCheckResourceAttr("data.apstra_telemetry_service_registry_entry.test", "storage_schema_path", rosetta.StringersToFriendlyString(ts.StorageSchemaPath)),
 					resource.TestCheckResourceAttrWith("data.apstra_telemetry_service_registry_entry.test", "application_schema", TestAppSchema),
 				),
 			},

--- a/apstra/design/configlet_generator.go
+++ b/apstra/design/configlet_generator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -87,35 +88,35 @@ func (o ConfigletGenerator) ResourceAttributesNested() map[string]resourceSchema
 				// incompatible with sections other than file
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionDeleteBasedInterface)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionDeleteBasedInterface)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionInterface)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionInterface)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionFrr)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionFrr)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionOspf)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionOspf)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionSetBasedInterface)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionSetBasedInterface)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionSetBasedSystem)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionSetBasedSystem)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionSystem)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionSystem)),
 				),
 				apstravalidator.ForbiddenWhenValueIs(
 					path.MatchRelative().AtParent().AtName("section"),
-					types.StringValue(utils.StringersToFriendlyString(enum.ConfigletSectionSystemTop)),
+					types.StringValue(rosetta.StringersToFriendlyString(enum.ConfigletSectionSystemTop)),
 				),
 			},
 		},
@@ -134,7 +135,7 @@ func (o ConfigletGenerator) AttrTypes() map[string]attr.Type {
 
 func (o *ConfigletGenerator) LoadApiData(ctx context.Context, in *apstra.ConfigletGenerator, diags *diag.Diagnostics) {
 	o.ConfigStyle = types.StringValue(in.ConfigStyle.String())
-	o.Section = types.StringValue(utils.StringersToFriendlyString(in.Section, in.ConfigStyle))
+	o.Section = types.StringValue(rosetta.StringersToFriendlyString(in.Section, in.ConfigStyle))
 	o.TemplateText = types.StringValue(in.TemplateText)
 	o.NegationTemplateText = utils.StringValueOrNull(ctx, in.NegationTemplateText, diags)
 	o.FileName = utils.StringValueOrNull(ctx, in.Filename, diags)
@@ -150,7 +151,7 @@ func (o *ConfigletGenerator) Request(_ context.Context, diags *diag.Diagnostics)
 	}
 
 	var section enum.ConfigletSection
-	err = utils.ApiStringerFromFriendlyString(&section, o.Section.ValueString(), o.ConfigStyle.ValueString())
+	err = rosetta.ApiStringerFromFriendlyString(&section, o.Section.ValueString(), o.ConfigStyle.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("error parsing configlet section %q", o.Section.ValueString()), err.Error())
 	}

--- a/apstra/design/template_rack_based.go
+++ b/apstra/design/template_rack_based.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -222,7 +223,7 @@ func (o *TemplateRackBased) Request(ctx context.Context, diags *diag.Diagnostics
 	}
 
 	var spineAsnScheme apstra.AsnAllocationScheme
-	err = utils.ApiStringerFromFriendlyString(&spineAsnScheme, o.AsnAllocation.ValueString())
+	err = rosetta.ApiStringerFromFriendlyString(&spineAsnScheme, o.AsnAllocation.ValueString())
 	if err != nil {
 		diags.AddError(errProviderBug,
 			fmt.Sprintf("error parsing ASN allocation scheme %q - %s",
@@ -233,7 +234,7 @@ func (o *TemplateRackBased) Request(ctx context.Context, diags *diag.Diagnostics
 	}
 
 	var overlayControlProtocol apstra.OverlayControlProtocol
-	err = utils.ApiStringerFromFriendlyString(&overlayControlProtocol, o.OverlayControlProtocol.ValueString())
+	err = rosetta.ApiStringerFromFriendlyString(&overlayControlProtocol, o.OverlayControlProtocol.ValueString())
 	if err != nil {
 		diags.AddError(errProviderBug,
 			fmt.Sprintf("error parsing overlay control protocol %q - %s",
@@ -264,8 +265,8 @@ func (o *TemplateRackBased) LoadApiData(ctx context.Context, in *apstra.Template
 
 	o.Name = types.StringValue(in.DisplayName)
 	o.Spine = NewDesignTemplateSpineObject(ctx, &in.Spine, diags)
-	o.AsnAllocation = types.StringValue(utils.StringersToFriendlyString(in.AsnAllocationPolicy.SpineAsnScheme))
-	o.OverlayControlProtocol = types.StringValue(utils.StringersToFriendlyString(in.VirtualNetworkPolicy.OverlayControlProtocol))
+	o.AsnAllocation = types.StringValue(rosetta.StringersToFriendlyString(in.AsnAllocationPolicy.SpineAsnScheme))
+	o.OverlayControlProtocol = types.StringValue(rosetta.StringersToFriendlyString(in.VirtualNetworkPolicy.OverlayControlProtocol))
 	o.RackInfos = NewRackInfoMap(ctx, in, diags)
 }
 

--- a/apstra/freeform/allocation_group.go
+++ b/apstra/freeform/allocation_group.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/enum"
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -108,7 +109,7 @@ func (o AllocGroup) ResourceAttributes() map[string]resourceSchema.Attribute {
 func (o *AllocGroup) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.FreeformAllocGroupData {
 	// unpack
 	var allocGroupType enum.ResourcePoolType
-	err := utils.ApiStringerFromFriendlyString(&allocGroupType, o.Type.ValueString())
+	err := rosetta.ApiStringerFromFriendlyString(&allocGroupType, o.Type.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("error parsing type %q", o.Type.ValueString()), err.Error())
 	}
@@ -129,6 +130,6 @@ func (o *AllocGroup) Request(ctx context.Context, diags *diag.Diagnostics) *apst
 func (o *AllocGroup) LoadApiData(ctx context.Context, in *apstra.FreeformAllocGroupData, diags *diag.Diagnostics) {
 	// pack
 	o.Name = types.StringValue(in.Name)
-	o.Type = types.StringValue(utils.StringersToFriendlyString(in.Type))
+	o.Type = types.StringValue(rosetta.StringersToFriendlyString(in.Type))
 	o.PoolIds = utils.SetValueOrNull(ctx, types.StringType, in.PoolIds, diags)
 }

--- a/apstra/freeform/resource.go
+++ b/apstra/freeform/resource.go
@@ -11,6 +11,7 @@ import (
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -76,12 +77,12 @@ func (o Resource) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 			MarkdownDescription: fmt.Sprintf("Value used by integer type resources (`%s`, `%s`, `%s`, `%s`). "+
 				"Also used by IP prefix resources (`%s` and `%s`) to indicate the required prefix size for automatic "+
 				"allocations from another object or a resource pool.",
-				utils.StringersToFriendlyString(enum.FFResourceTypeAsn),
-				utils.StringersToFriendlyString(enum.FFResourceTypeInt),
-				utils.StringersToFriendlyString(enum.FFResourceTypeVlan),
-				utils.StringersToFriendlyString(enum.FFResourceTypeVni),
-				utils.StringersToFriendlyString(enum.FFResourceTypeIpv4),
-				utils.StringersToFriendlyString(enum.FFResourceTypeIpv6),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeAsn),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeInt),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeVlan),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeVni),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv4),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv6),
 			),
 			Computed: true,
 		},
@@ -93,16 +94,16 @@ func (o Resource) DataSourceAttributes() map[string]dataSourceSchema.Attribute {
 		},
 		"ipv4_value": dataSourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("Value used by resources with type `%s` or `%s`.",
-				utils.StringersToFriendlyString(enum.FFResourceTypeIpv4),
-				utils.StringersToFriendlyString(enum.FFResourceTypeHostIpv4),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv4),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeHostIpv4),
 			),
 			Computed:   true,
 			CustomType: cidrtypes.IPv4PrefixType{},
 		},
 		"ipv6_value": dataSourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("Value used by resources with type `%s` or `%s`.",
-				utils.StringersToFriendlyString(enum.FFResourceTypeIpv6),
-				utils.StringersToFriendlyString(enum.FFResourceTypeHostIpv6),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv6),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeHostIpv6),
 			),
 			Computed:   true,
 			CustomType: cidrtypes.IPv6PrefixType{},
@@ -155,48 +156,48 @@ func (o Resource) ResourceAttributes() map[string]resourceSchema.Attribute {
 			MarkdownDescription: fmt.Sprintf("Value used by integer type resources (`%s`, `%s`, `%s`, `%s`). "+
 				"Also used by IP prefix resources (`%s` and `%s`) to indicate the required prefix size for automatic "+
 				"allocations from another object or a resource pool.",
-				utils.StringersToFriendlyString(enum.FFResourceTypeAsn),
-				utils.StringersToFriendlyString(enum.FFResourceTypeInt),
-				utils.StringersToFriendlyString(enum.FFResourceTypeVlan),
-				utils.StringersToFriendlyString(enum.FFResourceTypeVni),
-				utils.StringersToFriendlyString(enum.FFResourceTypeIpv4),
-				utils.StringersToFriendlyString(enum.FFResourceTypeIpv6),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeAsn),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeInt),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeVlan),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeVni),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv4),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv6),
 			),
 			Optional: true,
 			Computed: true,
 			Validators: []validator.Int64{
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeHostIpv4))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeHostIpv6))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeHostIpv4))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeHostIpv6))),
 			},
 		},
 		"ipv4_value": resourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("Value used by resources with type `%s` or `%s`. Must be CIDR notation.",
-				utils.StringersToFriendlyString(enum.FFResourceTypeIpv4),
-				utils.StringersToFriendlyString(enum.FFResourceTypeHostIpv4),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv4),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeHostIpv4),
 			),
 			Optional:   true,
 			Computed:   true,
 			CustomType: cidrtypes.IPv4PrefixType{},
 			Validators: []validator.String{
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeAsn))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeInt))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeVlan))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeVni))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeAsn))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeInt))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeVlan))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeVni))),
 			},
 		},
 		"ipv6_value": resourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("Value used by resources with type `%s` or `%s`. Must be CIDR notation.",
-				utils.StringersToFriendlyString(enum.FFResourceTypeIpv6),
-				utils.StringersToFriendlyString(enum.FFResourceTypeHostIpv6),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv6),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeHostIpv6),
 			),
 			Optional:   true,
 			Computed:   true,
 			CustomType: cidrtypes.IPv6PrefixType{},
 			Validators: []validator.String{
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeAsn))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeInt))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeVlan))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeVni))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeAsn))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeInt))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeVlan))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeVni))),
 			},
 		},
 		"allocated_from": resourceSchema.StringAttribute{
@@ -222,7 +223,7 @@ func (o Resource) ResourceAttributes() map[string]resourceSchema.Attribute {
 
 func (o *Resource) Request(_ context.Context, diags *diag.Diagnostics) *apstra.FreeformRaResourceData {
 	var resourceType enum.FFResourceType
-	err := utils.ApiStringerFromFriendlyString(&resourceType, o.Type.ValueString())
+	err := rosetta.ApiStringerFromFriendlyString(&resourceType, o.Type.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("error parsing type %q", o.Type.ValueString()), err.Error())
 	}
@@ -258,7 +259,7 @@ func (o *Resource) Request(_ context.Context, diags *diag.Diagnostics) *apstra.F
 func (o *Resource) LoadApiData(_ context.Context, in *apstra.FreeformRaResourceData, diags *diag.Diagnostics) {
 	o.Name = types.StringValue(in.Label)
 	o.GroupId = types.StringValue(string(in.GroupId))
-	o.Type = types.StringValue(utils.StringersToFriendlyString(in.ResourceType))
+	o.Type = types.StringValue(rosetta.StringersToFriendlyString(in.ResourceType))
 	o.AllocatedFrom = types.StringPointerValue((*string)(in.AllocatedFrom))
 	o.IntValue = types.Int64Null()
 	o.Ipv4Value = cidrtypes.NewIPv4PrefixNull()

--- a/apstra/freeform/resource_generator.go
+++ b/apstra/freeform/resource_generator.go
@@ -10,6 +10,7 @@ import (
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -134,20 +135,20 @@ func (o ResourceGenerator) ResourceAttributes() map[string]resourceSchema.Attrib
 		"subnet_prefix_len": resourceSchema.Int64Attribute{
 			MarkdownDescription: fmt.Sprintf("Length of the subnet for the generated Resources. "+
 				"Only applicable when `type` is `%s` or `%s`",
-				utils.StringersToFriendlyString(enum.FFResourceTypeIpv4),
-				utils.StringersToFriendlyString(enum.FFResourceTypeIpv6),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv4),
+				rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv6),
 			),
 			Optional: true,
 			Validators: []validator.Int64{
 				int64validator.Between(1, 127),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeAsn))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeHostIpv4))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeHostIpv6))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeInt))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeVlan))),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeVni))),
-				apstravalidator.RequiredWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeIpv4))),
-				apstravalidator.RequiredWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(enum.FFResourceTypeIpv6))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeAsn))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeHostIpv4))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeHostIpv6))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeInt))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeVlan))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeVni))),
+				apstravalidator.RequiredWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv4))),
+				apstravalidator.RequiredWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(enum.FFResourceTypeIpv6))),
 			},
 		},
 	}
@@ -155,7 +156,7 @@ func (o ResourceGenerator) ResourceAttributes() map[string]resourceSchema.Attrib
 
 func (o *ResourceGenerator) Request(_ context.Context, diags *diag.Diagnostics) *apstra.FreeformResourceGeneratorData {
 	var resourceType enum.FFResourceType
-	err := utils.ApiStringerFromFriendlyString(&resourceType, o.Type.ValueString())
+	err := rosetta.ApiStringerFromFriendlyString(&resourceType, o.Type.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("error parsing type %q", o.Type.ValueString()), err.Error())
 	}
@@ -188,7 +189,7 @@ func (o *ResourceGenerator) Request(_ context.Context, diags *diag.Diagnostics) 
 func (o *ResourceGenerator) LoadApiData(_ context.Context, in *apstra.FreeformResourceGeneratorData, diags *diag.Diagnostics) {
 	o.Name = types.StringValue(in.Label)
 	o.Scope = types.StringValue(in.Scope)
-	o.Type = types.StringValue(utils.StringersToFriendlyString(in.ResourceType))
+	o.Type = types.StringValue(rosetta.StringersToFriendlyString(in.ResourceType))
 	if in.ResourceType == enum.FFResourceTypeVlan {
 		o.AllocatedFrom = types.StringPointerValue(in.ScopeNodePoolLabel)
 	} else {

--- a/apstra/freeform/system.go
+++ b/apstra/freeform/system.go
@@ -8,6 +8,7 @@ import (
 	apstraregexp "github.com/Juniper/terraform-provider-apstra/apstra/regexp"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -120,24 +121,24 @@ func (o System) ResourceAttributes() map[string]resourceSchema.Attribute {
 		},
 		"type": resourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("Type of the System. Must be one of `%s` or `%s`",
-				utils.StringersToFriendlyString(apstra.SystemTypeInternal),
-				utils.StringersToFriendlyString(apstra.SystemTypeExternal),
+				rosetta.StringersToFriendlyString(apstra.SystemTypeInternal),
+				rosetta.StringersToFriendlyString(apstra.SystemTypeExternal),
 			),
 			Required:      true,
 			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			Validators: []validator.String{stringvalidator.OneOf(
-				utils.StringersToFriendlyString(apstra.SystemTypeInternal),
-				utils.StringersToFriendlyString(apstra.SystemTypeExternal),
+				rosetta.StringersToFriendlyString(apstra.SystemTypeInternal),
+				rosetta.StringersToFriendlyString(apstra.SystemTypeExternal),
 			)},
 		},
 		"device_profile_id": resourceSchema.StringAttribute{
 			MarkdownDescription: fmt.Sprintf("Device profile ID of the System. Required when `type` is %q.",
-				utils.StringersToFriendlyString(apstra.SystemTypeInternal)),
+				rosetta.StringersToFriendlyString(apstra.SystemTypeInternal)),
 			Optional: true,
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
-				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(apstra.SystemTypeExternal))),
-				apstravalidator.RequiredWhenValueIs(path.MatchRoot("type"), types.StringValue(utils.StringersToFriendlyString(apstra.SystemTypeInternal))),
+				apstravalidator.ForbiddenWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(apstra.SystemTypeExternal))),
+				apstravalidator.RequiredWhenValueIs(path.MatchRoot("type"), types.StringValue(rosetta.StringersToFriendlyString(apstra.SystemTypeInternal))),
 			},
 		},
 		"system_id": resourceSchema.StringAttribute{
@@ -163,9 +164,9 @@ func (o *System) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.F
 
 	var systemType apstra.SystemType
 	switch o.Type.ValueString() {
-	case utils.StringersToFriendlyString(apstra.SystemTypeExternal):
+	case rosetta.StringersToFriendlyString(apstra.SystemTypeExternal):
 		systemType = apstra.SystemTypeExternal
-	case utils.StringersToFriendlyString(apstra.SystemTypeInternal):
+	case rosetta.StringersToFriendlyString(apstra.SystemTypeInternal):
 		systemType = apstra.SystemTypeInternal
 	default:
 		diags.AddError("unexpected system type", "got: "+o.Type.ValueString())
@@ -184,7 +185,7 @@ func (o *System) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.F
 func (o *System) LoadApiData(ctx context.Context, in *apstra.FreeformSystemData, diags *diag.Diagnostics) {
 	o.Name = types.StringValue(in.Label)
 	o.Hostname = types.StringValue(in.Hostname)
-	o.Type = types.StringValue(utils.StringersToFriendlyString(in.Type))
+	o.Type = types.StringValue(rosetta.StringersToFriendlyString(in.Type))
 	o.DeviceProfileId = types.StringPointerValue((*string)(in.DeviceProfileId))
 	o.SystemId = types.StringPointerValue((*string)(in.SystemId))
 	o.Tags = utils.SetValueOrNull(ctx, types.StringType, in.Tags, diags) // safe to ignore diagnostic here

--- a/apstra/resource_configlet.go
+++ b/apstra/resource_configlet.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/design"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -68,7 +69,7 @@ func (o *resourceConfiglet) ValidateConfig(ctx context.Context, req resource.Val
 
 		// parse the config style
 		var configletStyle enum.ConfigletStyle
-		err := utils.ApiStringerFromFriendlyString(&configletStyle, generator.ConfigStyle.ValueString())
+		err := rosetta.ApiStringerFromFriendlyString(&configletStyle, generator.ConfigStyle.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("generators").AtListIndex(i),
@@ -78,7 +79,7 @@ func (o *resourceConfiglet) ValidateConfig(ctx context.Context, req resource.Val
 
 		// parse the config section
 		var configletSection enum.ConfigletSection
-		err = utils.ApiStringerFromFriendlyString(&configletSection, generator.Section.ValueString(), generator.ConfigStyle.ValueString())
+		err = rosetta.ApiStringerFromFriendlyString(&configletSection, generator.Section.ValueString(), generator.ConfigStyle.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("generators").AtListIndex(i),

--- a/apstra/resource_datacenter_configlet.go
+++ b/apstra/resource_datacenter_configlet.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -71,7 +72,7 @@ func (o *resourceDatacenterConfiglet) ValidateConfig(ctx context.Context, req re
 
 		// parse the config style
 		var configletStyle enum.ConfigletStyle
-		err := utils.ApiStringerFromFriendlyString(&configletStyle, generator.ConfigStyle.ValueString())
+		err := rosetta.ApiStringerFromFriendlyString(&configletStyle, generator.ConfigStyle.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("generators").AtListIndex(i),
@@ -81,7 +82,7 @@ func (o *resourceDatacenterConfiglet) ValidateConfig(ctx context.Context, req re
 
 		// parse the config section
 		var configletSection enum.ConfigletSection
-		err = utils.ApiStringerFromFriendlyString(&configletSection, generator.Section.ValueString(), generator.ConfigStyle.ValueString())
+		err = rosetta.ApiStringerFromFriendlyString(&configletSection, generator.Section.ValueString(), generator.ConfigStyle.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("generators").AtListIndex(i),

--- a/apstra/resource_datacenter_connectivity_template_primitives_test.go
+++ b/apstra/resource_datacenter_connectivity_template_primitives_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/stretchr/testify/require"
 )
@@ -481,7 +482,7 @@ func (o resourceDataCenterConnectivityTemplatePrimitiveBgpPeeringGenericSystem) 
 			intPtrOrNull(o.localAsn),
 			strconv.FormatBool(o.neighborAsnDynamic),
 			strconv.FormatBool(o.peerFromLoopback),
-			utils.StringersToFriendlyString(o.peerTo),
+			rosetta.StringersToFriendlyString(o.peerTo),
 			routingPolicies,
 		),
 	)
@@ -907,8 +908,8 @@ func (o resourceDataCenterConnectivityTemplatePrimitiveIpLink) render(indent int
 			o.routingZoneId,
 			intPtrOrNull(o.vlanId),
 			intPtrOrNull(o.l3Mtu),
-			utils.StringersToFriendlyString(o.ipv4AddressingType),
-			utils.StringersToFriendlyString(o.ipv6AddressingType),
+			rosetta.StringersToFriendlyString(o.ipv4AddressingType),
+			rosetta.StringersToFriendlyString(o.ipv6AddressingType),
 			bgpPeeringGenericSystems,
 			bgpPeeringIpEndpoints,
 			dynamicBgpPeerings,

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/enum"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/require"
@@ -54,11 +55,11 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 
 		switch {
 		case unspecifiedAsNone.Check(apiVersion):
-			t.Logf("case unspecifiedAsNone: returning %s for version %s", utils.StringersToFriendlyString(enum.DeployModeNone), apiVersion)
-			return utils.StringersToFriendlyString(enum.DeployModeNone)
+			t.Logf("case unspecifiedAsNone: returning %s for version %s", rosetta.StringersToFriendlyString(enum.DeployModeNone), apiVersion)
+			return rosetta.StringersToFriendlyString(enum.DeployModeNone)
 		case unspecifiedAsUndeploy.Check(apiVersion):
-			t.Logf("case unspecifiedAsUndeploy: returning %s for version %s", utils.StringersToFriendlyString(enum.DeployModeNone), apiVersion)
-			return utils.StringersToFriendlyString(enum.DeployModeUndeploy)
+			t.Logf("case unspecifiedAsUndeploy: returning %s for version %s", rosetta.StringersToFriendlyString(enum.DeployModeNone), apiVersion)
+			return rosetta.StringersToFriendlyString(enum.DeployModeUndeploy)
 		default:
 			panic("unable to determine behavior for unspecified deploy mode")
 		}
@@ -177,7 +178,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 								IP:   net.IP{1, 1, 1, 1},
 								Mask: net.CIDRMask(32, 32),
 							},
-							deployMode: utils.StringersToFriendlyString(enum.DeployModeReady),
+							deployMode: rosetta.StringersToFriendlyString(enum.DeployModeReady),
 							tags:       []string{"one"},
 						},
 					},
@@ -185,12 +186,12 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeReady)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeReady)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "SPINE1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "spine1.test"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeReady)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeReady)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "1"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
 					},
@@ -208,7 +209,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 								IP:   net.IP{2, 2, 2, 2},
 								Mask: net.CIDRMask(32, 32),
 							},
-							deployMode: utils.StringersToFriendlyString(enum.DeployModeDrain),
+							deployMode: rosetta.StringersToFriendlyString(enum.DeployModeDrain),
 							tags:       []string{"two", "2"},
 						},
 					},
@@ -216,12 +217,12 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "SPINE2"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "spine2.test"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "2"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "2.2.2.2/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "two"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "2"),
@@ -257,7 +258,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 							hostname:     "leafstartminimalhostname.com",
 							asn:          utils.ToPtr(1),
 							loopbackIpv4: &net.IPNet{IP: net.IP{1, 1, 1, 1}, Mask: net.CIDRMask(32, 32)},
-							deployMode:   utils.StringersToFriendlyString(enum.DeployModeDrain),
+							deployMode:   rosetta.StringersToFriendlyString(enum.DeployModeDrain),
 							tags:         []string{"one", "1"},
 						},
 					},
@@ -267,12 +268,12 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Leaf"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "leaf_start_minimal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartminimalhostname.com"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
@@ -290,12 +291,12 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Leaf"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "leaf_start_minimal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartminimalhostname.com"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 					},
 				},
 				{
@@ -326,7 +327,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 							hostname:     "leafstartmaximalhostname.com",
 							asn:          utils.ToPtr(1),
 							loopbackIpv4: &net.IPNet{IP: net.IP{1, 1, 1, 1}, Mask: net.CIDRMask(32, 32)},
-							deployMode:   utils.StringersToFriendlyString(enum.DeployModeDrain),
+							deployMode:   rosetta.StringersToFriendlyString(enum.DeployModeDrain),
 							tags:         []string{"one", "1"},
 						},
 					},
@@ -336,12 +337,12 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Leaf"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "leaf_start_maximal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartmaximalhostname.com"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
@@ -359,12 +360,12 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-7x10-Leaf"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "leaf_start_maximal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "leafstartmaximalhostname.com"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.asn", "1"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.loopback_ipv4", "1.1.1.1/32"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 					},
 				},
 				{
@@ -409,7 +410,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						systemAttributes: &systemAttributes{
 							name:       "access_start_minimal_name",
 							hostname:   "accessstartminimalhostname.com",
-							deployMode: utils.StringersToFriendlyString(enum.DeployModeDrain),
+							deployMode: rosetta.StringersToFriendlyString(enum.DeployModeDrain),
 							tags:       []string{"one", "1"},
 						},
 					},
@@ -419,10 +420,10 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_minimal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartminimalhostname.com"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
@@ -440,10 +441,10 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_minimal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartminimalhostname.com"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 					},
 				},
 				{
@@ -472,7 +473,7 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						systemAttributes: &systemAttributes{
 							name:       "access_start_maximal_name",
 							hostname:   "accessstartmaximalhostname.com",
-							deployMode: utils.StringersToFriendlyString(enum.DeployModeDrain),
+							deployMode: rosetta.StringersToFriendlyString(enum.DeployModeDrain),
 							tags:       []string{"one", "1"},
 						},
 					},
@@ -482,10 +483,10 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_maximal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartmaximalhostname.com"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.#", "2"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "one"),
 						resource.TestCheckTypeSetElemAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.tags.*", "1"),
@@ -503,10 +504,10 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "interface_map_name", "Juniper_vQFX__AOS-8x10-1"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "node_id"),
 						resource.TestCheckResourceAttrSet(resourceDataCenterDeviceAllocationRefName, "device_profile_node_id"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.name", "access_start_maximal_name"),
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.hostname", "accessstartmaximalhostname.com"),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 					},
 				},
 				{
@@ -533,13 +534,13 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						nodeName:              "l2_one_access_002_leaf1",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
 						systemAttributes: &systemAttributes{
-							deployMode: utils.StringersToFriendlyString(enum.DeployModeNone),
+							deployMode: rosetta.StringersToFriendlyString(enum.DeployModeNone),
 						},
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeNone)),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeNone)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeNone)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeNone)),
 					},
 				},
 				{
@@ -548,13 +549,13 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						nodeName:              "l2_one_access_002_leaf1",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
 						systemAttributes: &systemAttributes{
-							deployMode: utils.StringersToFriendlyString(enum.DeployModeDrain),
+							deployMode: rosetta.StringersToFriendlyString(enum.DeployModeDrain),
 						},
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDrain)),
 					},
 				},
 			},
@@ -582,13 +583,13 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						nodeName:              "l2_esi_acs_dual_001_leaf2",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
 						systemAttributes: &systemAttributes{
-							deployMode: utils.StringersToFriendlyString(enum.DeployModeReady),
+							deployMode: rosetta.StringersToFriendlyString(enum.DeployModeReady),
 						},
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeReady)),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeReady)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeReady)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeReady)),
 					},
 				},
 				{
@@ -597,13 +598,13 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						nodeName:              "l2_esi_acs_dual_001_leaf2",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
 						systemAttributes: &systemAttributes{
-							deployMode: utils.StringersToFriendlyString(enum.DeployModeNone),
+							deployMode: rosetta.StringersToFriendlyString(enum.DeployModeNone),
 						},
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeNone)),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeNone)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeNone)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeNone)),
 					},
 				},
 				{
@@ -612,13 +613,13 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 						nodeName:              "l2_esi_acs_dual_001_leaf2",
 						initialInterfaceMapId: "Juniper_vQFX__AOS-7x10-Leaf",
 						systemAttributes: &systemAttributes{
-							deployMode: utils.StringersToFriendlyString(enum.DeployModeReady),
+							deployMode: rosetta.StringersToFriendlyString(enum.DeployModeReady),
 						},
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeReady)),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeReady)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeReady)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeReady)),
 					},
 				},
 				{
@@ -629,8 +630,8 @@ func TestResourceDatacenterDeviceAllocation(t *testing.T) {
 					},
 					checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "blueprint_id", bpClient.Id().String()),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeReady)),
-						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", utils.StringersToFriendlyString(enum.DeployModeReady)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeReady)),
+						resource.TestCheckResourceAttr(resourceDataCenterDeviceAllocationRefName, "system_attributes.deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeReady)),
 					},
 				},
 			},

--- a/apstra/resource_datacenter_generic_system_integration_test.go
+++ b/apstra/resource_datacenter_generic_system_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -68,7 +69,7 @@ func (o *resourceDataCenterGenericSystemLink) addTestChecks(t testing.TB, testCh
 		// todo - each tag, somehow? not critical, the extra plan stage will catch it
 	}
 	if o.lagMode != apstra.RackLinkLagModeNone {
-		m["lag_mode"] = utils.StringersToFriendlyString(o.lagMode)
+		m["lag_mode"] = rosetta.StringersToFriendlyString(o.lagMode)
 	}
 	if o.groupLabel != "" {
 		m["group_label"] = o.groupLabel
@@ -174,7 +175,7 @@ func (o resourceDataCenterGenericSystem) testChecks(t testing.TB, bpId apstra.Ob
 		result.append(t, "TestCheckTypeSetElemAttr", "tags.*", tag)
 	}
 	if o.deployMode == nil {
-		result.append(t, "TestCheckResourceAttr", "deploy_mode", utils.StringersToFriendlyString(enum.DeployModeDeploy))
+		result.append(t, "TestCheckResourceAttr", "deploy_mode", rosetta.StringersToFriendlyString(enum.DeployModeDeploy))
 	} else {
 		result.append(t, "TestCheckResourceAttr", "deploy_mode", *o.deployMode)
 	}
@@ -981,7 +982,7 @@ func TestResourceDatacenterGenericSystem(t *testing.T) {
 				{ // check for deploy_mode = not_set
 					preApplyResourceActionType: plancheck.ResourceActionUpdate,
 					config: resourceDataCenterGenericSystem{
-						deployMode: utils.ToPtr(utils.StringersToFriendlyString(enum.DeployModeNone)),
+						deployMode: utils.ToPtr(rosetta.StringersToFriendlyString(enum.DeployModeNone)),
 						links: []resourceDataCenterGenericSystemLink{
 							{
 								targetSwitchId: leafSwitchIds[1],

--- a/apstra/resource_datacenter_security_policy_test.go
+++ b/apstra/resource_datacenter_security_policy_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
-	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -89,7 +89,7 @@ func (o testCaseResourceSecurityPolicy) renderConfig(bpId apstra.ObjectId) strin
 			rule.Data.Label,
 			stringOrNull(rule.Data.Description),
 			rule.Data.Action.Value,
-			utils.StringersToFriendlyString(rule.Data.Protocol),
+			rosetta.StringersToFriendlyString(rule.Data.Protocol),
 			renderPorts(rule.Data.SrcPort),
 			renderPorts(rule.Data.DstPort),
 			renderEstablished(rule.Data.TcpStateQualifier),

--- a/apstra/resource_freeform_allocation_group_integration_test.go
+++ b/apstra/resource_freeform_allocation_group_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
-	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -42,7 +42,7 @@ func (o resourceAllocGroup) render(rType, rName string) string {
 		rType, rName,
 		o.blueprintId,
 		o.name,
-		utils.StringersToFriendlyString(o.groupType),
+		rosetta.StringersToFriendlyString(o.groupType),
 		stringSliceOrNull(o.poolIds),
 	)
 }
@@ -54,7 +54,7 @@ func (o resourceAllocGroup) testChecks(t testing.TB, rType, rName string) testCh
 	result.append(t, "TestCheckResourceAttrSet", "id")
 	result.append(t, "TestCheckResourceAttr", "blueprint_id", o.blueprintId)
 	result.append(t, "TestCheckResourceAttr", "name", o.name)
-	result.append(t, "testCheckResourceAttr", "type", utils.StringersToFriendlyString(o.groupType))
+	result.append(t, "testCheckResourceAttr", "type", rosetta.StringersToFriendlyString(o.groupType))
 	return result
 }
 

--- a/apstra/resource_freeform_resource.go
+++ b/apstra/resource_freeform_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/freeform"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -61,7 +62,7 @@ func (o *resourceFreeformResource) ValidateConfig(ctx context.Context, req resou
 	}
 
 	var resourceType enum.FFResourceType
-	err := utils.ApiStringerFromFriendlyString(&resourceType, config.Type.ValueString())
+	err := rosetta.ApiStringerFromFriendlyString(&resourceType, config.Type.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("type"), "failed to parse 'type' attribute", err.Error())
 		return

--- a/apstra/resource_freeform_resource_generator.go
+++ b/apstra/resource_freeform_resource_generator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/freeform"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -56,7 +57,7 @@ func (o *resourceFreeformResourceGenerator) ValidateConfig(ctx context.Context, 
 
 	// Extract the type
 	var resourceType enum.FFResourceType
-	err := utils.ApiStringerFromFriendlyString(&resourceType, config.Type.ValueString())
+	err := rosetta.ApiStringerFromFriendlyString(&resourceType, config.Type.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("type"), "failed to parse 'type' attribute", err.Error())
 		return

--- a/apstra/resource_freeform_resource_generator_integraion_test.go
+++ b/apstra/resource_freeform_resource_generator_integraion_test.go
@@ -14,6 +14,7 @@ import (
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -49,7 +50,7 @@ func (o resourceFreeformResourceGenerator) render(rType, rName string) string {
 		rType, rName,
 		o.blueprintId,
 		o.name,
-		utils.StringersToFriendlyString(o.resourceType),
+		rosetta.StringersToFriendlyString(o.resourceType),
 		o.scope,
 		stringOrNull(o.allocatedFrom),
 		o.containerId,
@@ -66,7 +67,7 @@ func (o resourceFreeformResourceGenerator) testChecks(t testing.TB, rType, rName
 	result.append(t, "TestCheckResourceAttr", "name", o.name)
 	result.append(t, "TestCheckResourceAttr", "scope", o.scope)
 	result.append(t, "TestCheckResourceAttr", "container_id", o.containerId)
-	result.append(t, "TestCheckResourceAttr", "type", utils.StringersToFriendlyString(o.resourceType))
+	result.append(t, "TestCheckResourceAttr", "type", rosetta.StringersToFriendlyString(o.resourceType))
 	if o.allocatedFrom == "" {
 		result.append(t, "TestCheckNoResourceAttr", "allocated_from")
 	} else {

--- a/apstra/resource_freeform_resource_integraion_test.go
+++ b/apstra/resource_freeform_resource_integraion_test.go
@@ -15,6 +15,7 @@ import (
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -55,7 +56,7 @@ func (o resourceFreeformResource) render(rType, rName string) string {
 		o.blueprintId,
 		o.name,
 		o.groupId,
-		utils.StringersToFriendlyString(o.resourceType),
+		rosetta.StringersToFriendlyString(o.resourceType),
 		intPtrOrNull(o.integerValue),
 		ipNetOrNull(o.ipv4Value),
 		ipNetOrNull(o.ipv6Value),
@@ -72,7 +73,7 @@ func (o resourceFreeformResource) testChecks(t testing.TB, rType, rName string) 
 	result.append(t, "TestCheckResourceAttr", "blueprint_id", o.blueprintId)
 	result.append(t, "TestCheckResourceAttr", "name", o.name)
 	result.append(t, "TestCheckResourceAttr", "group_id", o.groupId.String())
-	result.append(t, "TestCheckResourceAttr", "type", utils.StringersToFriendlyString(o.resourceType))
+	result.append(t, "TestCheckResourceAttr", "type", rosetta.StringersToFriendlyString(o.resourceType))
 	if o.integerValue != nil {
 		result.append(t, "TestCheckResourceAttr", "integer_value", strconv.Itoa(*o.integerValue))
 	} else {

--- a/apstra/utils/configlets.go
+++ b/apstra/utils/configlets.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 )
 
 func ConfigletSupportsPlatforms(configletdata *apstra.ConfigletData, platforms []enum.ConfigletStyle) bool {
@@ -47,7 +48,7 @@ func AllConfigletSectionNames() []string {
 func ConfigletSectionNamesByStyle(style enum.ConfigletStyle) []string {
 	var result []string
 	for _, v := range apstra.ValidConfigletSections(style) {
-		result = append(result, StringersToFriendlyString(v, style))
+		result = append(result, rosetta.StringersToFriendlyString(v, style))
 	}
 	return result
 }

--- a/apstra/utils/freeform_resource.go
+++ b/apstra/utils/freeform_resource.go
@@ -4,13 +4,14 @@ import (
 	"sort"
 
 	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 )
 
 func AllFFResourceTypes() []string {
 	members := enum.FFResourceTypes.Members()
 	result := make([]string, len(members))
 	for i, member := range members {
-		result[i] = StringersToFriendlyString(member)
+		result[i] = rosetta.StringersToFriendlyString(member)
 	}
 	sort.Strings(result)
 	return result

--- a/apstra/utils/interface_numbering.go
+++ b/apstra/utils/interface_numbering.go
@@ -4,13 +4,14 @@ import (
 	"sort"
 
 	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 )
 
 func AllInterfaceNumberingIpv4Types() []string {
 	members := enum.InterfaceNumberingIpv4Types.Members()
 	result := make([]string, len(members))
 	for i, member := range members {
-		result[i] = StringersToFriendlyString(member)
+		result[i] = rosetta.StringersToFriendlyString(member)
 	}
 
 	sort.Strings(result)
@@ -21,7 +22,7 @@ func AllInterfaceNumberingIpv6Types() []string {
 	members := enum.InterfaceNumberingIpv6Types.Members()
 	result := make([]string, len(members))
 	for i, member := range members {
-		result[i] = StringersToFriendlyString(member)
+		result[i] = rosetta.StringersToFriendlyString(member)
 	}
 
 	sort.Strings(result)

--- a/apstra/utils/node.go
+++ b/apstra/utils/node.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 )
 
 func AllNodeDeployModes() []string {
 	members := enum.DeployModes.Members()
 	result := make([]string, len(members))
 	for i, member := range members {
-		result[i] = StringersToFriendlyString(member)
+		result[i] = rosetta.StringersToFriendlyString(member)
 	}
 
 	return result
@@ -34,12 +35,12 @@ func GetNodeDeployMode(ctx context.Context, client *apstra.TwoStageL3ClosClient,
 		return "", err
 	}
 
-	return StringersToFriendlyString(deployMode), nil
+	return rosetta.StringersToFriendlyString(deployMode), nil
 }
 
 func SetNodeDeployMode(ctx context.Context, client *apstra.TwoStageL3ClosClient, nodeId string, modeString string) error {
 	var modeIota enum.DeployMode
-	err := ApiStringerFromFriendlyString(&modeIota, modeString)
+	err := rosetta.ApiStringerFromFriendlyString(&modeIota, modeString)
 	if err != nil {
 		return err
 	}

--- a/apstra/utils/peering.go
+++ b/apstra/utils/peering.go
@@ -4,13 +4,14 @@ import (
 	"sort"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 )
 
 func PeerToTypes() []string {
 	result := []string{
-		StringersToFriendlyString(apstra.CtPrimitiveBgpPeerToLoopback),
-		StringersToFriendlyString(apstra.CtPrimitiveBgpPeerToInterfaceOrIpEndpoint),
-		StringersToFriendlyString(apstra.CtPrimitiveBgpPeerToInterfaceOrSharedIpEndpoint),
+		rosetta.StringersToFriendlyString(apstra.CtPrimitiveBgpPeerToLoopback),
+		rosetta.StringersToFriendlyString(apstra.CtPrimitiveBgpPeerToInterfaceOrIpEndpoint),
+		rosetta.StringersToFriendlyString(apstra.CtPrimitiveBgpPeerToInterfaceOrSharedIpEndpoint),
 	}
 	sort.Strings(result)
 	return result

--- a/apstra/utils/resource_group.go
+++ b/apstra/utils/resource_group.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 )
 
 func AllResourceGroupNameStrings() []string {
@@ -13,7 +14,7 @@ func AllResourceGroupNameStrings() []string {
 		if rgn == apstra.ResourceGroupNameNone {
 			continue
 		}
-		result = append(result, StringersToFriendlyString(rgn))
+		result = append(result, rosetta.StringersToFriendlyString(rgn))
 	}
 
 	sort.Strings(result)

--- a/apstra/utils/resource_pool.go
+++ b/apstra/utils/resource_pool.go
@@ -4,13 +4,14 @@ import (
 	"sort"
 
 	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 )
 
 func AllResourcePoolTypes() []string {
 	members := enum.ResourcePoolTypes.Members()
 	result := make([]string, len(members))
 	for i, member := range members {
-		result[i] = StringersToFriendlyString(member)
+		result[i] = rosetta.StringersToFriendlyString(member)
 	}
 	sort.Strings(result)
 	return result

--- a/apstra/utils/telemetry_service_registry_entry.go
+++ b/apstra/utils/telemetry_service_registry_entry.go
@@ -4,13 +4,14 @@ import (
 	"sort"
 
 	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 )
 
 func AllStorageSchemaPaths() []string {
 	members := enum.StorageSchemaPaths.Members()
 	result := make([]string, len(members))
 	for i, member := range members {
-		result[i] = StringersToFriendlyString(member)
+		result[i] = rosetta.StringersToFriendlyString(member)
 	}
 	sort.Strings(result)
 	return result

--- a/internal/rosetta/rosetta.go
+++ b/internal/rosetta/rosetta.go
@@ -1,4 +1,4 @@
-package utils
+package rosetta
 
 import (
 	"errors"

--- a/internal/rosetta/rosetta_test.go
+++ b/internal/rosetta/rosetta_test.go
@@ -1,4 +1,4 @@
-package utils
+package rosetta
 
 import (
 	"fmt"


### PR DESCRIPTION
Lots of changes here, but all are handled by the tooling, so no logic changes:
- IDE drag-and-drop of `utils/rosetta.go` and `utils/rosetta_test.go` into new directory `internal/rosetta/`
- cleanup of affected files with `gofumpt`