### PR TITLE
Ensure Third Party Licenses are writable by file owner

### DIFF
--- a/scripts/compliance.sh
+++ b/scripts/compliance.sh
@@ -79,3 +79,7 @@ if [[ "$minimal_mode" == true ]]; then
     # We now likely have some empty directories. Get rid of 'em.
     find "$TPC" -depth -type d -empty -exec rmdir -- "{}" \;
 fi
+
+# Set permissions on the compliance directory because of https://github.com/Juniper/terraform-provider-apstra/issues/1183
+find "$TPC" -type f -print0 | xargs -0 chmod 644
+find "$TPC" -type d -print0 | xargs -0 chmod 755


### PR DESCRIPTION
#1183 is a problem where extracting the provider zip onto an existing installation fails due to non-writable files.

This PR ensures that the whole `Third_Party_Code/` (tree of licenses) is writable by owner.