### PR TITLE
Change `raw.RawJsonResourceAttributes()` from pointer receiver to value receiver

### DIFF
--- a/apstra/provider.go
+++ b/apstra/provider.go
@@ -666,7 +666,7 @@ func (p *Provider) Resources(_ context.Context) []func() resource.Resource {
 		func() resource.Resource { return &resourceManagedDevice{} },
 		func() resource.Resource { return &resourceManagedDeviceAck{} },
 		func() resource.Resource { return &resourceModularDeviceProfile{} },
-		func() resource.Resource { return &resourceRawJson{} },
+		func() resource.Resource { return &resourceRawJSON{} },
 		func() resource.Resource { return &resourceResourcePoolAllocation{} },
 		func() resource.Resource { return &resourcePropertySet{} },
 		func() resource.Resource { return &resourceRackType{} },

--- a/apstra/raw/rawJson.go
+++ b/apstra/raw/rawJson.go
@@ -14,14 +14,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-type RawJson struct {
-	Id           types.String         `tfsdk:"id"`
-	Url          types.String         `tfsdk:"url"`
+type RawJSON struct {
+	ID           types.String         `tfsdk:"id"`
+	URL          types.String         `tfsdk:"url"`
 	UpdateMethod types.String         `tfsdk:"update_method"`
 	Payload      jsontypes.Normalized `tfsdk:"payload"`
 }
 
-func (o RawJson) ResourceAttributes() map[string]schema.Attribute {
+func (o RawJSON) ResourceAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"id": schema.StringAttribute{
 			MarkdownDescription: "The ID of the raw JSON object. We attempt to determine the ID from the API response. " +

--- a/apstra/raw/rawJson.go
+++ b/apstra/raw/rawJson.go
@@ -21,7 +21,7 @@ type RawJson struct {
 	Payload      jsontypes.Normalized `tfsdk:"payload"`
 }
 
-func (o *RawJson) ResourceAttributes() map[string]schema.Attribute {
+func (o RawJson) ResourceAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"id": schema.StringAttribute{
 			MarkdownDescription: "The ID of the raw JSON object. We attempt to determine the ID from the API response. " +

--- a/apstra/resource_raw_json.go
+++ b/apstra/resource_raw_json.go
@@ -42,7 +42,7 @@ func (o *resourceRawJson) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"respond with a payload containing the new object ID: `{\"id\": \"xxxxxxxx\"}`. Config drift detection is " +
 			"not implemented, but update-in-place should be possible.. The `Update()` and `Delete()` functions append " +
 			"the ID (`/xxxxxxxx`) to the URL.",
-		Attributes: (*raw.RawJson)(nil).ResourceAttributes(),
+		Attributes: raw.RawJson{}.ResourceAttributes(),
 	}
 }
 

--- a/apstra/resource_raw_json.go
+++ b/apstra/resource_raw_json.go
@@ -16,23 +16,23 @@ import (
 )
 
 var (
-	_ resource.ResourceWithConfigure = &resourceRawJson{}
-	_ resourceWithSetClient          = &resourceRawJson{}
+	_ resource.ResourceWithConfigure = &resourceRawJSON{}
+	_ resourceWithSetClient          = &resourceRawJSON{}
 )
 
-type resourceRawJson struct {
+type resourceRawJSON struct {
 	client *apstra.Client
 }
 
-func (o *resourceRawJson) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (o *resourceRawJSON) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_raw_json"
 }
 
-func (o *resourceRawJson) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (o *resourceRawJSON) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	configureResource(ctx, o, req, resp)
 }
 
-func (o *resourceRawJson) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (o *resourceRawJSON) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: docCategoryFootGun + "**!!! Warning !!!**\n" +
 			"This is resource is intended only to solve problems not addressed by the normal resources." +
@@ -42,12 +42,12 @@ func (o *resourceRawJson) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"respond with a payload containing the new object ID: `{\"id\": \"xxxxxxxx\"}`. Config drift detection is " +
 			"not implemented, but update-in-place should be possible.. The `Update()` and `Delete()` functions append " +
 			"the ID (`/xxxxxxxx`) to the URL.",
-		Attributes: raw.RawJson{}.ResourceAttributes(),
+		Attributes: raw.RawJSON{}.ResourceAttributes(),
 	}
 }
 
-func (o *resourceRawJson) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan raw.RawJson
+func (o *resourceRawJSON) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan raw.RawJSON
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -57,9 +57,9 @@ func (o *resourceRawJson) Create(ctx context.Context, req resource.CreateRequest
 		Id *string `json:"id"`
 	}
 
-	u, err := url.Parse(plan.Url.ValueString())
+	u, err := url.Parse(plan.URL.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("cannot parse URL %q", plan.Url.ValueString()), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("cannot parse URL %q", plan.URL.ValueString()), err.Error())
 		return
 	}
 
@@ -73,11 +73,11 @@ func (o *resourceRawJson) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	if plan.Id.IsUnknown() {
-		plan.Id = types.StringPointerValue(idResponse.Id)
+	if plan.ID.IsUnknown() {
+		plan.ID = types.StringPointerValue(idResponse.Id)
 	}
 
-	if plan.Id.IsNull() {
+	if plan.ID.IsNull() {
 		resp.Diagnostics.AddWarning(
 			"ID is null",
 			"creation did not produce an error, but no ID was specified in the configuration and we failed to find one in the API response",
@@ -87,21 +87,21 @@ func (o *resourceRawJson) Create(ctx context.Context, req resource.CreateRequest
 	resp.State.Set(ctx, &plan)
 }
 
-func (o *resourceRawJson) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var state raw.RawJson
+func (o *resourceRawJSON) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state raw.RawJSON
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if state.Id.IsNull() {
+	if state.ID.IsNull() {
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
 	}
 
-	u, err := url.Parse(state.Url.ValueString())
+	u, err := url.Parse(state.URL.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("cannot parse URL %q", state.Url.ValueString()), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("cannot parse URL %q", state.URL.ValueString()), err.Error())
 		return
 	}
 
@@ -123,21 +123,21 @@ func (o *resourceRawJson) Read(ctx context.Context, req resource.ReadRequest, re
 	resp.State.Set(ctx, &state)
 }
 
-func (o *resourceRawJson) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan raw.RawJson
+func (o *resourceRawJSON) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan raw.RawJSON
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if plan.Id.IsNull() {
+	if plan.ID.IsNull() {
 		resp.Diagnostics.AddWarning("cannot update raw JSON object", "ID is null -- cannot update")
 		return
 	}
 
-	u, err := url.Parse(fmt.Sprintf("%s/%s", plan.Url.ValueString(), plan.Id.ValueString()))
+	u, err := url.Parse(fmt.Sprintf("%s/%s", plan.URL.ValueString(), plan.ID.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("cannot parse URL %q", plan.Url.ValueString()), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("cannot parse URL %q", plan.URL.ValueString()), err.Error())
 		return
 	}
 
@@ -154,21 +154,21 @@ func (o *resourceRawJson) Update(ctx context.Context, req resource.UpdateRequest
 	resp.State.Set(ctx, &plan)
 }
 
-func (o *resourceRawJson) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var state raw.RawJson
+func (o *resourceRawJSON) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state raw.RawJSON
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if state.Id.IsNull() {
+	if state.ID.IsNull() {
 		resp.Diagnostics.AddWarning("cannot delete raw JSON object", "ID is null -- cannot update")
 		return
 	}
 
-	u, err := url.Parse(fmt.Sprintf("%s/%s", state.Url.ValueString(), state.Id.ValueString()))
+	u, err := url.Parse(fmt.Sprintf("%s/%s", state.URL.ValueString(), state.ID.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("cannot parse URL %q", state.Url.ValueString()), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("cannot parse URL %q", state.URL.ValueString()), err.Error())
 		return
 	}
 
@@ -187,6 +187,6 @@ func (o *resourceRawJson) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 }
 
-func (o *resourceRawJson) setClient(client *apstra.Client) {
+func (o *resourceRawJSON) setClient(client *apstra.Client) {
 	o.client = client
 }


### PR DESCRIPTION
The main purpose of this PR is to change this function signature:
```go
func (o *RawJson) ResourceAttributes() map[string]schema.Attribute
```

To this function signature:
```go
func (o RawJson) ResourceAttributes() map[string]schema.Attribute
```

...for consistency with other resources.

While in there, I also updated some variable and type names to use Go convention for capitalization: `Json` -> `JSON`, `Id` -> `ID` and `Url` -> `URL`.

Closes #1212