### PR TITLE
Absorb SDK breaking changes re: cabling map

### DIFF
--- a/apstra/blueprint/datacenter_generic_system.go
+++ b/apstra/blueprint/datacenter_generic_system.go
@@ -274,13 +274,14 @@ func (o *DatacenterGenericSystem) ReadLinks(ctx context.Context, bp *apstra.TwoS
 	}
 
 	// get the list of links from the API and filter out non-Ethernet links
-	apiLinks, err := bp.GetCablingMapLinksBySystem(ctx, apstra.ObjectId(o.Id.ValueString()))
+	apiLinks, err := bp.GetCablingMapLinksBySystem(ctx, o.Id.ValueString())
 	if err != nil {
 		diags.AddError(fmt.Sprintf("failed to fetch generic system %s links", o.Id), err.Error())
 		return
 	}
 	for i := len(apiLinks) - 1; i >= 0; i-- { // loop backwards through the slice
-		if apiLinks[i].Type != apstra.LinkTypeEthernet { // target non-Ethernet links for deletion
+		// remove non-Ethernet links from the slice
+		if apiLinks[i].Type != nil && *apiLinks[i].Type != enum.LinkTypeEthernet {
 			apiLinks[i] = apiLinks[len(apiLinks)-1] // overwrite unwanted element with last element
 			apiLinks = apiLinks[:len(apiLinks)-1]   // shorten the slice to eliminate the newly dup'ed last item.
 		}
@@ -290,7 +291,7 @@ func (o *DatacenterGenericSystem) ReadLinks(ctx context.Context, bp *apstra.TwoS
 	for i, apiLink := range apiLinks {
 		var dcgsl DatacenterGenericSystemLink
 		// loadApiData handles every detail except for the transform ID
-		dcgsl.loadApiData(ctx, &apiLink, apstra.ObjectId(o.Id.ValueString()), diags)
+		dcgsl.loadApiData(ctx, &apiLink, o.Id.ValueString(), diags)
 		if diags.HasError() {
 			return
 		}
@@ -984,7 +985,7 @@ func IfIdFromSwIdAndIfName(ctx context.Context, bp *apstra.TwoStageL3ClosClient,
 		Node([]apstra.QEEAttribute{
 			apstra.NodeTypeInterface.QEEAttribute(),
 			{Key: "if_name", Value: apstra.QEStringVal(ifName)},
-			{Key: "if_type", Value: apstra.QEStringVal(apstra.InterfaceTypeEthernet.String())},
+			{Key: "if_type", Value: apstra.QEStringVal(enum.InterfaceTypeEthernet.String())},
 			{Key: "name", Value: apstra.QEStringVal("n_interface")},
 		})
 

--- a/apstra/blueprint/datacenter_generic_system_link.go
+++ b/apstra/blueprint/datacenter_generic_system_link.go
@@ -113,13 +113,21 @@ func (o *DatacenterGenericSystemLink) Digest() string {
 	return o.TargetSwitchId.ValueString() + ":" + o.TargetSwitchIfName.ValueString()
 }
 
-func (o *DatacenterGenericSystemLink) loadApiData(ctx context.Context, in *apstra.CablingMapLink, genericSystemId apstra.ObjectId, diags *diag.Diagnostics) {
-	switchEndpoint := in.OppositeEndpointBySystemId(genericSystemId)
+func (o *DatacenterGenericSystemLink) loadApiData(ctx context.Context, in *apstra.CablingMapLink, genericSystemId string, diags *diag.Diagnostics) {
+	switchEndpoint := in.OppositeEndpointBySystemID(genericSystemId)
 
-	o.TargetSwitchId = types.StringValue(switchEndpoint.System.Id.String())
-	o.TargetSwitchIfName = types.StringPointerValue(switchEndpoint.Interface.IfName)
-	o.GroupLabel = types.StringValue(in.GroupLabel)
-	o.LagMode = value.StringOrNull(ctx, switchEndpoint.Interface.LagMode.String(), diags)
+	if switchEndpoint != nil {
+		if switchEndpoint.System != nil {
+			o.TargetSwitchId = types.StringValue(switchEndpoint.System.ID)
+		}
+		if switchEndpoint.Interface.IfName != nil {
+			o.TargetSwitchIfName = types.StringPointerValue(switchEndpoint.Interface.IfName)
+		}
+		if switchEndpoint.Interface.LAGMode != nil {
+			o.LagMode = value.StringOrNull(ctx, switchEndpoint.Interface.LAGMode.String(), diags)
+		}
+	}
+	o.GroupLabel = types.StringPointerValue(in.GroupLabel)
 	o.Tags = value.SetOrNull(ctx, types.StringType, in.TagLabels, diags)
 }
 

--- a/apstra/resource_datacenter_generic_system.go
+++ b/apstra/resource_datacenter_generic_system.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -213,7 +214,7 @@ func (o *resourceDatacenterGenericSystem) Create(ctx context.Context, req resour
 	}
 
 	// use link IDs to learn the generic system ID
-	genericSystemId, err := bp.SystemNodeFromLinkIds(ctx, linkIds, apstra.SystemNodeRoleGeneric)
+	genericSystemID, err := bp.SystemNodeFromLinkIds(ctx, linkIds, &enum.SystemNodeRoleGeneric)
 	if err != nil {
 		sb := new(strings.Builder)
 		for i, linkId := range linkIds {
@@ -225,9 +226,11 @@ func (o *resourceDatacenterGenericSystem) Create(ctx context.Context, req resour
 		}
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("failed to determine new generic system ID from returned link IDs: [%s]", sb.String()),
-			err.Error())
+			err.Error(),
+		)
+		return
 	}
-	plan.Id = types.StringValue(genericSystemId.String())
+	plan.Id = types.StringValue(genericSystemID.String())
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...) // provisional state in case of error below
 
 	// set generic system properties sending <nil> for prior state

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.25.4
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20260227210643-a9513883785a
+	github.com/Juniper/apstra-go-sdk v0.0.0-20260314133645-ec30c9f28505
 	github.com/chrismarget-j/version-constraints v0.0.0-20250911132047-1122a37b27ae
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-version v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20260227210643-a9513883785a h1:sJMrklJT9OMBpsIv6HY0qzB/EPM+UvUxauaeXXlH9tk=
-github.com/Juniper/apstra-go-sdk v0.0.0-20260227210643-a9513883785a/go.mod h1:IXhtfYsKJAfSwUgvi1roB+DN+InkGyGb/ely7LOOF/0=
+github.com/Juniper/apstra-go-sdk v0.0.0-20260314133645-ec30c9f28505 h1:18AlCJw2QNi8MRHmNdkwfIiKAEhF2aBG3xnfb1aEOl4=
+github.com/Juniper/apstra-go-sdk v0.0.0-20260314133645-ec30c9f28505/go.mod h1:IXhtfYsKJAfSwUgvi1roB+DN+InkGyGb/ely7LOOF/0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=


### PR DESCRIPTION
This PR bumps the SDK to the version with recent cabling map changes: ObjectId vs string, pointers instead of values, etc.