### PR TITLE
Replace `Int64AttrValueFromPtr()` with `Int64PointerValue()`

### DIFF
--- a/apstra/blueprint/blueprint.go
+++ b/apstra/blueprint/blueprint.go
@@ -681,11 +681,11 @@ func (o *Blueprint) LoadFabricSettings(ctx context.Context, settings *apstra.Fab
 		}
 	}
 
-	o.DefaultIpLinksToGenericMtu = utils.Int64AttrValueFromPtr(settings.ExternalRouterMtu)
-	o.DefaultSviL3Mtu = utils.Int64AttrValueFromPtr(settings.DefaultSviL3Mtu)
-	o.EsiMacMsb = utils.Int64AttrValueFromPtr(settings.EsiMacMsb)
+	o.DefaultIpLinksToGenericMtu = utils.Int64PointerValue(settings.ExternalRouterMtu)
+	o.DefaultSviL3Mtu = utils.Int64PointerValue(settings.DefaultSviL3Mtu)
+	o.EsiMacMsb = utils.Int64PointerValue(settings.EsiMacMsb)
 	o.EvpnType5Routes = boolAttrValueFromFeatureswitchEnumPtr(settings.EvpnGenerateType5HostRoutes)
-	o.FabricMtu = utils.Int64AttrValueFromPtr(settings.FabricL3Mtu)
+	o.FabricMtu = utils.Int64PointerValue(settings.FabricL3Mtu)
 	o.Ipv6Applications = boolAttrValueFromBoolPtr(settings.Ipv6Enabled)
 	o.JunosEvpnMaxNexthopAndInterfaceNumber = boolAttrValueFromFeatureswitchEnumPtr(settings.JunosEvpnMaxNexthopAndInterfaceNumber)
 	o.JunosEvpnRoutingInstanceModeMacVrf = boolAttrValueFromFeatureswitchEnumPtr(settings.JunosEvpnRoutingInstanceVlanAware)

--- a/apstra/freeform/resource_generator.go
+++ b/apstra/freeform/resource_generator.go
@@ -195,5 +195,5 @@ func (o *ResourceGenerator) LoadApiData(_ context.Context, in *apstra.FreeformRe
 		o.AllocatedFrom = types.StringPointerValue((*string)(in.AllocatedFrom))
 	}
 	o.ContainerId = types.StringValue(string(in.ContainerId))
-	o.SubnetPrefixLen = utils.Int64AttrValueFromPtr(in.SubnetPrefixLen)
+	o.SubnetPrefixLen = utils.Int64PointerValue(in.SubnetPrefixLen)
 }

--- a/apstra/utils/terraform_plugin_framework_value_creation.go
+++ b/apstra/utils/terraform_plugin_framework_value_creation.go
@@ -193,11 +193,3 @@ func Ipv6PrefixPointerValue(v *net.IPNet) cidrtypes.IPv6Prefix {
 
 	return cidrtypes.NewIPv6PrefixValue(v.String())
 }
-
-func Int64AttrValueFromPtr[A constraints.Integer](a *A) types.Int64 {
-	if a == nil {
-		return types.Int64Null()
-	}
-
-	return types.Int64Value(int64(*a))
-}


### PR DESCRIPTION
`Int64PointerValue()` and `Int64AttrValueFromPtr()` are the same function.

This PR eliminates `Int64AttrValueFromPtr()` and replaces it with `Int64PointerValue()`