### PR TITLE
Bump SDK; bug fix in test code

### DIFF
--- a/apstra/resource_datacenter_connectivity_template_primitives_test.go
+++ b/apstra/resource_datacenter_connectivity_template_primitives_test.go
@@ -16,7 +16,6 @@ import (
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
-	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/Juniper/terraform-provider-apstra/internal/pointer"
 	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -974,7 +973,7 @@ func randomIpLinks(t testing.TB, ctx context.Context, count int, client *apstra.
 
 		result[acctest.RandStringFromCharSet(6, acctest.CharSetAlpha)] = resourceDataCenterConnectivityTemplatePrimitiveIpLink{
 			routingZoneId:            testutils.SecurityZoneA(t, ctx, client, cleanup).String(),
-			vlanId:                   oneOf(nil, pointer.To(rand.IntN(4000)+100)),
+			vlanId:                   oneOf(nil, pointer.To(rand.IntN(3995)+100)),
 			l3Mtu:                    oneOf(nil, pointer.To((rand.IntN((constants.L3MtuMax-constants.L3MtuMin)/2)*2)+constants.L3MtuMin)),
 			ipv4AddressingType:       ipv4AddressingType,
 			ipv6AddressingType:       ipv6AddressingType,

--- a/apstra/resource_datacenter_device_allocation_test.go
+++ b/apstra/resource_datacenter_device_allocation_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
-	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/Juniper/terraform-provider-apstra/internal/pointer"
 	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/go-version"

--- a/apstra/resource_datacenter_generic_system_integration_test.go
+++ b/apstra/resource_datacenter_generic_system_integration_test.go
@@ -984,7 +984,7 @@ func TestResourceDatacenterGenericSystem(t *testing.T) {
 				{ // check for deploy_mode = not_set
 					preApplyResourceActionType: plancheck.ResourceActionUpdate,
 					config: resourceDataCenterGenericSystem{
-						deployMode: pointer.To(utils.StringersToFriendlyString(enum.DeployModeNone)),
+						deployMode: pointer.To(rosetta.StringersToFriendlyString(enum.DeployModeNone)),
 						links: []resourceDataCenterGenericSystemLink{
 							{
 								targetSwitchId: leafSwitchIds[1],

--- a/apstra/resource_freeform_resource_generator_integraion_test.go
+++ b/apstra/resource_freeform_resource_generator_integraion_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
-	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/Juniper/terraform-provider-apstra/internal/pointer"
 	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/go-version"

--- a/apstra/resource_freeform_resource_integraion_test.go
+++ b/apstra/resource_freeform_resource_integraion_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
-	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/Juniper/terraform-provider-apstra/internal/pointer"
 	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
 	"github.com/hashicorp/go-version"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.24.6
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20251027222922-d5efb7b8ddc2
+	github.com/Juniper/apstra-go-sdk v0.0.0-20251105154054-acda0ee324d8
 	github.com/chrismarget-j/version-constraints v0.0.0-20250911132047-1122a37b27ae
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-licenses/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20251027222922-d5efb7b8ddc2 h1:kgAcb8HRjzxkDPNlSrvwk1P5O7LZhhc0PFPlGW2zFq4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20251027222922-d5efb7b8ddc2/go.mod h1:IXhtfYsKJAfSwUgvi1roB+DN+InkGyGb/ely7LOOF/0=
+github.com/Juniper/apstra-go-sdk v0.0.0-20251105154054-acda0ee324d8 h1:vYvnx2khWNqS3QMo9ICDzoa1ykW8yV4d1abc7fBX0HI=
+github.com/Juniper/apstra-go-sdk v0.0.0-20251105154054-acda0ee324d8/go.mod h1:IXhtfYsKJAfSwUgvi1roB+DN+InkGyGb/ely7LOOF/0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
In this PR we have:

- Bugfix for random VLAN ID selection in tests (values out of range were possible)
- Bump SDK release to latest version
- absorb relocation of `StringersToFriendlyString` from `utils` package to `rosetta` package