### PR TITLE
New custom type: `StringWithEmptyEqualsNull`

### DIFF
--- a/apstra/custom_types/string_with_empty_equals_null_type.go
+++ b/apstra/custom_types/string_with_empty_equals_null_type.go
@@ -1,0 +1,69 @@
+package customtypes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.StringTypable = (*StringWithEmptyEqualsNullType)(nil)
+	_ attr.Type               = (*StringWithEmptyEqualsNullType)(nil)
+)
+
+type StringWithEmptyEqualsNullType struct {
+	basetypes.StringType
+}
+
+// String returns a human readable string of the type name.
+func (t StringWithEmptyEqualsNullType) String() string {
+	return "customtypes.StringWithEmptyEqualsNull"
+}
+
+// ValueType returns the Value type.
+func (t StringWithEmptyEqualsNullType) ValueType(_ context.Context) attr.Value {
+	return StringWithEmptyEqualsNull{}
+}
+
+// Equal returns true if the given type is equivalent.
+func (t StringWithEmptyEqualsNullType) Equal(o attr.Type) bool {
+	other, ok := o.(StringWithEmptyEqualsNullType)
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+// ValueFromString returns a StringValuable type given a StringValue.
+func (t StringWithEmptyEqualsNullType) ValueFromString(_ context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return StringWithEmptyEqualsNull{
+		StringValue: in,
+	}, nil
+}
+
+// ValueFromTerraform returns a Value given a tftypes.Value.  This is meant to convert the tftypes.Value into a more convenient Go type
+// for the provider to consume the data with.
+func (t StringWithEmptyEqualsNullType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}

--- a/apstra/custom_types/string_with_empty_equals_null_type_test.go
+++ b/apstra/custom_types/string_with_empty_equals_null_type_test.go
@@ -30,6 +30,10 @@ func TestStringWithEmptyEqualsNullType_ValueFromTerraform(t *testing.T) {
 			in:          tftypes.NewValue(tftypes.String, nil),
 			expectation: customtypes.NewStringWithEmptyEqualsNullNull(),
 		},
+		"null from pointer": {
+			in:          tftypes.NewValue(tftypes.String, nil),
+			expectation: customtypes.NewStringWithEmptyEqualsNullPointerValue(nil),
+		},
 		"wrongType": {
 			in:          tftypes.NewValue(tftypes.Number, 123),
 			expectedErr: "can't unmarshal tftypes.Number into *string, expected string",

--- a/apstra/custom_types/string_with_empty_equals_null_type_test.go
+++ b/apstra/custom_types/string_with_empty_equals_null_type_test.go
@@ -1,0 +1,56 @@
+package customtypes_test
+
+import (
+	"context"
+	"testing"
+
+	customtypes "github.com/Juniper/terraform-provider-apstra/apstra/custom_types"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringWithEmptyEqualsNullType_ValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in          tftypes.Value
+		expectation attr.Value
+		expectedErr string
+	}{
+		"true": {
+			in:          tftypes.NewValue(tftypes.String, "foo"),
+			expectation: customtypes.NewStringWithEmptyEqualsNullValue("foo"),
+		},
+		"unknown": {
+			in:          tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expectation: customtypes.NewStringWithEmptyEqualsNullUnknown(),
+		},
+		"null": {
+			in:          tftypes.NewValue(tftypes.String, nil),
+			expectation: customtypes.NewStringWithEmptyEqualsNullNull(),
+		},
+		"wrongType": {
+			in:          tftypes.NewValue(tftypes.Number, 123),
+			expectedErr: "can't unmarshal tftypes.Number into *string, expected string",
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			got, err := customtypes.StringWithEmptyEqualsNullType{}.ValueFromTerraform(ctx, tCase.in)
+			if tCase.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Equal(t, tCase.expectedErr, err.Error())
+				return
+			}
+
+			require.Truef(t, got.Equal(tCase.expectation), "values not equal %s, %s", tCase.expectation, got)
+		})
+	}
+}

--- a/apstra/custom_types/string_with_empty_equals_null_value.go
+++ b/apstra/custom_types/string_with_empty_equals_null_value.go
@@ -1,0 +1,82 @@
+package customtypes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var (
+	_ basetypes.StringValuable                   = (*StringWithEmptyEqualsNull)(nil)
+	_ basetypes.StringValuableWithSemanticEquals = (*StringWithEmptyEqualsNull)(nil)
+)
+
+type StringWithEmptyEqualsNull struct {
+	basetypes.StringValue
+}
+
+func (v StringWithEmptyEqualsNull) Type(_ context.Context) attr.Type {
+	return StringWithEmptyEqualsNullType{}
+}
+
+func (v StringWithEmptyEqualsNull) Equal(o attr.Value) bool {
+	other, ok := o.(StringWithEmptyEqualsNull)
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+// StringSemanticEquals implements the semantic equality check. According to this
+// (https://discuss.hashicorp.com/t/can-semantic-equality-check-in-custom-types-be-asymmetrical/60644/2?u=hqnvylrx)
+// semantic equality checks on custom types are always implementeed as oldValue.SemanticEquals(ctx, newValue)
+func (v StringWithEmptyEqualsNull) StringSemanticEquals(_ context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(StringWithEmptyEqualsNull)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", newValuable),
+		)
+
+		return false, diags
+	}
+
+	// check for actual equality
+	if v.Equal(newValue) {
+		return true, diags
+	}
+
+	// values are semantically equal if one is "" and the other is Null
+	if (v.IsNull() && newValue.ValueString() == "") || (newValue.IsNull() && v.ValueString() == "") {
+		return true, diags
+	}
+
+	return false, diags
+}
+
+func NewStringWithEmptyEqualsNullNull() StringWithEmptyEqualsNull {
+	return StringWithEmptyEqualsNull{
+		StringValue: basetypes.NewStringNull(),
+	}
+}
+
+func NewStringWithEmptyEqualsNullUnknown() StringWithEmptyEqualsNull {
+	return StringWithEmptyEqualsNull{
+		StringValue: basetypes.NewStringUnknown(),
+	}
+}
+
+func NewStringWithEmptyEqualsNullValue(value string) StringWithEmptyEqualsNull {
+	return StringWithEmptyEqualsNull{
+		StringValue: basetypes.NewStringValue(value),
+	}
+}

--- a/apstra/custom_types/string_with_empty_equals_null_value.go
+++ b/apstra/custom_types/string_with_empty_equals_null_value.go
@@ -80,3 +80,13 @@ func NewStringWithEmptyEqualsNullValue(value string) StringWithEmptyEqualsNull {
 		StringValue: basetypes.NewStringValue(value),
 	}
 }
+
+// NewStringWithEmptyEqualsNullPointerValue creates a new StringWithEmptyEqualsNull from a *string.
+// If value is nil, the resulting StringWithEmptyEqualsNull will be Null.
+func NewStringWithEmptyEqualsNullPointerValue(value *string) StringWithEmptyEqualsNull {
+	if value == nil {
+		return NewStringWithEmptyEqualsNullNull()
+	}
+
+	return NewStringWithEmptyEqualsNullValue(*value)
+}

--- a/apstra/custom_types/string_with_empty_equals_null_value_test.go
+++ b/apstra/custom_types/string_with_empty_equals_null_value_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	customtypes "github.com/Juniper/terraform-provider-apstra/apstra/custom_types"
+	"github.com/Juniper/terraform-provider-apstra/internal/pointer"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/require"
 )
@@ -22,6 +23,11 @@ func TestStringWithEmptyEqualsNull_StringSemanticEquals(t *testing.T) {
 			givenValue:    customtypes.NewStringWithEmptyEqualsNullValue("foo"),
 			expectedMatch: true,
 		},
+		"equal values from pointer": {
+			currentValue:  customtypes.NewStringWithEmptyEqualsNullValue("foo"),
+			givenValue:    customtypes.NewStringWithEmptyEqualsNullPointerValue(pointer.To("foo")),
+			expectedMatch: true,
+		},
 		"semantically equal - null and empty": {
 			currentValue:  customtypes.NewStringWithEmptyEqualsNullNull(),
 			givenValue:    customtypes.NewStringWithEmptyEqualsNullValue(""),
@@ -30,6 +36,11 @@ func TestStringWithEmptyEqualsNull_StringSemanticEquals(t *testing.T) {
 		"semantically equal - empty and null": {
 			currentValue:  customtypes.NewStringWithEmptyEqualsNullValue(""),
 			givenValue:    customtypes.NewStringWithEmptyEqualsNullNull(),
+			expectedMatch: true,
+		},
+		"semantically equal - empty and nil pointer value": {
+			currentValue:  customtypes.NewStringWithEmptyEqualsNullValue(""),
+			givenValue:    customtypes.NewStringWithEmptyEqualsNullPointerValue(nil),
 			expectedMatch: true,
 		},
 		"not equal": {

--- a/apstra/custom_types/string_with_empty_equals_null_value_test.go
+++ b/apstra/custom_types/string_with_empty_equals_null_value_test.go
@@ -1,0 +1,51 @@
+package customtypes_test
+
+import (
+	"context"
+	"testing"
+
+	customtypes "github.com/Juniper/terraform-provider-apstra/apstra/custom_types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringWithEmptyEqualsNull_StringSemanticEquals(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		currentValue  customtypes.StringWithEmptyEqualsNull
+		givenValue    basetypes.StringValuable
+		expectedMatch bool
+	}{
+		"equal": {
+			currentValue:  customtypes.NewStringWithEmptyEqualsNullValue("foo"),
+			givenValue:    customtypes.NewStringWithEmptyEqualsNullValue("foo"),
+			expectedMatch: true,
+		},
+		"semantically equal - null and empty": {
+			currentValue:  customtypes.NewStringWithEmptyEqualsNullNull(),
+			givenValue:    customtypes.NewStringWithEmptyEqualsNullValue(""),
+			expectedMatch: true,
+		},
+		"semantically equal - empty and null": {
+			currentValue:  customtypes.NewStringWithEmptyEqualsNullValue(""),
+			givenValue:    customtypes.NewStringWithEmptyEqualsNullNull(),
+			expectedMatch: true,
+		},
+		"not equal": {
+			currentValue:  customtypes.NewStringWithEmptyEqualsNullValue("foo"),
+			givenValue:    customtypes.NewStringWithEmptyEqualsNullValue("FOO"),
+			expectedMatch: false,
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+
+			match, diags := tCase.currentValue.StringSemanticEquals(context.Background(), tCase.givenValue)
+			require.Equalf(t, tCase.expectedMatch, match, "Expected StringSemanticEquals to return: %t, but got: %t", tCase.expectedMatch, match)
+			require.Nil(t, diags)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a custom string type: `customtypes.StringWithEmptyEqualsNull{}`

It has semantic equality logic which treats an empty value `""` as equal to a Null value.

It'll be used for attributes where empty string is an illegal API value, but we use `""` to signal that the value should be cleared on the server side.

This way, during `Read()` we can return missing/empty values as `Null` and no drift will be detected if the user used an explicit empty string (`thing = ""`) to wipe out a previously assigned value.