### PR TITLE
Introduce `internal/errors` package with CRUD error helper functions

### DIFF
--- a/internal/errors/constants.go
+++ b/internal/errors/constants.go
@@ -1,0 +1,10 @@
+package errors
+
+const (
+	createFailed = "Failed to create %s"
+	readFailed   = "Failed to read %s"
+	updateFailed = "Failed to update %s"
+	deleteFailed = "Failed to delete %s"
+
+	InvalidConfig = "Invalid configuration"
+)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,46 @@
+package errors
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func CreateError(v any) string {
+	t := reflect.TypeOf(v)
+
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	return fmt.Sprintf(createFailed, t.Name())
+}
+
+func ReadError(v any) string {
+	t := reflect.TypeOf(v)
+
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	return fmt.Sprintf(readFailed, t.Name())
+}
+
+func UpdateError(v any) string {
+	t := reflect.TypeOf(v)
+
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	return fmt.Sprintf(updateFailed, t.Name())
+}
+
+func DeleteError(v any) string {
+	t := reflect.TypeOf(v)
+
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	return fmt.Sprintf(deleteFailed, t.Name())
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,142 @@
+package errors_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/Juniper/terraform-provider-apstra/internal/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateError(t *testing.T) {
+	type testObj1 struct{}
+
+	type testCase struct {
+		t any
+		e string
+	}
+
+	testCases := map[string]testCase{
+		"test_obj_1": {
+			t: testObj1{},
+			e: "Failed to create testObj1",
+		},
+		"test_context": {
+			t: context.Background(),
+			e: "Failed to create backgroundCtx",
+		},
+		"test_bytes_buffer_ptr": {
+			t: new(bytes.Buffer),
+			e: "Failed to create Buffer",
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+
+			r := errors.CreateError(tCase.t)
+			require.Equal(t, tCase.e, r)
+		})
+	}
+}
+
+func TestReadError(t *testing.T) {
+	type testObj1 struct{}
+
+	type testCase struct {
+		t any
+		e string
+	}
+
+	testCases := map[string]testCase{
+		"test_obj_1": {
+			t: testObj1{},
+			e: "Failed to read testObj1",
+		},
+		"test_context": {
+			t: context.Background(),
+			e: "Failed to read backgroundCtx",
+		},
+		"test_bytes_buffer_ptr": {
+			t: new(bytes.Buffer),
+			e: "Failed to read Buffer",
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+
+			r := errors.ReadError(tCase.t)
+			require.Equal(t, tCase.e, r)
+		})
+	}
+}
+
+func TestUpdateError(t *testing.T) {
+	type testObj1 struct{}
+
+	type testCase struct {
+		t any
+		e string
+	}
+
+	testCases := map[string]testCase{
+		"test_obj_1": {
+			t: testObj1{},
+			e: "Failed to update testObj1",
+		},
+		"test_context": {
+			t: context.Background(),
+			e: "Failed to update backgroundCtx",
+		},
+		"test_bytes_buffer_ptr": {
+			t: new(bytes.Buffer),
+			e: "Failed to update Buffer",
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+
+			r := errors.UpdateError(tCase.t)
+			require.Equal(t, tCase.e, r)
+		})
+	}
+}
+
+func TestDeleteError(t *testing.T) {
+	type testObj1 struct{}
+
+	type testCase struct {
+		t any
+		e string
+	}
+
+	testCases := map[string]testCase{
+		"test_obj_1": {
+			t: testObj1{},
+			e: "Failed to delete testObj1",
+		},
+		"test_context": {
+			t: context.Background(),
+			e: "Failed to delete backgroundCtx",
+		},
+		"test_bytes_buffer_ptr": {
+			t: new(bytes.Buffer),
+			e: "Failed to delete Buffer",
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+
+			r := errors.DeleteError(tCase.t)
+			require.Equal(t, tCase.e, r)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces `internal/errors` which includes helper functions intended to be used in resource/datasource CRUD methods.

Example potential use in a `Tag` resource's `Read()` function:

```go
        // Get object from API
        data, err := o.client.GetTag(ctx, state.ID.ValueString())
        if err != nil {
                if utils.IsApstra404(err) {
                        // resource deleted outside of terraform
                        resp.State.RemoveResource(ctx)
                        return
                }
                resp.Diagnostics.AddError(errors.ReadError(data), err.Error()) // <<--- this thing right here
                return
        }
```

This will produce a user-facing Terraform error with summary: `Failed to read Tag`

The goal here is to make the code more boilerplate and reduce copy/paste errors.