### PR TITLE
Add Apstra 6.1.0 to supported versions list

### DIFF
--- a/apstra/compatibility/api_versions.go
+++ b/apstra/compatibility/api_versions.go
@@ -20,10 +20,12 @@ func SupportedApiVersions() []string {
 		apiversions.Apstra501,
 		apiversions.Apstra510,
 		apiversions.Apstra600,
-		// apiversions.Apstra610, todo: check/update the MarkdownDescription strings in the following methods to
-		//                         see if multiple interconnect domains are supported when 6.1.0 becomes available:
-		//                           - resourceDatacenterDciInterconnectDomain.Schema()
-		//                           - dataSourceDatacenterInterconnectDomains.Schema()
+		apiversions.Apstra610,
+		// apiversions.Apstra611, soon
+		// apiversions.Apstra700, todo: check/update the MarkdownDescription strings in the following methods to see
+		//                         if multiple interconnect domains are supported when new versions become available:
+		//                           - resourceDatacenterInterconnectDomainGateway.Schema()
+		//                           - dataSourceDatacenterInterconnectDomainGateway.Schema()
 	}
 
 	sdkVersions := compatibility.SupportedApiVersions()

--- a/apstra/compatibility/api_versions_test.go
+++ b/apstra/compatibility/api_versions_test.go
@@ -17,6 +17,7 @@ func TestSupportedApiVersions(t *testing.T) {
 		apiversions.Apstra501,
 		apiversions.Apstra510,
 		apiversions.Apstra600,
+		apiversions.Apstra610,
 	}
 
 	result := SupportedApiVersions()
@@ -33,8 +34,9 @@ func TestSupportedApiVersionsPretty(t *testing.T) {
 		apiversions.Apstra422 + ", " +
 		apiversions.Apstra500 + ", " +
 		apiversions.Apstra501 + ", " +
-		apiversions.Apstra510 + ", and " +
-		apiversions.Apstra600
+		apiversions.Apstra510 + ", " +
+		apiversions.Apstra600 + ", and " +
+		apiversions.Apstra610
 
 	result := SupportedApiVersionsPretty()
 	if expected != result {

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ It covers day 0 and day 1 operations (design and deployment), and a growing list
 
 Use the navigation tree on the left to read about the available resources and data sources.
 
-This release has been tested with Apstra versions 4.2.0, 4.2.1, 4.2.1.1, 4.2.2, 5.0.0, 5.0.1, 5.1.0, and 6.0.0.
+This release has been tested with Apstra versions 4.2.0, 4.2.1, 4.2.1.1, 4.2.2, 5.0.0, 5.0.1, 5.1.0, 6.0.0, and 6.1.0.
 
 Some example projects which make use of this provider can be found [here](https://github.com/Juniper/terraform-apstra-examples).
 


### PR DESCRIPTION
This branch tested with:

 - 4.2.0-236
 - 4.2.1-207
 - 4.2.1.1-10
 - 4.2.2-2
 - 5.0.0-63
 - 5.0.1-1
 - 5.1.0-117
 - 6.0.0-189
 - 6.1.0-5
