### PR TITLE
Bump SDK and add support for Apstra 6.1.2

### DIFF
--- a/apstra/api_versions/versions.go
+++ b/apstra/api_versions/versions.go
@@ -14,6 +14,7 @@ const (
 	Apstra600  = "6.0.0"
 	Apstra610  = "6.1.0"
 	Apstra611  = "6.1.1"
+	Apstra612  = "6.1.2"
 
 	GeApstra421 = ">=" + Apstra421
 	GeApstra500 = ">=" + Apstra500

--- a/apstra/blueprint/datacenter_generic_system_link.go
+++ b/apstra/blueprint/datacenter_generic_system_link.go
@@ -120,8 +120,8 @@ func (o *DatacenterGenericSystemLink) loadApiData(ctx context.Context, in *apstr
 		if switchEndpoint.System != nil {
 			o.TargetSwitchId = types.StringValue(switchEndpoint.System.ID)
 		}
-		if switchEndpoint.Interface.IfName != nil {
-			o.TargetSwitchIfName = types.StringPointerValue(switchEndpoint.Interface.IfName)
+		if switchEndpoint.Interface.Name != nil {
+			o.TargetSwitchIfName = types.StringPointerValue(switchEndpoint.Interface.Name)
 		}
 		if switchEndpoint.Interface.LAGMode != nil {
 			o.LagMode = value.StringOrNull(ctx, switchEndpoint.Interface.LAGMode.String(), diags)

--- a/apstra/blueprint/interconnect_domain.go
+++ b/apstra/blueprint/interconnect_domain.go
@@ -135,28 +135,30 @@ func (o InterconnectDomain) ResourceAttributes() map[string]resourceSchema.Attri
 	}
 }
 
-func (o InterconnectDomain) Request(_ context.Context, diags *diag.Diagnostics) *apstra.EvpnInterconnectGroupData {
-	var esiMac net.HardwareAddr
+func (o InterconnectDomain) Request(_ context.Context, diags *diag.Diagnostics) apstra.EVPNInterconnectGroup {
+	var esiMAC net.HardwareAddr
 
 	if utils.HasValue(o.EsiMac) {
 		var err error
-		esiMac, err = net.ParseMAC(o.EsiMac.ValueString())
+		esiMAC, err = net.ParseMAC(o.EsiMac.ValueString())
 		if err != nil {
 			diags.AddError("failed to parse interconnect esi mac: "+o.EsiMac.ValueString(), err.Error())
 		}
 	}
 
-	return &apstra.EvpnInterconnectGroupData{
-		Label:       o.Name.ValueString(),
-		RouteTarget: o.RouteTarget.ValueString(),
-		EsiMac:      esiMac,
+	result := apstra.EVPNInterconnectGroup{
+		Label:       o.Name.ValueStringPointer(),
+		RouteTarget: o.RouteTarget.ValueStringPointer(),
+		ESIMAC:      esiMAC,
 	}
+	_ = result.SetID(o.Id.ValueString()) // this will not error
+	return result
 }
 
-func (o *InterconnectDomain) LoadApiData(_ context.Context, data *apstra.EvpnInterconnectGroupData, _ *diag.Diagnostics) {
-	o.EsiMac = hwtypes.NewMACAddressValue(data.EsiMac.String())
-	o.Name = types.StringValue(data.Label)
-	o.RouteTarget = types.StringValue(data.RouteTarget)
+func (o *InterconnectDomain) LoadApiData(_ context.Context, data apstra.EVPNInterconnectGroup, _ *diag.Diagnostics) {
+	o.EsiMac = hwtypes.NewMACAddressValue(data.ESIMAC.String())
+	o.Name = types.StringPointerValue(data.Label)
+	o.RouteTarget = types.StringPointerValue(data.RouteTarget)
 }
 
 func (o *InterconnectDomain) Query(resultName string) apstra.QEQuery {

--- a/apstra/compatibility/api_versions.go
+++ b/apstra/compatibility/api_versions.go
@@ -22,6 +22,7 @@ func SupportedApiVersions() []string {
 		apiversions.Apstra600,
 		apiversions.Apstra610,
 		apiversions.Apstra611,
+		apiversions.Apstra612,
 		// apiversions.Apstra700, todo: check/update the MarkdownDescription strings in the following methods to see
 		//                         if multiple interconnect domains are supported when new versions become available:
 		//                           - resourceDatacenterInterconnectDomainGateway.Schema()

--- a/apstra/compatibility/api_versions_test.go
+++ b/apstra/compatibility/api_versions_test.go
@@ -19,6 +19,7 @@ func TestSupportedApiVersions(t *testing.T) {
 		apiversions.Apstra600,
 		apiversions.Apstra610,
 		apiversions.Apstra611,
+		apiversions.Apstra612,
 	}
 
 	result := SupportedApiVersions()

--- a/apstra/compatibility/api_versions_test.go
+++ b/apstra/compatibility/api_versions_test.go
@@ -37,8 +37,9 @@ func TestSupportedApiVersionsPretty(t *testing.T) {
 		apiversions.Apstra501 + ", " +
 		apiversions.Apstra510 + ", " +
 		apiversions.Apstra600 + ", " +
-		apiversions.Apstra610 + ", and " +
-		apiversions.Apstra611
+		apiversions.Apstra610 + ", " +
+		apiversions.Apstra611 + ", and " +
+		apiversions.Apstra612
 
 	result := SupportedApiVersionsPretty()
 	if expected != result {

--- a/apstra/data_source_datacenter_interconnect_domain.go
+++ b/apstra/data_source_datacenter_interconnect_domain.go
@@ -56,10 +56,10 @@ func (o *dataSourceDatacenterInterconnectDomain) Read(ctx context.Context, req d
 		return
 	}
 
-	var api *apstra.EvpnInterconnectGroup
+	var api apstra.EVPNInterconnectGroup
 	switch {
 	case !config.Name.IsNull():
-		api, err = bp.GetEvpnInterconnectGroupByName(ctx, config.Name.ValueString())
+		api, err = bp.GetEVPNInterconnectGroupByName(ctx, config.Name.ValueString())
 		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("name"),
@@ -68,7 +68,7 @@ func (o *dataSourceDatacenterInterconnectDomain) Read(ctx context.Context, req d
 			return
 		}
 	case !config.Id.IsNull():
-		api, err = bp.GetEvpnInterconnectGroup(ctx, apstra.ObjectId(config.Id.ValueString()))
+		api, err = bp.GetEVPNInterconnectGroup(ctx, config.Id.ValueString())
 		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
@@ -84,11 +84,11 @@ func (o *dataSourceDatacenterInterconnectDomain) Read(ctx context.Context, req d
 
 	// add ID value in case the caller passed us the name instead
 	if !utils.HasValue(config.Id) {
-		config.Id = types.StringValue(api.Id.String())
+		config.Id = types.StringPointerValue(api.ID())
 	}
 
 	// load the remaining details
-	config.LoadApiData(ctx, api.Data, &resp.Diagnostics)
+	config.LoadApiData(ctx, api, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/apstra/data_source_datacenter_interconnect_domains.go
+++ b/apstra/data_source_datacenter_interconnect_domains.go
@@ -133,7 +133,7 @@ func (o *dataSourceDatacenterInterconnectDomains) setBpClientFunc(f func(context
 }
 
 func (o *dataSourceDatacenterInterconnectDomains) getAllIds(ctx context.Context, bp *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) []attr.Value {
-	all, err := bp.GetAllEvpnInterconnectGroups(ctx)
+	all, err := bp.GetAllEVPNInterconnectGroups(ctx)
 	if err != nil {
 		diags.AddError(
 			fmt.Sprintf("failed to retrieve Interconnect Domains in Blueprint %s", bp.Id()), err.Error())
@@ -142,7 +142,7 @@ func (o *dataSourceDatacenterInterconnectDomains) getAllIds(ctx context.Context,
 
 	result := make([]attr.Value, len(all))
 	for i, each := range all {
-		result[i] = types.StringValue(each.Id.String())
+		result[i] = types.StringPointerValue(each.ID())
 	}
 
 	return result

--- a/apstra/freeform/aggregate_link_endpoint.go
+++ b/apstra/freeform/aggregate_link_endpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"sort"
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
@@ -113,8 +114,14 @@ func (o AggregateLinkEndpoint) resourceAttributes() map[string]resourceSchema.At
 			Required:            true,
 		},
 		"lag_mode": resourceSchema.StringAttribute{
-			MarkdownDescription: fmt.Sprintf("LAG mode of the logical aggregate interface. Must be one of: `%s`.",
-				strings.Join(enum.LAGModes.Values(), "`, `")),
+			MarkdownDescription: fmt.Sprintf(
+				"LAG mode of the logical aggregate interface. Must be one of: `%s`.",
+				func() string {
+					vals := enum.LAGModes.Values()
+					sort.Strings(vals)
+					return strings.Join(vals, "`, `")
+				}(),
+			),
 			Required:   true,
 			Validators: []validator.String{stringvalidator.OneOf(enum.LAGModes.Values()...)},
 		},

--- a/apstra/resource_datacenter_interconnect_domain.go
+++ b/apstra/resource_datacenter_interconnect_domain.go
@@ -73,23 +73,23 @@ func (o *resourceDatacenterInterconnectDomain) Create(ctx context.Context, req r
 		return
 	}
 
-	id, err := bp.CreateEvpnInterconnectGroup(ctx, request)
+	id, err := bp.CreateEVPNInterconnectGroup(ctx, request)
 	if err != nil {
 		resp.Diagnostics.AddError("failed creating interconnect domain", err.Error())
 		return
 	}
 
-	plan.Id = types.StringValue(id.String())
+	plan.Id = types.StringValue(id)
 
 	if plan.EsiMac.IsUnknown() {
 		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...) // just in case we fail
-		api, err := bp.GetEvpnInterconnectGroup(ctx, id)
+		api, err := bp.GetEVPNInterconnectGroup(ctx, id)
 		if err != nil {
 			resp.Diagnostics.AddError("failed reading new Interconnect Domain ESI MAC", err.Error())
 			return
 		}
 
-		plan.LoadApiData(ctx, api.Data, &resp.Diagnostics)
+		plan.LoadApiData(ctx, api, &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -117,7 +117,7 @@ func (o *resourceDatacenterInterconnectDomain) Read(ctx context.Context, req res
 		return
 	}
 
-	api, err := bp.GetEvpnInterconnectGroup(ctx, apstra.ObjectId(state.Id.ValueString()))
+	api, err := bp.GetEVPNInterconnectGroup(ctx, state.Id.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
@@ -128,7 +128,7 @@ func (o *resourceDatacenterInterconnectDomain) Read(ctx context.Context, req res
 	}
 
 	// Set state
-	state.LoadApiData(ctx, api.Data, &resp.Diagnostics)
+	state.LoadApiData(ctx, api, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -163,7 +163,7 @@ func (o *resourceDatacenterInterconnectDomain) Update(ctx context.Context, req r
 	}
 
 	// Update Interconnect Domain
-	err = bp.UpdateEvpnInterconnectGroup(ctx, apstra.ObjectId(plan.Id.ValueString()), request)
+	err = bp.UpdateEVPNInterconnectGroup(ctx, request)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("error updating Blueprint %s Interconnect Domain %s", plan.BlueprintId, plan.Id),
@@ -172,13 +172,13 @@ func (o *resourceDatacenterInterconnectDomain) Update(ctx context.Context, req r
 	}
 
 	if plan.EsiMac.IsUnknown() {
-		api, err := bp.GetEvpnInterconnectGroup(ctx, apstra.ObjectId(plan.Id.ValueString()))
+		api, err := bp.GetEVPNInterconnectGroup(ctx, plan.Id.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("failed reading updated Interconnect Domain ESI MAC", err.Error())
 			return
 		}
 
-		plan.LoadApiData(ctx, api.Data, &resp.Diagnostics)
+		plan.LoadApiData(ctx, api, &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -216,7 +216,7 @@ func (o *resourceDatacenterInterconnectDomain) Delete(ctx context.Context, req r
 	}
 
 	// Delete Interconnect Domain by calling API
-	err = bp.DeleteEvpnInterconnectGroup(ctx, apstra.ObjectId(state.Id.ValueString()))
+	err = bp.DeleteEVPNInterconnectGroup(ctx, state.Id.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
 			return // 404 is okay

--- a/apstra/resource_datacenter_interconnect_domain_gateway_integration_test.go
+++ b/apstra/resource_datacenter_interconnect_domain_gateway_integration_test.go
@@ -43,7 +43,7 @@ type resourceDataCenterInterconnectDomainGateway struct {
 	name                 string
 	ipAddress            net.IP
 	asn                  uint32
-	interconnectDomainId apstra.ObjectId
+	interconnectDomainId string
 	nodes                []string
 	ttl                  *uint8
 	keepaliveTime        *uint16
@@ -78,7 +78,7 @@ func (o resourceDataCenterInterconnectDomainGateway) testChecks(t testing.TB, bp
 	result.append(t, "TestCheckResourceAttr", "name", o.name)
 	result.append(t, "TestCheckResourceAttr", "ip_address", o.ipAddress.String())
 	result.append(t, "TestCheckResourceAttr", "asn", strconv.Itoa(int(o.asn)))
-	result.append(t, "TestCheckResourceAttr", "interconnect_domain_id", o.interconnectDomainId.String())
+	result.append(t, "TestCheckResourceAttr", "interconnect_domain_id", o.interconnectDomainId)
 
 	result.append(t, "TestCheckResourceAttr", "local_gateway_nodes.#", strconv.Itoa(len(o.nodes)))
 	for _, node := range o.nodes {
@@ -117,11 +117,11 @@ func TestResourceDatacenterInterconnectDomainGateway(t *testing.T) {
 
 	bp := testutils.BlueprintC(t, ctx)
 
-	interconnectDomainIds := make([]apstra.ObjectId, 2)
+	interconnectDomainIds := make([]string, 2)
 	for i := range interconnectDomainIds {
-		id, err := bp.CreateEvpnInterconnectGroup(ctx, &apstra.EvpnInterconnectGroupData{
-			Label:       acctest.RandStringFromCharSet(6, acctest.CharSetAlpha),
-			RouteTarget: randomRT(t),
+		id, err := bp.CreateEVPNInterconnectGroup(ctx, apstra.EVPNInterconnectGroup{
+			Label:       pointer.To(acctest.RandStringFromCharSet(6, acctest.CharSetAlpha)),
+			RouteTarget: pointer.To(randomRT(t)),
 		})
 		require.NoError(t, err)
 		interconnectDomainIds[i] = id

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ It covers day 0 and day 1 operations (design and deployment), and a growing list
 
 Use the navigation tree on the left to read about the available resources and data sources.
 
-This release has been tested with Apstra versions 4.2.0, 4.2.1, 4.2.1.1, 4.2.2, 5.0.0, 5.0.1, 5.1.0, 6.0.0, 6.1.0, and 6.1.1.
+This release has been tested with Apstra versions 4.2.0, 4.2.1, 4.2.1.1, 4.2.2, 5.0.0, 5.0.1, 5.1.0, 6.0.0, 6.1.0, 6.1.1, and 6.1.2.
 
 Some example projects which make use of this provider can be found [here](https://github.com/Juniper/terraform-apstra-examples).
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.25.4
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20260314133645-ec30c9f28505
+	github.com/Juniper/apstra-go-sdk v0.0.0-20260416215109-beae98811fbd
 	github.com/chrismarget-j/version-constraints v0.0.0-20250911132047-1122a37b27ae
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-version v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20260314133645-ec30c9f28505 h1:18AlCJw2QNi8MRHmNdkwfIiKAEhF2aBG3xnfb1aEOl4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20260314133645-ec30c9f28505/go.mod h1:IXhtfYsKJAfSwUgvi1roB+DN+InkGyGb/ely7LOOF/0=
+github.com/Juniper/apstra-go-sdk v0.0.0-20260416215109-beae98811fbd h1:5YGB7D1bKQSnvI4el/uZpm5HKOCwr+D1xP12uHOAt00=
+github.com/Juniper/apstra-go-sdk v0.0.0-20260416215109-beae98811fbd/go.mod h1:IXhtfYsKJAfSwUgvi1roB+DN+InkGyGb/ely7LOOF/0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=


### PR DESCRIPTION
This PR bumps the SDK to the latest version with support for Apstra 6.1.2.

## 6.1.2 support
- Added version 6.1.2 to supported versions list, tests, etc.

## SDK changes forced some refactoring
- Stuff related to `apstra.EVPNInterconnectGroup{}` [SDK #700](https://github.com/Juniper/apstra-go-sdk/pull/700)
- Rename of `apstra.CablingMapLinkEndpointInterface.IfName` to `apstra.CablingMapLinkEndpointInterface.Name` [SDK #699](https://github.com/Juniper/apstra-go-sdk/pull/699)

## Odds and Ends
The `lag_mode` attribute of the `apstra_freeform_aggregate_link` resource changed the rendered order of the permitted values. This may be due to something in the SDK, but those values are backed by a map, so the order isn't guaranteed anyway. I added a sort function.

## Testing
Tests pass with:
 - 4.2.0-236
 - 4.2.1-207
 - 4.2.1.1-10
 - 4.2.2-2
 - 5.0.0-63
 - 5.0.1-1
 - 5.1.0-117
 - 6.0.0-189
 - 6.1.0-5
 - 6.1.1-70
 - 6.1.2-28
