### PR TITLE
Stop ignoring `golang.org/x/sys` when collecting third party licenses

### DIFF
--- a/Third_Party_Code/NOTICES.md
+++ b/Third_Party_Code/NOTICES.md
@@ -10921,6 +10921,43 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```
 
+## golang.org/x/sys
+
+* Name: golang.org/x/sys
+* Version: v0.37.0
+* License: [BSD-3-Clause](https://cs.opensource.google/go/x/sys/+/v0.37.0:LICENSE)
+
+```
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+
 ## golang.org/x/text
 
 * Name: golang.org/x/text

--- a/Third_Party_Code/golang.org/x/sys/LICENSE
+++ b/Third_Party_Code/golang.org/x/sys/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/scripts/compliance.sh
+++ b/scripts/compliance.sh
@@ -23,48 +23,6 @@ done
 IGNORE=()
 IGNORE+=(--ignore)
 IGNORE+=(github.com/Juniper) # don't bother with Juniper licenses
-IGNORE+=(--ignore)
-IGNORE+=(golang.org/x/sys) # explained below
-
-# golang.org/x/sys is ignored to avoid producing different results on different platforms (x/sys vs. x/sys/unix, etc...)
-# The license details for this package, if they were included in the Third_Party_Code directory, would look something
-# like this, depending on the build platform:
-
-    ### golang.org/x/sys/unix
-    #
-    #* Name: golang.org/x/sys/unix
-    #* Version: v0.17.0
-    #* License: [BSD-3-Clause](https://cs.opensource.google/go/x/sys/+/v0.17.0:LICENSE)
-    #
-    #
-    #Copyright (c) 2009 The Go Authors. All rights reserved.
-    #
-    #Redistribution and use in source and binary forms, with or without
-    #modification, are permitted provided that the following conditions are
-    #met:
-    #
-    #   * Redistributions of source code must retain the above copyright
-    #notice, this list of conditions and the following disclaimer.
-    #   * Redistributions in binary form must reproduce the above
-    #copyright notice, this list of conditions and the following disclaimer
-    #in the documentation and/or other materials provided with the
-    #distribution.
-    #   * Neither the name of Google Inc. nor the names of its
-    #contributors may be used to endorse or promote products derived from
-    #this software without specific prior written permission.
-    #
-    #THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    #"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    #LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-    #A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-    #OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-    #SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-    #LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-    #DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-    #THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    #(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    #OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 go tool go-licenses save   ${IGNORE[@]} --save_path "${TPC}" --force ./...
 go tool go-licenses report ${IGNORE[@]} --template .notices.tpl ./... > "${TPC}/NOTICES.md"


### PR DESCRIPTION
At one time we filtered out `golang.org/x/sys` when running `go-licenses` to collect third party licenses/notices.

We did this because use of different OSes between our dev environment (darwin) and the CI environment (linux) caused some slight variability in imports within this module.

I started this PR with the intention of fixing that discrepancy, but the discrepancy no longer seems to exist.

If/when it recurs, we can duplicate the license from the `golang.org/x/sys` module onto any of the packages (say, `golang.org/x/sys/unix`) it introduces.