### PR TITLE
Routing Zone resource/datasource - docstring and validation update

### DIFF
--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -70,13 +70,13 @@ func (o DatacenterRoutingZone) DataSourceAttributes() map[string]dataSourceSchem
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Name displayed in the Apstra web UI. Required when `id` is omitted.",
-			Computed:            true,
-			Optional:            true,
-			Validators: []validator.String{
-				stringvalidator.LengthBetween(1, 17),
-				stringvalidator.RegexMatches(apstraregexp.AlphaNumW2HLConstraint, apstraregexp.AlphaNumW2HLConstraintMsg),
-			},
+			MarkdownDescription: "Routing Zone *Label*. This is a mutable attribute of a `security_zone` node in the " +
+				"graph DB. It is not directly viewable in the web UI. The \"name\" value visible in the web UI is the " +
+				"`vrf_name` attribute. The *default* Routing Zone can be looked up by the value `Default routing zone`. " +
+				"Required when `id` is omitted.",
+			Computed:   true,
+			Optional:   true,
+			Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"vrf_name": dataSourceSchema.StringAttribute{
 			MarkdownDescription: "VRF name.",
@@ -159,8 +159,11 @@ func (o DatacenterRoutingZone) DataSourceFilterAttributes() map[string]dataSourc
 			Computed:            true,
 		},
 		"name": dataSourceSchema.StringAttribute{
-			MarkdownDescription: "Name displayed in the Apstra web UI.",
-			Optional:            true,
+			MarkdownDescription: "Routing Zone *Label*. This is a mutable attribute of a `security_zone` node in the " +
+				"graph DB. It is not directly viewable in the web UI. The \"name\" value visible in the web UI is the " +
+				"`vrf_name` attribute. The *default* Routing Zone can be looked up by the value `Default routing zone`. " +
+				"Required when `id` is omitted.",
+			Optional: true,
 		},
 		"vrf_name": dataSourceSchema.StringAttribute{
 			MarkdownDescription: "VRF name.",
@@ -244,8 +247,10 @@ func (o DatacenterRoutingZone) ResourceAttributes() map[string]resourceSchema.At
 			Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 		},
 		"name": resourceSchema.StringAttribute{
-			MarkdownDescription: "Name displayed in the Apstra web UI.",
-			Required:            true,
+			MarkdownDescription: "Routing Zone *Label*. This is a mutable attribute of a `security_zone` node in the " +
+				"graph DB. It is not directly viewable in the web UI. The \"name\" value visible in the web UI is the " +
+				"`vrf_name` attribute. Required when `id` is omitted.",
+			Required: true,
 			Validators: []validator.String{
 				stringvalidator.RegexMatches(apstraregexp.AlphaNumW2HLConstraint, apstraregexp.AlphaNumW2HLConstraintMsg),
 				stringvalidator.LengthBetween(1, 15),

--- a/apstra/resource_datacenter_routing_zone.go
+++ b/apstra/resource_datacenter_routing_zone.go
@@ -185,6 +185,7 @@ func (o *resourceDatacenterRoutingZone) Create(ctx context.Context, req resource
 	}
 
 	// make a security zone request
+	// todo: consider making vrf name optional - only overwrite with name when unknown.
 	plan.VrfName = plan.Name // copy whatever the user set as name in to VrfName
 	request := plan.Request(ctx, bp.Client(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {

--- a/docs/data-sources/datacenter_routing_zone.md
+++ b/docs/data-sources/datacenter_routing_zone.md
@@ -59,7 +59,7 @@ output "routing_zone" {
 ### Optional
 
 - `id` (String) Apstra graph node ID. Required when `name` is omitted.
-- `name` (String) Name displayed in the Apstra web UI. Required when `id` is omitted.
+- `name` (String) Routing Zone *Label*. This is a mutable attribute of a `security_zone` node in the graph DB. It is not directly viewable in the web UI. The "name" value visible in the web UI is the `vrf_name` attribute. The *default* Routing Zone can be looked up by the value `Default routing zone`. Required when `id` is omitted.
 
 ### Read-Only
 

--- a/docs/data-sources/datacenter_routing_zones.md
+++ b/docs/data-sources/datacenter_routing_zones.md
@@ -63,7 +63,7 @@ Optional:
 Must be one of `['ipv4','ipv4_ipv6','ipv6']`.
 Requires Apstra version >=6.1.0
 - `junos_evpn_irb_mode` (String) Symmetric IRB Routing for EVPN on Junos devices makes use of an L3 VNI for inter-subnet routing which is embedded into EVPN Type2-routes to support better scaling for networks with large amounts of VLANs.
-- `name` (String) Name displayed in the Apstra web UI.
+- `name` (String) Routing Zone *Label*. This is a mutable attribute of a `security_zone` node in the graph DB. It is not directly viewable in the web UI. The "name" value visible in the web UI is the `vrf_name` attribute. The *default* Routing Zone can be looked up by the value `Default routing zone`. Required when `id` is omitted.
 - `routing_policy_id` (String) Non-EVPN blueprints must use the default policy, so this field must be null. Set this attribute in an EVPN blueprint to use a non-default policy.
 - `vlan_id` (Number) Used for VLAN tagged Layer 3 links on external connections.
 - `vni` (Number) VxLAN VNI associated with the Routing Zone.
@@ -90,7 +90,7 @@ Optional:
 Must be one of `['ipv4','ipv4_ipv6','ipv6']`.
 Requires Apstra version >=6.1.0
 - `junos_evpn_irb_mode` (String) Symmetric IRB Routing for EVPN on Junos devices makes use of an L3 VNI for inter-subnet routing which is embedded into EVPN Type2-routes to support better scaling for networks with large amounts of VLANs.
-- `name` (String) Name displayed in the Apstra web UI.
+- `name` (String) Routing Zone *Label*. This is a mutable attribute of a `security_zone` node in the graph DB. It is not directly viewable in the web UI. The "name" value visible in the web UI is the `vrf_name` attribute. The *default* Routing Zone can be looked up by the value `Default routing zone`. Required when `id` is omitted.
 - `routing_policy_id` (String) Non-EVPN blueprints must use the default policy, so this field must be null. Set this attribute in an EVPN blueprint to use a non-default policy.
 - `vlan_id` (Number) Used for VLAN tagged Layer 3 links on external connections.
 - `vni` (Number) VxLAN VNI associated with the Routing Zone.

--- a/docs/resources/datacenter_routing_zone.md
+++ b/docs/resources/datacenter_routing_zone.md
@@ -40,7 +40,7 @@ resource "apstra_datacenter_resource_pool_allocation" "blue_loopbacks" {
 ### Required
 
 - `blueprint_id` (String) Apstra Blueprint ID.
-- `name` (String) Name displayed in the Apstra web UI.
+- `name` (String) Routing Zone *Label*. This is a mutable attribute of a `security_zone` node in the graph DB. It is not directly viewable in the web UI. The "name" value visible in the web UI is the `vrf_name` attribute. Required when `id` is omitted.
 
 ### Optional
 


### PR DESCRIPTION
The web UI for _Routing  Zone_ doesn't use the _label_ attribute like other resources.

Until recently, SDK methods and the Terraform provider followed the web UI's lead by using the API's `vrf_name` attribute as the Terraform `name` attribute.

This led to confusion: It didn't behave consistently with other resources, and the SDK's `GetByLabel()` function wasn't really *getting by label*.

The Terraform provider follows the web UI's lead by only allowing one input field: We chose `name` and driving the initial value for both `vrf_name` and `name` from that single string.

In the future, we should consider fully decoupling these: Make the `vrf_name` an optional input.

Worse, there's a further copmlication: Because we drive both values from a single string, that single string bears the full weight of worst-case NOS VRF string limitations: 15 characters with a limited character set.

The default RZ's `label` field is automatically populated with: `Default routing zone` -- 20 characters, and with "illegal" spaces!

Because we applied the input constraints to the `name` (API `label`) field, in the data source, it was impossible to look up the default routing zone after the switch from `vrf_name` to `label`.

Okay, so what's in this PR:
- updated doc strings which attempt to clarify things
- a todo comment about decoupling `label` from `vrf_name`
- removal of the strict string validation from the data source `label` field -- put whatever you want in there, including `Default routing zone`. It doesn't matter in lookup context, and this change makes it possible to retrieve the default RZ.