### PR TITLE
Bump SDK for 6.2.0 support

### DIFF
--- a/apstra/blueprint/connectivity_templates/primitives/ip_link.go
+++ b/apstra/blueprint/connectivity_templates/primitives/ip_link.go
@@ -158,9 +158,9 @@ func (o IpLink) ResourceAttributes() map[string]resourceSchema.Attribute {
 }
 
 func (o IpLink) attributes(_ context.Context, diags *diag.Diagnostics) *apstra.ConnectivityTemplatePrimitiveAttributesAttachLogicalLink {
-	var vlan *apstra.VLAN
+	var vlan *uint16
 	if !o.VlanId.IsNull() {
-		vlan = pointer.To(apstra.VLAN(o.VlanId.ValueInt64()))
+		vlan = pointer.To(uint16(o.VlanId.ValueInt64()))
 	}
 
 	var err error

--- a/apstra/blueprint/datacenter_routing_zone.go
+++ b/apstra/blueprint/datacenter_routing_zone.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
@@ -385,12 +386,12 @@ func (o DatacenterRoutingZone) ResourceAttributes() map[string]resourceSchema.At
 	}
 }
 
-func (o *DatacenterRoutingZone) Request(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) apstra.SecurityZone {
-	var result apstra.SecurityZone
+func (o *DatacenterRoutingZone) Request(ctx context.Context, client *apstra.Client, diags *diag.Diagnostics) datacenter.SecurityZone {
+	var result datacenter.SecurityZone
 	result.SetID(o.Id.ValueString()) // will set empty string if null or unknown -- this is fine
 
 	if !o.VlanId.IsNull() && !o.VlanId.IsUnknown() {
-		result.VLAN = pointer.To(apstra.VLAN(o.VlanId.ValueInt64()))
+		result.VLAN = pointer.To(uint16(o.VlanId.ValueInt64()))
 	}
 
 	if !o.Vni.IsNull() && !o.Vni.IsUnknown() {
@@ -412,11 +413,11 @@ func (o *DatacenterRoutingZone) Request(ctx context.Context, client *apstra.Clie
 		return result
 	}
 
-	result.RTPolicy = new(apstra.RTPolicy)
+	result.RTPolicy = new(datacenter.RTPolicy)
 	diags.Append(o.ImportRouteTargets.ElementsAs(ctx, &result.RTPolicy.ImportRTs, false)...)
 	diags.Append(o.ExportRouteTargets.ElementsAs(ctx, &result.RTPolicy.ExportRTs, false)...)
 	if diags.HasError() {
-		return apstra.SecurityZone{}
+		return datacenter.SecurityZone{}
 	}
 
 	result.Type = enum.SecurityZoneTypeEVPN
@@ -451,7 +452,7 @@ func (o *DatacenterRoutingZone) DhcpServerRequest(_ context.Context, _ *diag.Dia
 	return request
 }
 
-func (o *DatacenterRoutingZone) LoadApiData(ctx context.Context, sz apstra.SecurityZone, diags *diag.Diagnostics) {
+func (o *DatacenterRoutingZone) LoadApiData(ctx context.Context, sz datacenter.SecurityZone, diags *diag.Diagnostics) {
 	if !utils.HasValue(o.Name) { // required attribute
 		o.Name = types.StringValue(sz.Label)
 	}

--- a/apstra/blueprint/datacenter_security_policy.go
+++ b/apstra/blueprint/datacenter_security_policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/terraform-provider-apstra/internal/value"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -195,31 +196,31 @@ func (o DatacenterSecurityPolicy) ResourceAttributes() map[string]resourceSchema
 }
 
 func (o *DatacenterSecurityPolicy) Read(ctx context.Context, bp *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) error {
-	var api *apstra.Policy
+	var api datacenter.Policy
 	var err error
 
 	if o.Id.IsNull() {
 		api, err = bp.GetPolicyByLabel(ctx, o.Name.ValueString())
 	} else {
-		api, err = bp.GetPolicy(ctx, apstra.ObjectId(o.Id.ValueString()))
+		api, err = bp.GetPolicy(ctx, o.Id.ValueString())
 	}
 	if err != nil {
 		return err
 	}
 
-	o.Id = types.StringValue(api.Id.String())
-	o.loadApiData(ctx, api.Data, diags)
+	o.Id = types.StringPointerValue(api.ID())
+	o.loadApiData(ctx, api, diags)
 
 	return nil
 }
 
-func (o *DatacenterSecurityPolicy) loadApiData(ctx context.Context, data *apstra.PolicyData, diags *diag.Diagnostics) {
+func (o *DatacenterSecurityPolicy) loadApiData(ctx context.Context, data datacenter.Policy, diags *diag.Diagnostics) {
 	var srcAppPointId, dstAppPointId types.String
 	if data.SrcApplicationPoint != nil {
-		srcAppPointId = value.StringOrNull(ctx, data.SrcApplicationPoint.Id.String(), diags)
+		srcAppPointId = types.StringPointerValue(data.SrcApplicationPoint)
 	}
 	if data.DstApplicationPoint != nil {
-		dstAppPointId = value.StringOrNull(ctx, data.DstApplicationPoint.Id.String(), diags)
+		dstAppPointId = types.StringPointerValue(data.DstApplicationPoint)
 	}
 
 	o.Name = types.StringValue(data.Label)
@@ -310,28 +311,22 @@ func (o *DatacenterSecurityPolicy) Query(resultName string) apstra.QEQuery {
 	return matchQuery
 }
 
-func (o *DatacenterSecurityPolicy) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.PolicyData {
-	var srcApplicationPoint, dstApplicationPoint *apstra.PolicyApplicationPointData
-	if !o.SrcAppPointId.IsNull() {
-		srcApplicationPoint = &apstra.PolicyApplicationPointData{Id: apstra.ObjectId(o.SrcAppPointId.ValueString())}
-	}
-	if !o.DstAppPointId.IsNull() {
-		dstApplicationPoint = &apstra.PolicyApplicationPointData{Id: apstra.ObjectId(o.DstAppPointId.ValueString())}
-	}
-
+func (o *DatacenterSecurityPolicy) Request(ctx context.Context, diags *diag.Diagnostics) datacenter.Policy {
 	var tags []string
 	diags.Append(o.Tags.ElementsAs(ctx, &tags, false)...)
 	if tags == nil {
 		tags = make([]string, 0) // we must send an empty slice to wipe out current tags
 	}
 
-	return &apstra.PolicyData{
+	result := datacenter.Policy{
 		Enabled:             o.Enabled.ValueBool(),
 		Label:               o.Name.ValueString(),
 		Description:         o.Description.ValueString(),
-		SrcApplicationPoint: srcApplicationPoint,
-		DstApplicationPoint: dstApplicationPoint,
+		SrcApplicationPoint: o.SrcAppPointId.ValueStringPointer(),
+		DstApplicationPoint: o.DstAppPointId.ValueStringPointer(),
 		Rules:               policyRuleListToApstraPolicyRuleSlice(ctx, o.Rules, diags),
 		Tags:                tags,
 	}
+	_ = result.SetID(o.Id.ValueString()) // skipping error check b/c we know that result.id is currently empty
+	return result
 }

--- a/apstra/blueprint/datacenter_security_policy_rule.go
+++ b/apstra/blueprint/datacenter_security_policy_rule.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
@@ -226,7 +226,7 @@ func (o DatacenterSecurityPolicyRule) ResourceAttributes() map[string]resourceSc
 	}
 }
 
-func (o *DatacenterSecurityPolicyRule) loadApiData(ctx context.Context, in *apstra.PolicyRuleData, diags *diag.Diagnostics) {
+func (o *DatacenterSecurityPolicyRule) loadApiData(ctx context.Context, in datacenter.PolicyRule, diags *diag.Diagnostics) {
 	var established types.Bool
 	if in.Protocol == enum.PolicyRuleProtocolTcp {
 		if in.TcpStateQualifier == nil {
@@ -245,12 +245,12 @@ func (o *DatacenterSecurityPolicyRule) loadApiData(ctx context.Context, in *apst
 	o.Established = established
 }
 
-func (o *DatacenterSecurityPolicyRule) request(ctx context.Context, path path.Path, diags *diag.Diagnostics) *apstra.PolicyRuleData {
+func (o *DatacenterSecurityPolicyRule) request(ctx context.Context, path path.Path, diags *diag.Diagnostics) datacenter.PolicyRule {
 	var protocol enum.PolicyRuleProtocol
 	err := rosetta.ApiStringerFromFriendlyString(&protocol, o.Protocol.ValueString())
 	if err != nil {
 		diags.AddAttributeError(path, fmt.Sprintf("failed to parse policy rule protocol %s", o.Protocol), err.Error())
-		return nil
+		return datacenter.PolicyRule{}
 	}
 
 	action := enum.PolicyRuleActions.Parse(o.Action.ValueString())
@@ -259,13 +259,13 @@ func (o *DatacenterSecurityPolicyRule) request(ctx context.Context, path path.Pa
 			path.AtName("action"),
 			constants.ErrStringParse,
 			fmt.Sprintf("failed to parse action %s", o.Action))
-		return nil
+		return datacenter.PolicyRule{}
 	}
 
 	srcPort := portRangeSetToApstraPortRanges(ctx, o.SrcPorts, diags)
 	dstPort := portRangeSetToApstraPortRanges(ctx, o.DstPorts, diags)
 	if diags.HasError() {
-		return nil
+		return datacenter.PolicyRule{}
 	}
 
 	var tcpStateQualifier *enum.TcpStateQualifier
@@ -273,7 +273,7 @@ func (o *DatacenterSecurityPolicyRule) request(ctx context.Context, path path.Pa
 		tcpStateQualifier = &enum.TcpStateQualifierEstablished
 	}
 
-	return &apstra.PolicyRuleData{
+	return datacenter.PolicyRule{
 		Label:             o.Name.ValueString(),
 		Description:       o.Description.ValueString(),
 		Protocol:          protocol,
@@ -284,7 +284,7 @@ func (o *DatacenterSecurityPolicyRule) request(ctx context.Context, path path.Pa
 	}
 }
 
-func newPolicyRuleList(ctx context.Context, in []apstra.PolicyRule, diags *diag.Diagnostics) types.List {
+func newPolicyRuleList(ctx context.Context, in []datacenter.PolicyRule, diags *diag.Diagnostics) types.List {
 	var d diag.Diagnostics
 
 	if len(in) == 0 {
@@ -293,8 +293,8 @@ func newPolicyRuleList(ctx context.Context, in []apstra.PolicyRule, diags *diag.
 
 	rules := make([]attr.Value, len(in))
 	for i, inRule := range in {
-		rule := DatacenterSecurityPolicyRule{Id: types.StringValue(inRule.Id.String())}
-		rule.loadApiData(ctx, inRule.Data, diags)
+		rule := DatacenterSecurityPolicyRule{Id: types.StringPointerValue(inRule.ID())}
+		rule.loadApiData(ctx, inRule, diags)
 		if diags.HasError() {
 			return types.ListNull(types.ObjectType{AttrTypes: DatacenterSecurityPolicyRule{}.attrTypes()})
 		}
@@ -309,7 +309,7 @@ func newPolicyRuleList(ctx context.Context, in []apstra.PolicyRule, diags *diag.
 	return types.ListValueMust(types.ObjectType{AttrTypes: DatacenterSecurityPolicyRule{}.attrTypes()}, rules)
 }
 
-func policyRuleListToApstraPolicyRuleSlice(ctx context.Context, ruleList types.List, diags *diag.Diagnostics) []apstra.PolicyRule {
+func policyRuleListToApstraPolicyRuleSlice(ctx context.Context, ruleList types.List, diags *diag.Diagnostics) []datacenter.PolicyRule {
 	var ruleSlice []DatacenterSecurityPolicyRule
 	diags.Append(ruleList.ElementsAs(ctx, &ruleSlice, false)...)
 	if diags.HasError() {
@@ -320,11 +320,9 @@ func policyRuleListToApstraPolicyRuleSlice(ctx context.Context, ruleList types.L
 		return nil
 	}
 
-	result := make([]apstra.PolicyRule, len(ruleSlice))
+	result := make([]datacenter.PolicyRule, len(ruleSlice))
 	for i, rule := range ruleSlice {
-		result[i] = apstra.PolicyRule{
-			Data: rule.request(ctx, path.Root("rules").AtListIndex(i), diags),
-		}
+		result[i] = rule.request(ctx, path.Root("rules").AtListIndex(i), diags)
 	}
 
 	return result

--- a/apstra/blueprint/datacenter_security_policy_rule_port.go
+++ b/apstra/blueprint/datacenter_security_policy_rule_port.go
@@ -2,7 +2,8 @@ package blueprint
 
 import (
 	"context"
-	"github.com/Juniper/apstra-go-sdk/apstra"
+
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dataSourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -71,19 +72,19 @@ func (o DatacenterSecurityPolicyRulePortRange) ResourceAttributes() map[string]r
 	}
 }
 
-func (o *DatacenterSecurityPolicyRulePortRange) loadApiData(_ context.Context, data *apstra.PortRange, _ *diag.Diagnostics) {
+func (o *DatacenterSecurityPolicyRulePortRange) loadApiData(_ context.Context, data datacenter.PortRange, _ *diag.Diagnostics) {
 	o.FromPort = types.Int64Value(int64(data.First))
 	o.ToPort = types.Int64Value(int64(data.Last))
 }
 
-func (o *DatacenterSecurityPolicyRulePortRange) request(_ context.Context, _ *diag.Diagnostics) *apstra.PortRange {
-	return &apstra.PortRange{
+func (o *DatacenterSecurityPolicyRulePortRange) request(_ context.Context, _ *diag.Diagnostics) datacenter.PortRange {
+	return datacenter.PortRange{
 		First: uint16(o.FromPort.ValueInt64()),
 		Last:  uint16(o.ToPort.ValueInt64()),
 	}
 }
 
-func newDatacenterPolicyRulePortRangeSet(ctx context.Context, in []apstra.PortRange, diags *diag.Diagnostics) types.Set {
+func newDatacenterPolicyRulePortRangeSet(ctx context.Context, in []datacenter.PortRange, diags *diag.Diagnostics) types.Set {
 	if len(in) == 0 {
 		return types.SetNull(types.ObjectType{AttrTypes: DatacenterSecurityPolicyRulePortRange{}.attrTypes()})
 	}
@@ -91,7 +92,7 @@ func newDatacenterPolicyRulePortRangeSet(ctx context.Context, in []apstra.PortRa
 	portRanges := make([]attr.Value, len(in))
 	for i, inRange := range in {
 		var portRange DatacenterSecurityPolicyRulePortRange
-		portRange.loadApiData(ctx, &inRange, diags)
+		portRange.loadApiData(ctx, inRange, diags)
 		if diags.HasError() {
 			return types.SetNull(types.ObjectType{AttrTypes: DatacenterSecurityPolicyRulePortRange{}.attrTypes()})
 		}
@@ -107,7 +108,7 @@ func newDatacenterPolicyRulePortRangeSet(ctx context.Context, in []apstra.PortRa
 	return types.SetValueMust(types.ObjectType{AttrTypes: DatacenterSecurityPolicyRulePortRange{}.attrTypes()}, portRanges)
 }
 
-func portRangeSetToApstraPortRanges(ctx context.Context, portSet types.Set, diags *diag.Diagnostics) apstra.PortRanges {
+func portRangeSetToApstraPortRanges(ctx context.Context, portSet types.Set, diags *diag.Diagnostics) datacenter.PortRanges {
 	var portRangeSlice []DatacenterSecurityPolicyRulePortRange
 	diags.Append(portSet.ElementsAs(ctx, &portRangeSlice, false)...)
 	if diags.HasError() {
@@ -118,9 +119,9 @@ func portRangeSetToApstraPortRanges(ctx context.Context, portSet types.Set, diag
 		return nil
 	}
 
-	result := make(apstra.PortRanges, len(portRangeSlice))
+	result := make(datacenter.PortRanges, len(portRangeSlice))
 	for i, portRange := range portRangeSlice {
-		result[i] = *portRange.request(ctx, diags)
+		result[i] = portRange.request(ctx, diags)
 	}
 
 	return result

--- a/apstra/blueprint/datacenter_virtual_network.go
+++ b/apstra/blueprint/datacenter_virtual_network.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	apiversions "github.com/Juniper/terraform-provider-apstra/apstra/api_versions"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
@@ -595,53 +596,51 @@ func (o DatacenterVirtualNetwork) ResourceAttributes() map[string]resourceSchema
 	}
 }
 
-func (o *DatacenterVirtualNetwork) Request(ctx context.Context, diags *diag.Diagnostics) *apstra.VirtualNetworkData {
+func (o *DatacenterVirtualNetwork) Request(ctx context.Context, diags *diag.Diagnostics) datacenter.VirtualNetwork {
 	var vnType enum.VnType
 	err := vnType.FromString(o.Type.ValueString())
 	if err != nil {
 		diags.Append(
 			validatordiag.BugInProviderDiagnostic(
 				fmt.Sprintf("error parsing virtual network type %q - %s", o.Type.String(), err.Error())))
-		return nil
+		return datacenter.VirtualNetwork{}
 	}
 
 	b := make(map[string]VnBinding)
 	diags.Append(o.Bindings.ElementsAs(ctx, &b, false)...)
 	if diags.HasError() {
-		return nil
+		return datacenter.VirtualNetwork{}
 	}
-	vnBindings := make([]apstra.VnBinding, len(b))
+	vnBindings := make([]datacenter.VNBinding, len(b))
 	var i int
 	for leafId, binding := range b {
-		vnBindings[i] = *binding.Request(ctx, leafId, diags)
+		vnBindings[i] = binding.Request(ctx, leafId, diags)
 		i++
 	}
 	if diags.HasError() {
-		return nil
+		return datacenter.VirtualNetwork{}
 	}
 
-	var vnId *apstra.VNI
+	var vnId *uint32
 	if utils.HasValue(o.Vni) {
-		v := apstra.VNI(o.Vni.ValueInt64())
-		vnId = &v
+		vnId = pointer.To(uint32(o.Vni.ValueInt64()))
 	}
 
 	if o.Type.ValueString() == enum.VnTypeVlan.String() {
 		// Maximum of one binding is required when type==vlan.
 		// Apstra requires vlan == vni when creating a "vlan" type VN.
 		// VNI attribute is forbidden when type == VLAN
-		if len(vnBindings) > 0 && vnBindings[0].VlanId != nil {
-			v := apstra.VNI(*vnBindings[0].VlanId)
-			vnId = &v
+		if len(vnBindings) > 0 && vnBindings[0].VLAN != nil {
+			vnId = pointer.To(uint32(*vnBindings[0].VLAN))
 		}
 	}
 
-	var reservedVlanId *apstra.VLAN
+	var reservedVlanId *uint16
 	if o.ReserveVlan.ValueBool() {
 		if utils.HasValue(o.ReservedVlanId) {
-			reservedVlanId = pointer.To(apstra.VLAN(o.ReservedVlanId.ValueInt64()))
+			reservedVlanId = pointer.To(uint16(o.ReservedVlanId.ValueInt64()))
 		} else {
-			reservedVlanId = vnBindings[0].VlanId
+			reservedVlanId = vnBindings[0].VLAN
 		}
 	}
 
@@ -673,9 +672,9 @@ func (o *DatacenterVirtualNetwork) Request(ctx context.Context, diags *diag.Diag
 		l3Mtu = &i
 	}
 
-	var rtPolicy *apstra.RTPolicy
+	var rtPolicy *datacenter.RTPolicy
 	if !o.ImportRouteTargets.IsNull() || !o.ExportRouteTargets.IsNull() {
-		rtPolicy = new(apstra.RTPolicy)
+		rtPolicy = new(datacenter.RTPolicy)
 		if !o.ImportRouteTargets.IsNull() {
 			diags.Append(o.ImportRouteTargets.ElementsAs(ctx, &rtPolicy.ImportRTs, false)...)
 		}
@@ -684,77 +683,79 @@ func (o *DatacenterVirtualNetwork) Request(ctx context.Context, diags *diag.Diag
 		}
 	}
 
-	return &apstra.VirtualNetworkData{
+	result := datacenter.VirtualNetwork{
 		Description:               o.Description.ValueString(),
-		DhcpService:               apstra.DhcpServiceEnabled(o.DhcpServiceEnabled.ValueBool()),
-		Ipv4Enabled:               o.IPv4ConnectivityEnabled.ValueBool(),
-		Ipv4Subnet:                ipv4Subnet,
-		Ipv6Enabled:               o.IPv6ConnectivityEnabled.ValueBool(),
-		Ipv6Subnet:                ipv6Subnet,
-		L3Mtu:                     l3Mtu,
+		DHCPService:               datacenter.DHCPServiceEnabled(o.DhcpServiceEnabled.ValueBool()),
+		IPv4Enabled:               o.IPv4ConnectivityEnabled.ValueBool(),
+		IPv4Subnet:                ipv4Subnet,
+		IPv6Enabled:               o.IPv6ConnectivityEnabled.ValueBool(),
+		IPv6Subnet:                ipv6Subnet,
+		L3MTU:                     l3Mtu,
 		Label:                     o.Name.ValueString(),
-		ReservedVlanId:            reservedVlanId,
-		RouteTarget:               "",
-		RtPolicy:                  rtPolicy,
-		SecurityZoneId:            apstra.ObjectId(o.RoutingZoneId.ValueString()),
-		SviIps:                    nil,
-		VirtualGatewayIpv4:        ipv4Gateway,
-		VirtualGatewayIpv6:        ipv6Gateway,
-		VirtualGatewayIpv4Enabled: o.IPv4GatewayEnabled.ValueBool(),
-		VirtualGatewayIpv6Enabled: o.IPv6GatewayEnabled.ValueBool(),
-		VnBindings:                vnBindings,
-		VnId:                      vnId,
-		VnType:                    vnType,
-		VirtualMac:                nil,
+		ReservedVLAN:              reservedVlanId,
+		RTPolicy:                  rtPolicy,
+		SecurityZoneID:            o.RoutingZoneId.ValueString(),
+		SVIIPs:                    nil,
+		VirtualGatewayIPv4:        ipv4Gateway,
+		VirtualGatewayIPv6:        ipv6Gateway,
+		VirtualGatewayIPv4Enabled: o.IPv4GatewayEnabled.ValueBool(),
+		VirtualGatewayIPv6Enabled: o.IPv6GatewayEnabled.ValueBool(),
+		Bindings:                  vnBindings,
+		VNI:                       vnId,
+		Type:                      vnType,
+		VirtualMAC:                nil,
 	}
+	_ = result.SetID(o.Id.ValueString()) // skipping error check b/c we know that result.id is currently empty
+	return result
 }
 
-func (o *DatacenterVirtualNetwork) LoadApiData(ctx context.Context, in *apstra.VirtualNetworkData, diags *diag.Diagnostics) {
-	var virtualGatewayIpv4, virtualGatewayIpv6 string
-	if len(in.VirtualGatewayIpv4.To4()) == net.IPv4len {
-		virtualGatewayIpv4 = in.VirtualGatewayIpv4.String()
+func (o *DatacenterVirtualNetwork) LoadApiData(ctx context.Context, in datacenter.VirtualNetwork, diags *diag.Diagnostics) {
+	var virtualGatewayIPv4, virtualGatewayIPv6 string
+	if len(in.VirtualGatewayIPv4.To4()) == net.IPv4len {
+		virtualGatewayIPv4 = in.VirtualGatewayIPv4.String()
 	}
-	if len(in.VirtualGatewayIpv6) == net.IPv6len {
-		virtualGatewayIpv6 = in.VirtualGatewayIpv6.String()
+	if len(in.VirtualGatewayIPv6) == net.IPv6len {
+		virtualGatewayIPv6 = in.VirtualGatewayIPv6.String()
 	}
 
+	o.Id = types.StringPointerValue(in.ID())
 	o.Name = types.StringValue(in.Label)
 	o.Description = value.StringOrNull(ctx, in.Description, diags)
-	o.Type = types.StringValue(in.VnType.String())
-	o.RoutingZoneId = types.StringValue(in.SecurityZoneId.String())
-	o.Bindings = newBindingMap(ctx, in.VnBindings, diags)
-	o.Vni = value.Int64OrNull(ctx, in.VnId, diags)
-	o.DhcpServiceEnabled = types.BoolValue(bool(in.DhcpService))
-	o.IPv4ConnectivityEnabled = types.BoolValue(in.Ipv4Enabled)
-	o.IPv6ConnectivityEnabled = types.BoolValue(in.Ipv6Enabled)
-	o.ReserveVlan = types.BoolValue(in.ReservedVlanId != nil)
-	if in.ReservedVlanId == nil {
+	o.Type = types.StringValue(in.Type.String())
+	o.RoutingZoneId = types.StringValue(in.SecurityZoneID)
+	o.Bindings = newBindingMap(ctx, in.Bindings, diags)
+	o.Vni = value.Int64OrNull(ctx, in.VNI, diags)
+	o.DhcpServiceEnabled = types.BoolValue(bool(in.DHCPService))
+	o.IPv4ConnectivityEnabled = types.BoolValue(in.IPv4Enabled)
+	o.IPv6ConnectivityEnabled = types.BoolValue(in.IPv6Enabled)
+	o.ReserveVlan = types.BoolValue(in.ReservedVLAN != nil)
+	if in.ReservedVLAN == nil {
 		o.ReservedVlanId = types.Int64Null()
 	} else {
-		o.ReservedVlanId = types.Int64Value(int64(*in.ReservedVlanId))
+		o.ReservedVlanId = types.Int64Value(int64(*in.ReservedVLAN))
 	}
-	if in.Ipv4Subnet == nil {
+	if in.IPv4Subnet == nil {
 		o.IPv4Subnet = types.StringNull()
 	} else {
-		o.IPv4Subnet = types.StringValue(in.Ipv4Subnet.String())
+		o.IPv4Subnet = types.StringValue(in.IPv4Subnet.String())
 	}
-	if in.Ipv6Subnet == nil {
+	if in.IPv6Subnet == nil {
 		o.IPv6Subnet = types.StringNull()
 	} else {
-		o.IPv6Subnet = types.StringValue(in.Ipv6Subnet.String())
+		o.IPv6Subnet = types.StringValue(in.IPv6Subnet.String())
 	}
-	o.IPv4GatewayEnabled = types.BoolValue(in.VirtualGatewayIpv4Enabled)
-	o.IPv6GatewayEnabled = types.BoolValue(in.VirtualGatewayIpv6Enabled)
-	o.IPv4Gateway = value.StringOrNull(ctx, virtualGatewayIpv4, diags)
-	o.IPv6Gateway = value.StringOrNull(ctx, virtualGatewayIpv6, diags)
-	o.L3Mtu = value.Int64OrNull(ctx, in.L3Mtu, diags)
+	o.IPv4GatewayEnabled = types.BoolValue(in.VirtualGatewayIPv4Enabled)
+	o.IPv6GatewayEnabled = types.BoolValue(in.VirtualGatewayIPv6Enabled)
+	o.IPv4Gateway = value.StringOrNull(ctx, virtualGatewayIPv4, diags)
+	o.IPv6Gateway = value.StringOrNull(ctx, virtualGatewayIPv6, diags)
+	o.L3Mtu = value.Int64OrNull(ctx, in.L3MTU, diags)
 
-	if in.RtPolicy == nil {
+	if in.RTPolicy == nil {
 		o.ImportRouteTargets = types.SetNull(types.StringType)
 		o.ExportRouteTargets = types.SetNull(types.StringType)
 	} else {
-		o.ImportRouteTargets = value.SetOrNull(ctx, types.StringType, in.RtPolicy.ImportRTs, diags)
-		o.ExportRouteTargets = value.SetOrNull(ctx, types.StringType, in.RtPolicy.ExportRTs, diags)
+		o.ImportRouteTargets = value.SetOrNull(ctx, types.StringType, in.RTPolicy.ImportRTs, diags)
+		o.ExportRouteTargets = value.SetOrNull(ctx, types.StringType, in.RTPolicy.ExportRTs, diags)
 	}
 
 	o.Tags = value.SetOrNull(ctx, types.StringType, in.Tags, diags)

--- a/apstra/blueprint/vn_binding.go
+++ b/apstra/blueprint/vn_binding.go
@@ -3,9 +3,10 @@ package blueprint
 import (
 	"context"
 
-	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/terraform-provider-apstra/apstra/design"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/pointer"
 	"github.com/Juniper/terraform-provider-apstra/internal/value"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -80,32 +81,31 @@ func (o VnBinding) ResourceAttributes() map[string]resourceSchema.Attribute {
 	}
 }
 
-func (o VnBinding) Request(ctx context.Context, leafId string, diags *diag.Diagnostics) *apstra.VnBinding {
-	var vlanId *apstra.VLAN
+func (o VnBinding) Request(ctx context.Context, leafId string, diags *diag.Diagnostics) datacenter.VNBinding {
+	var vlan *uint16
 	if utils.HasValue(o.VlanId) {
-		v := apstra.VLAN(o.VlanId.ValueInt64())
-		vlanId = &v
+		vlan = pointer.To(uint16(o.VlanId.ValueInt64()))
 	}
 
-	var result apstra.VnBinding
-	result.SystemId = apstra.ObjectId(leafId)
-	result.VlanId = vlanId
-	diags.Append(o.AccessIds.ElementsAs(ctx, &result.AccessSwitchNodeIds, false)...)
-	return &result
+	var result datacenter.VNBinding
+	result.SystemID = leafId
+	result.VLAN = vlan
+	diags.Append(o.AccessIds.ElementsAs(ctx, &result.AccessSwitchNodeIDs, false)...)
+	return result
 }
 
-func (o *VnBinding) LoadApiData(ctx context.Context, in apstra.VnBinding, diags *diag.Diagnostics) {
-	accessIds, d := types.SetValueFrom(ctx, types.StringType, in.AccessSwitchNodeIds)
+func (o *VnBinding) LoadApiData(ctx context.Context, in datacenter.VNBinding, diags *diag.Diagnostics) {
+	accessIds, d := types.SetValueFrom(ctx, types.StringType, in.AccessSwitchNodeIDs)
 	diags.Append(d...)
 	if diags.HasError() {
 		return
 	}
 
-	o.VlanId = value.Int64OrNull(ctx, in.VlanId, diags)
+	o.VlanId = value.Int64OrNull(ctx, in.VLAN, diags)
 	o.AccessIds = accessIds
 }
 
-func newBindingMap(ctx context.Context, in []apstra.VnBinding, diags *diag.Diagnostics) types.Map {
+func newBindingMap(ctx context.Context, in []datacenter.VNBinding, diags *diag.Diagnostics) types.Map {
 	if len(in) == 0 {
 		return types.MapNull(types.ObjectType{AttrTypes: VnBinding{}.AttrTypes()})
 	}
@@ -117,7 +117,7 @@ func newBindingMap(ctx context.Context, in []apstra.VnBinding, diags *diag.Diagn
 		if diags.HasError() {
 			return types.MapNull(types.ObjectType{AttrTypes: VnBinding{}.AttrTypes()})
 		}
-		bindings[in[i].SystemId.String()] = types.ObjectValueMust(
+		bindings[in[i].SystemID] = types.ObjectValueMust(
 			VnBinding{}.AttrTypes(),
 			map[string]attr.Value{
 				"vlan_id":    b.VlanId,

--- a/apstra/blueprint/vn_binding_constructor.go
+++ b/apstra/blueprint/vn_binding_constructor.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/terraform-provider-apstra/apstra/design"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
+	"github.com/Juniper/terraform-provider-apstra/internal/pointer"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -60,10 +62,9 @@ func (o VnBindingConstructor) DataSourceAttributes() map[string]dataSourceSchema
 
 func (o *VnBindingConstructor) Compute(ctx context.Context, bpClient *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) {
 	// only one VLAN per constructor; get it in the expected form
-	var vlanId *apstra.VLAN
+	var vlan *uint16
 	if utils.HasValue(o.VlanId) {
-		v := apstra.VLAN(o.VlanId.ValueInt64())
-		vlanId = &v
+		vlan = pointer.To(uint16(o.VlanId.ValueInt64()))
 	}
 
 	// extract o.SwitchIds to []string
@@ -133,7 +134,7 @@ func (o *VnBindingConstructor) Compute(ctx context.Context, bpClient *apstra.Two
 
 	// leafToVnBinding is a map keyed by either leaf node ID (non-redundant
 	// leafs) or leaf redundancy group ID
-	leafToVnBinding := make(map[string]apstra.VnBinding)
+	leafToVnBinding := make(map[string]datacenter.VNBinding)
 
 	// loop over access switches, create or update leafToVnBinding entry for each
 	for _, accessSwitchId := range accessSwitchIds {
@@ -194,14 +195,14 @@ func (o *VnBindingConstructor) Compute(ctx context.Context, bpClient *apstra.Two
 		// We may have already created a binding for this leaf...
 		if vnb, ok := leafToVnBinding[leafBindingId]; ok {
 			// binding exists, add our access ID to the list
-			vnb.AccessSwitchNodeIds = utils.Uniq(append(vnb.AccessSwitchNodeIds, apstra.ObjectId(accessBindingId)))
+			vnb.AccessSwitchNodeIDs = utils.Uniq(append(vnb.AccessSwitchNodeIDs, accessBindingId))
 			leafToVnBinding[leafBindingId] = vnb
 		} else {
 			// binding not found, create a new one
-			leafToVnBinding[leafBindingId] = apstra.VnBinding{
-				AccessSwitchNodeIds: []apstra.ObjectId{apstra.ObjectId(accessBindingId)},
-				SystemId:            apstra.ObjectId(leafBindingId),
-				VlanId:              vlanId,
+			leafToVnBinding[leafBindingId] = datacenter.VNBinding{
+				AccessSwitchNodeIDs: []string{accessBindingId},
+				SystemID:            leafBindingId,
+				VLAN:                vlan,
 			}
 		}
 	}
@@ -225,9 +226,9 @@ func (o *VnBindingConstructor) Compute(ctx context.Context, bpClient *apstra.Two
 		// We may have already created a binding for this leafBindingId...
 		if _, ok := leafToVnBinding[leafBindingId]; !ok {
 			// binding not found. create one.
-			leafToVnBinding[leafBindingId] = apstra.VnBinding{
-				SystemId: apstra.ObjectId(leafBindingId),
-				VlanId:   vlanId,
+			leafToVnBinding[leafBindingId] = datacenter.VNBinding{
+				SystemID: leafBindingId,
+				VLAN:     vlan,
 			}
 		}
 	}

--- a/apstra/connectivity_template/ip_link.go
+++ b/apstra/connectivity_template/ip_link.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
 	"github.com/Juniper/terraform-provider-apstra/apstra/design"
 	apstravalidator "github.com/Juniper/terraform-provider-apstra/apstra/validator"
+	"github.com/Juniper/terraform-provider-apstra/internal/pointer"
 	"github.com/Juniper/terraform-provider-apstra/internal/value"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -132,8 +133,7 @@ func (o IpLink) Marshal(ctx context.Context, diags *diag.Diagnostics) string {
 
 	if !o.VlanId.IsNull() {
 		obj.Tagged = true
-		vlan := apstra.VLAN(o.VlanId.ValueInt64())
-		obj.VlanId = &vlan
+		obj.VlanId = pointer.To(uint16(o.VlanId.ValueInt64()))
 	}
 
 	if o.Ipv4AddressingType.IsNull() {
@@ -195,14 +195,14 @@ func (o *IpLink) loadSdkPrimitive(ctx context.Context, in apstra.ConnectivityTem
 var _ JsonPrimitive = &ipLinkPrototype{}
 
 type ipLinkPrototype struct {
-	Label              string       `json:"label,omitempty"`
-	RoutingZoneId      string       `json:"routing_zone_id"`
-	Tagged             bool         `json:"tagged"`
-	VlanId             *apstra.VLAN `json:"vlan_id,omitempty"`
-	Ipv4AddressingType string       `json:"ipv4_addressing_type"`
-	Ipv6AddressingType string       `json:"ipv6_addressing_type"`
-	ChildPrimitives    []string     `json:"child_primitives,omitempty"`
-	L3Mtu              *uint16      `json:"l3_mtu,omitempty"`
+	Label              string   `json:"label,omitempty"`
+	RoutingZoneId      string   `json:"routing_zone_id"`
+	Tagged             bool     `json:"tagged"`
+	VlanId             *uint16  `json:"vlan_id,omitempty"`
+	Ipv4AddressingType string   `json:"ipv4_addressing_type"`
+	Ipv6AddressingType string   `json:"ipv6_addressing_type"`
+	ChildPrimitives    []string `json:"child_primitives,omitempty"`
+	L3Mtu              *uint16  `json:"l3_mtu,omitempty"`
 }
 
 func (o ipLinkPrototype) attributes(_ context.Context, path path.Path, diags *diag.Diagnostics) apstra.ConnectivityTemplatePrimitiveAttributes {

--- a/apstra/data_source_blueprint_device_rendered_config_integration_test.go
+++ b/apstra/data_source_blueprint_device_rendered_config_integration_test.go
@@ -30,8 +30,8 @@ data %q "test" {
 `
 
 type dataSourceBlueprintDeviceRenderedConfig struct {
-	nodeId   apstra.ObjectId
-	systemId apstra.ObjectId
+	nodeId   string
+	systemId string
 }
 
 func (o dataSourceBlueprintDeviceRenderedConfig) render(rType, bpId string) string {
@@ -46,7 +46,7 @@ func (o dataSourceBlueprintDeviceRenderedConfig) render(rType, bpId string) stri
 func TestAccDatasourceBlueprintDeviceRenderedConfig(t *testing.T) {
 	ctx := context.Background()
 	bp := testutils.BlueprintI(t, ctx)
-	leafMap := testutils.GetSystemIds(t, ctx, bp, "leaf")
+	leafMap := testutils.GetSystemIDs(t, ctx, bp, "leaf")
 	require.Equal(t, 2, len(leafMap))
 
 	type testCase struct {
@@ -56,14 +56,14 @@ func TestAccDatasourceBlueprintDeviceRenderedConfig(t *testing.T) {
 	}
 
 	nodeLabels := make([]string, len(leafMap))
-	nodeIds := make([]apstra.ObjectId, len(leafMap))
-	sysIds := make([]apstra.ObjectId, len(leafMap))
+	nodeIds := make([]string, len(leafMap))
+	sysIds := make([]string, len(leafMap))
 	var i int
 	for k, v := range leafMap {
 		var node struct {
-			SystemId apstra.ObjectId `json:"system_id"`
+			SystemId string `json:"system_id"`
 		}
-		require.NoError(t, bp.Client().GetNode(ctx, bp.Id(), v, &node))
+		require.NoError(t, bp.Client().GetNode(ctx, bp.Id(), apstra.ObjectId(v), &node))
 
 		nodeLabels[i] = k
 		nodeIds[i] = v
@@ -72,7 +72,7 @@ func TestAccDatasourceBlueprintDeviceRenderedConfig(t *testing.T) {
 		i++
 	}
 
-	changeLeafAsn := func(t testing.TB, ctx context.Context, leafId apstra.ObjectId, client *apstra.TwoStageL3ClosClient) {
+	changeLeafAsn := func(t testing.TB, ctx context.Context, leafId string, client *apstra.TwoStageL3ClosClient) {
 		t.Helper()
 
 		query := new(apstra.PathQuery).
@@ -144,7 +144,7 @@ func TestAccDatasourceBlueprintDeviceRenderedConfig(t *testing.T) {
 			config: dataSourceBlueprintDeviceRenderedConfig{nodeId: nodeIds[0]},
 			checks: []resource.TestCheckFunc{
 				resource.TestCheckResourceAttr("data."+datasourceType+".test", "blueprint_id", bp.Id().String()),
-				resource.TestCheckResourceAttr("data."+datasourceType+".test", "node_id", nodeIds[0].String()),
+				resource.TestCheckResourceAttr("data."+datasourceType+".test", "node_id", nodeIds[0]),
 				resource.TestCheckNoResourceAttr("data."+datasourceType+".test", "system_id"),
 				resource.TestCheckResourceAttrSet("data."+datasourceType+".test", "deployed_config"),
 				resource.TestCheckResourceAttrSet("data."+datasourceType+".test", "staged_config"),
@@ -158,7 +158,7 @@ func TestAccDatasourceBlueprintDeviceRenderedConfig(t *testing.T) {
 			checks: []resource.TestCheckFunc{
 				resource.TestCheckResourceAttr("data."+datasourceType+".test", "blueprint_id", bp.Id().String()),
 				resource.TestCheckNoResourceAttr("data."+datasourceType+".test", "node_id"),
-				resource.TestCheckResourceAttr("data."+datasourceType+".test", "system_id", sysIds[0].String()),
+				resource.TestCheckResourceAttr("data."+datasourceType+".test", "system_id", sysIds[0]),
 				resource.TestCheckResourceAttrSet("data."+datasourceType+".test", "deployed_config"),
 				resource.TestCheckResourceAttrSet("data."+datasourceType+".test", "staged_config"),
 				resource.TestCheckNoResourceAttr("data."+datasourceType+".test", "incremental_config"),
@@ -173,7 +173,7 @@ func TestAccDatasourceBlueprintDeviceRenderedConfig(t *testing.T) {
 			config: dataSourceBlueprintDeviceRenderedConfig{nodeId: nodeIds[0]},
 			checks: []resource.TestCheckFunc{
 				resource.TestCheckResourceAttr("data."+datasourceType+".test", "blueprint_id", bp.Id().String()),
-				resource.TestCheckResourceAttr("data."+datasourceType+".test", "node_id", nodeIds[0].String()),
+				resource.TestCheckResourceAttr("data."+datasourceType+".test", "node_id", nodeIds[0]),
 				resource.TestCheckNoResourceAttr("data."+datasourceType+".test", "system_id"),
 				resource.TestCheckResourceAttrSet("data."+datasourceType+".test", "deployed_config"),
 				resource.TestCheckResourceAttrSet("data."+datasourceType+".test", "staged_config"),
@@ -190,7 +190,7 @@ func TestAccDatasourceBlueprintDeviceRenderedConfig(t *testing.T) {
 			checks: []resource.TestCheckFunc{
 				resource.TestCheckResourceAttr("data."+datasourceType+".test", "blueprint_id", bp.Id().String()),
 				resource.TestCheckNoResourceAttr("data."+datasourceType+".test", "node_id"),
-				resource.TestCheckResourceAttr("data."+datasourceType+".test", "system_id", sysIds[0].String()),
+				resource.TestCheckResourceAttr("data."+datasourceType+".test", "system_id", sysIds[0]),
 				resource.TestCheckResourceAttrSet("data."+datasourceType+".test", "deployed_config"),
 				resource.TestCheckResourceAttrSet("data."+datasourceType+".test", "staged_config"),
 				resource.TestCheckResourceAttrWith("data."+datasourceType+".test", "incremental_config", expectAsnChange),

--- a/apstra/data_source_datacenter_connectivity_templates_status_integration_test.go
+++ b/apstra/data_source_datacenter_connectivity_templates_status_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
@@ -74,12 +75,12 @@ func TestDatasourceDatacenterConnectivityTemplatesStatus(t *testing.T) {
 		return applicationPointIds
 	}
 
-	newCt := func(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosClient, tags []string, vlan int, typeName string, assignmentCount int) (apstra.ObjectId, [][]string) {
+	newCt := func(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosClient, tags []string, vlan uint16, typeName string, assignmentCount int) (apstra.ObjectId, [][]string) {
 		t.Helper()
 
-		var vlanId *apstra.VLAN
+		var vlanPtr *uint16
 		if vlan > 0 { // with vlan 0 we send nil pointer to create an invalid CT
-			vlanId = pointer.To(apstra.VLAN(vlan))
+			vlanPtr = pointer.To(vlan)
 		}
 
 		// create a security zone unique for each CT
@@ -88,11 +89,11 @@ func TestDatasourceDatacenterConnectivityTemplatesStatus(t *testing.T) {
 		if compatibility.BPDefaultRoutingZoneAddressingOK.Check(version.Must(version.NewVersion(bp.Client().ApiVersion()))) {
 			as = &enum.AddressingSchemeIPv6
 		}
-		szId, err := bp.CreateSecurityZone(ctx, apstra.SecurityZone{
+		szId, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 			Label:             szName,
 			Type:              enum.SecurityZoneTypeEVPN,
 			VRFName:           szName,
-			VLAN:              vlanId,
+			VLAN:              vlanPtr,
 			AddressingSupport: as,
 		})
 		require.NoError(t, err)
@@ -107,7 +108,7 @@ func TestDatasourceDatacenterConnectivityTemplatesStatus(t *testing.T) {
 					Attributes: &apstra.ConnectivityTemplatePrimitiveAttributesAttachLogicalLink{
 						SecurityZone: (*apstra.ObjectId)(&szId),
 						Tagged:       true,
-						Vlan:         vlanId,
+						Vlan:         vlanPtr,
 					},
 				},
 			},
@@ -168,13 +169,13 @@ func TestDatasourceDatacenterConnectivityTemplatesStatus(t *testing.T) {
 	}
 
 	// create a valid CT without applying it and add its tests
-	_, checkArgs = newCt(t, ctx, bp, randomStrings(rand.Intn(10)+1, 6), vlanIds[0], datasourceTypeName, 0)
+	_, checkArgs = newCt(t, ctx, bp, randomStrings(rand.Intn(10)+1, 6), uint16(vlanIds[0]), datasourceTypeName, 0)
 	for _, args := range checkArgs {
 		checks.append(t, args[0], args[1:]...)
 	}
 
 	// create a valid CT and apply it and add its tests
-	ctId, checkArgs := newCt(t, ctx, bp, randomStrings(rand.Intn(10)+1, 6), vlanIds[1], datasourceTypeName, len(portIds))
+	ctId, checkArgs := newCt(t, ctx, bp, randomStrings(rand.Intn(10)+1, 6), uint16(vlanIds[1]), datasourceTypeName, len(portIds))
 	for _, args := range checkArgs {
 		checks.append(t, args[0], args[1:]...)
 	}

--- a/apstra/data_source_datacenter_interconnect_domain.go
+++ b/apstra/data_source_datacenter_interconnect_domain.go
@@ -59,7 +59,7 @@ func (o *dataSourceDatacenterInterconnectDomain) Read(ctx context.Context, req d
 	var api apstra.EVPNInterconnectGroup
 	switch {
 	case !config.Name.IsNull():
-		api, err = bp.GetEVPNInterconnectGroupByName(ctx, config.Name.ValueString())
+		api, err = bp.GetEVPNInterconnectGroupByLabel(ctx, config.Name.ValueString())
 		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("name"),

--- a/apstra/data_source_datacenter_routing_zone.go
+++ b/apstra/data_source_datacenter_routing_zone.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -57,7 +58,7 @@ func (o *dataSourceDatacenterRoutingZone) Read(ctx context.Context, req datasour
 		return
 	}
 
-	var api apstra.SecurityZone
+	var api datacenter.SecurityZone
 	switch {
 	case !config.Id.IsNull():
 		api, err = bp.GetSecurityZone(ctx, config.Id.ValueString())

--- a/apstra/data_source_datacenter_security_policies.go
+++ b/apstra/data_source_datacenter_security_policies.go
@@ -130,7 +130,7 @@ func (o *dataSourceDatacenterSecurityPolicies) Read(ctx context.Context, req dat
 }
 
 func (o *dataSourceDatacenterSecurityPolicies) getAllIds(ctx context.Context, bp *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) []attr.Value {
-	all, err := bp.GetAllPolicies(ctx)
+	all, err := bp.GetPolicies(ctx)
 	if err != nil {
 		diags.AddError(
 			fmt.Sprintf("failed to retrieve Security Policies in Blueprint %s", bp.Id()), err.Error())
@@ -139,7 +139,7 @@ func (o *dataSourceDatacenterSecurityPolicies) getAllIds(ctx context.Context, bp
 
 	result := make([]attr.Value, len(all))
 	for i, each := range all {
-		result[i] = types.StringValue(each.Id.String())
+		result[i] = types.StringPointerValue(each.ID())
 	}
 
 	return result

--- a/apstra/data_source_datacenter_security_policy_test.go
+++ b/apstra/data_source_datacenter_security_policy_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -44,12 +44,12 @@ func TestDatacenterSecurityPolicy(t *testing.T) {
 	require.NotNil(t, szID)
 
 	testCases := map[string]struct {
-		id         string
-		policyData apstra.PolicyData
-		checks     []resource.TestCheckFunc
+		id     string
+		policy datacenter.Policy
+		checks []resource.TestCheckFunc
 	}{
 		"minimal_enabled": {
-			policyData: apstra.PolicyData{
+			policy: datacenter.Policy{
 				Label:   "minimal_enabled",
 				Enabled: true,
 			},
@@ -60,7 +60,7 @@ func TestDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		"minimal_disabled": {
-			policyData: apstra.PolicyData{
+			policy: datacenter.Policy{
 				Label:   "minimal_disabled",
 				Enabled: false,
 			},
@@ -71,7 +71,7 @@ func TestDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		"with_description": {
-			policyData: apstra.PolicyData{
+			policy: datacenter.Policy{
 				Label:       "with_description",
 				Description: "with_description ... description",
 			},
@@ -82,9 +82,9 @@ func TestDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		"with_src_app_point": {
-			policyData: apstra.PolicyData{
+			policy: datacenter.Policy{
 				Label:               "with_src_app_point",
-				SrcApplicationPoint: &apstra.PolicyApplicationPointData{Id: apstra.ObjectId(*szID)},
+				SrcApplicationPoint: szID,
 			},
 			checks: []resource.TestCheckFunc{
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "id", "bogus placeholder fixed in loop below. this check must be first"),
@@ -93,9 +93,9 @@ func TestDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		"with_dst_app_point": {
-			policyData: apstra.PolicyData{
+			policy: datacenter.Policy{
 				Label:               "with_dst_app_point",
-				DstApplicationPoint: &apstra.PolicyApplicationPointData{Id: apstra.ObjectId(*szID)},
+				DstApplicationPoint: szID,
 			},
 			checks: []resource.TestCheckFunc{
 				resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "id", "bogus placeholder fixed in loop below. this check must be first"),
@@ -104,9 +104,9 @@ func TestDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		"with_tags": {
-			policyData: apstra.PolicyData{
+			policy: datacenter.Policy{
 				Label:               "with_tags",
-				DstApplicationPoint: &apstra.PolicyApplicationPointData{Id: apstra.ObjectId(*szID)},
+				DstApplicationPoint: szID,
 				Tags:                []string{"foo", "bar"},
 			},
 			checks: []resource.TestCheckFunc{
@@ -118,50 +118,42 @@ func TestDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		"with_rules": {
-			policyData: apstra.PolicyData{
+			policy: datacenter.Policy{
 				Label: "with_rules",
-				Rules: []apstra.PolicyRule{
+				Rules: []datacenter.PolicyRule{
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:       "name_0",
-							Description: "description_0",
-							Protocol:    enum.PolicyRuleProtocolIcmp,
-							Action:      enum.PolicyRuleActionDeny,
-						},
+						Label:       "name_0",
+						Description: "description_0",
+						Protocol:    enum.PolicyRuleProtocolIcmp,
+						Action:      enum.PolicyRuleActionDeny,
 					},
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:       "name_1",
-							Description: "description_1",
-							Protocol:    enum.PolicyRuleProtocolIp,
-							Action:      enum.PolicyRuleActionDenyLog,
-						},
+						Label:       "name_1",
+						Description: "description_1",
+						Protocol:    enum.PolicyRuleProtocolIp,
+						Action:      enum.PolicyRuleActionDenyLog,
 					},
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:       "name_2",
-							Description: "description_2",
-							Protocol:    enum.PolicyRuleProtocolTcp,
-							Action:      enum.PolicyRuleActionPermitLog,
-						},
+						Label:       "name_2",
+						Description: "description_2",
+						Protocol:    enum.PolicyRuleProtocolTcp,
+						Action:      enum.PolicyRuleActionPermitLog,
 					},
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:       "name_3",
-							Description: "description_3",
-							Protocol:    enum.PolicyRuleProtocolTcp,
-							Action:      enum.PolicyRuleActionPermitLog,
-							SrcPort: []apstra.PortRange{
-								{First: 11, Last: 11},
-								{First: 13, Last: 13},
-								{First: 15, Last: 19},
-							},
-							DstPort: []apstra.PortRange{
-								{First: 21, Last: 21},
-								{First: 23, Last: 23},
-								{First: 25, Last: 25},
-								{First: 27, Last: 29},
-							},
+						Label:       "name_3",
+						Description: "description_3",
+						Protocol:    enum.PolicyRuleProtocolTcp,
+						Action:      enum.PolicyRuleActionPermitLog,
+						SrcPort: []datacenter.PortRange{
+							{First: 11, Last: 11},
+							{First: 13, Last: 13},
+							{First: 15, Last: 19},
+						},
+						DstPort: []datacenter.PortRange{
+							{First: 21, Last: 21},
+							{First: 23, Last: 23},
+							{First: 25, Last: 25},
+							{First: 27, Last: 29},
 						},
 					},
 				},
@@ -204,18 +196,16 @@ func TestDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		"with_established": {
-			policyData: apstra.PolicyData{
+			policy: datacenter.Policy{
 				Label: "with_established",
-				Rules: []apstra.PolicyRule{
+				Rules: []datacenter.PolicyRule{
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:             "ssh_established",
-							Description:       "ssh established",
-							Protocol:          enum.PolicyRuleProtocolTcp,
-							Action:            enum.PolicyRuleActionPermitLog,
-							SrcPort:           []apstra.PortRange{{First: 22, Last: 22}},
-							TcpStateQualifier: &enum.TcpStateQualifierEstablished,
-						},
+						Label:             "ssh_established",
+						Description:       "ssh established",
+						Protocol:          enum.PolicyRuleProtocolTcp,
+						Action:            enum.PolicyRuleActionPermitLog,
+						SrcPort:           []datacenter.PortRange{{First: 22, Last: 22}},
+						TcpStateQualifier: &enum.TcpStateQualifierEstablished,
 					},
 				},
 			},
@@ -236,13 +226,13 @@ func TestDatacenterSecurityPolicy(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		id, err := bp.CreatePolicy(ctx, &tc.policyData)
+		id, err := bp.CreatePolicy(ctx, tc.policy)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		tc.id = id.String()
-		tc.checks[0] = resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "id", id.String())
+		tc.id = id
+		tc.checks[0] = resource.TestCheckResourceAttr(dataSourceDataCenterSecurityPolicyRefName, "id", id)
 		testCases[i] = tc
 	}
 

--- a/apstra/data_source_datacenter_virtual_network.go
+++ b/apstra/data_source_datacenter_virtual_network.go
@@ -3,17 +3,20 @@ package tfapstra
 import (
 	"context"
 	"fmt"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ datasource.DataSourceWithConfigure = &dataSourceDatacenterVirtualNetwork{}
-var _ datasourceWithSetDcBpClientFunc = &dataSourceDatacenterVirtualNetwork{}
+var (
+	_ datasource.DataSourceWithConfigure = &dataSourceDatacenterVirtualNetwork{}
+	_ datasourceWithSetDcBpClientFunc    = &dataSourceDatacenterVirtualNetwork{}
+)
 
 type dataSourceDatacenterVirtualNetwork struct {
 	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)
@@ -54,10 +57,10 @@ func (o *dataSourceDatacenterVirtualNetwork) Read(ctx context.Context, req datas
 		return
 	}
 
-	var api *apstra.VirtualNetwork
+	var api datacenter.VirtualNetwork
 	switch {
 	case !config.Name.IsNull():
-		api, err = bp.GetVirtualNetworkByName(ctx, config.Name.ValueString())
+		api, err = bp.GetVirtualNetworkByLabel(ctx, config.Name.ValueString())
 		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("name"),
@@ -66,7 +69,7 @@ func (o *dataSourceDatacenterVirtualNetwork) Read(ctx context.Context, req datas
 			return
 		}
 	case !config.Id.IsNull():
-		api, err = bp.GetVirtualNetwork(ctx, apstra.ObjectId(config.Id.ValueString()))
+		api, err = bp.GetVirtualNetwork(ctx, config.Id.ValueString())
 		if utils.IsApstra404(err) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
@@ -81,8 +84,7 @@ func (o *dataSourceDatacenterVirtualNetwork) Read(ctx context.Context, req datas
 	}
 
 	// load the API response and set the state
-	config.Id = types.StringValue(api.Id.String())
-	config.LoadApiData(ctx, api.Data, &resp.Diagnostics)
+	config.LoadApiData(ctx, api, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/apstra/data_source_datacenter_virtual_network_test.go
+++ b/apstra/data_source_datacenter_virtual_network_test.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -38,7 +39,7 @@ func TestDatacenterVirtualNetwork(t *testing.T) {
 
 	// create a security zone within the blueprint
 	name := acctest.RandString(5)
-	zoneId, err := bp.CreateSecurityZone(ctx, apstra.SecurityZone{
+	zoneId, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 		Type:    enum.SecurityZoneTypeEVPN,
 		VRFName: name,
 		Label:   name,
@@ -49,75 +50,70 @@ func TestDatacenterVirtualNetwork(t *testing.T) {
 
 	// grab some data we'll need when creating virtual networks
 	leafIdStrings := systemIds(ctx, t, bp, "leaf")
-	vnBindings := make([]apstra.VnBinding, len(leafIdStrings))
+	vnBindings := make([]datacenter.VNBinding, len(leafIdStrings))
 	for i, id := range leafIdStrings {
-		vnBindings[i] = apstra.VnBinding{SystemId: apstra.ObjectId(id)}
+		vnBindings[i] = datacenter.VNBinding{SystemID: id}
 	}
 
 	// specify virtual networks we want to create (and ultimately test the data source against)
-	virtualNetworks := []apstra.VirtualNetwork{
+	virtualNetworks := []datacenter.VirtualNetwork{
 		{
-			Data: &apstra.VirtualNetworkData{
-				Ipv4Enabled:    true,
-				Ipv4Subnet:     randIpNetMust(t, "10.0.0.0/16"),
-				Label:          acctest.RandString(5),
-				SecurityZoneId: apstra.ObjectId(zoneId),
-				VnType:         enum.VnTypeVxlan,
-				VnBindings:     vnBindings,
-			},
+			IPv4Enabled:    true,
+			IPv4Subnet:     randIpNetMust(t, "10.0.0.0/16"),
+			Label:          acctest.RandString(5),
+			SecurityZoneID: zoneId,
+			Type:           enum.VnTypeVxlan,
+			Bindings:       vnBindings,
 		},
 		{
-			Data: &apstra.VirtualNetworkData{
-				Ipv4Enabled:    true,
-				Ipv4Subnet:     randIpNetMust(t, "10.1.0.0/16"),
-				Label:          acctest.RandString(5),
-				SecurityZoneId: apstra.ObjectId(zoneId),
-				VnType:         enum.VnTypeVlan,
-				VnBindings:     []apstra.VnBinding{{SystemId: apstra.ObjectId(leafIdStrings[0])}},
-			},
+			IPv4Enabled:    true,
+			IPv4Subnet:     randIpNetMust(t, "10.1.0.0/16"),
+			Label:          acctest.RandString(5),
+			SecurityZoneID: zoneId,
+			Type:           enum.VnTypeVlan,
+			Bindings:       []datacenter.VNBinding{{SystemID: leafIdStrings[0]}},
 		},
 	}
 
 	// create the test virtual networks
 	for i := range virtualNetworks {
-		virtualNetworks[i].Id, err = bp.CreateVirtualNetwork(ctx, virtualNetworks[i].Data)
-		if err != nil {
-			t.Fatal(err)
-		}
+		id, err := bp.CreateVirtualNetwork(ctx, virtualNetworks[i])
+		require.NoError(t, err)
+		require.NoError(t, virtualNetworks[i].SetID(id))
 	}
 
-	genTestCheckFuncs := func(vn apstra.VirtualNetwork) []resource.TestCheckFunc {
+	genTestCheckFuncs := func(vn datacenter.VirtualNetwork) []resource.TestCheckFunc {
 		result := []resource.TestCheckFunc{
-			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "id", vn.Id.String()),
+			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "id", *vn.ID()),
 			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "blueprint_id", bp.Id().String()),
-			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "name", vn.Data.Label),
-			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "type", vn.Data.VnType.String()),
-			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "ipv4_connectivity_enabled", fmt.Sprintf("%t", vn.Data.Ipv4Enabled)),
-			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "ipv4_virtual_gateway_enabled", fmt.Sprintf("%t", vn.Data.VirtualGatewayIpv4Enabled)),
-			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "ipv6_connectivity_enabled", fmt.Sprintf("%t", vn.Data.Ipv6Enabled)),
-			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "ipv6_virtual_gateway_enabled", fmt.Sprintf("%t", vn.Data.VirtualGatewayIpv6Enabled)),
-			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "bindings.%", fmt.Sprintf("%d", len(vn.Data.VnBindings))),
+			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "name", vn.Label),
+			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "type", vn.Type.String()),
+			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "ipv4_connectivity_enabled", fmt.Sprintf("%t", vn.IPv4Enabled)),
+			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "ipv4_virtual_gateway_enabled", fmt.Sprintf("%t", vn.VirtualGatewayIPv4Enabled)),
+			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "ipv6_connectivity_enabled", fmt.Sprintf("%t", vn.IPv6Enabled)),
+			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "ipv6_virtual_gateway_enabled", fmt.Sprintf("%t", vn.VirtualGatewayIPv6Enabled)),
+			resource.TestCheckResourceAttr("data.apstra_datacenter_virtual_network.test", "bindings.%", fmt.Sprintf("%d", len(vn.Bindings))),
 		}
 		return result
 	}
 
-	testCheckFuncsByVnId := make(map[apstra.ObjectId][]resource.TestCheckFunc, len(virtualNetworks))
+	testCheckFuncsByVnId := make(map[string][]resource.TestCheckFunc, len(virtualNetworks))
 	for _, virtualNetwork := range virtualNetworks {
-		testCheckFuncsByVnId[virtualNetwork.Id] = genTestCheckFuncs(virtualNetwork)
+		testCheckFuncsByVnId[*virtualNetwork.ID()] = genTestCheckFuncs(virtualNetwork)
 	}
 
 	stepsById := make([]resource.TestStep, len(virtualNetworks))
 	for i, virtualNetwork := range virtualNetworks {
 		stepsById[i] = resource.TestStep{
-			Config: insecureProviderConfigHCL + fmt.Sprintf(dataSourceDataCenterVirtualNetworkByIdHcl, bp.Id(), virtualNetwork.Id),
-			Check:  resource.ComposeAggregateTestCheckFunc(testCheckFuncsByVnId[virtualNetwork.Id]...),
+			Config: insecureProviderConfigHCL + fmt.Sprintf(dataSourceDataCenterVirtualNetworkByIdHcl, bp.Id(), *virtualNetwork.ID()),
+			Check:  resource.ComposeAggregateTestCheckFunc(testCheckFuncsByVnId[*virtualNetwork.ID()]...),
 		}
 	}
 
 	stepsByName := make([]resource.TestStep, len(virtualNetworks))
 	for i, virtualNetwork := range virtualNetworks {
 		stepsByName[i] = resource.TestStep{
-			Config: insecureProviderConfigHCL + fmt.Sprintf(dataSourceDataCenterVirtualNetworkByNameHcl, bp.Id(), virtualNetwork.Data.Label),
+			Config: insecureProviderConfigHCL + fmt.Sprintf(dataSourceDataCenterVirtualNetworkByNameHcl, bp.Id(), virtualNetwork.Label),
 			Check:  resource.ComposeAggregateTestCheckFunc(genTestCheckFuncs(virtualNetwork)...),
 		}
 	}

--- a/apstra/data_source_datacenter_virtual_networks.go
+++ b/apstra/data_source_datacenter_virtual_networks.go
@@ -175,7 +175,7 @@ func (o *dataSourceDatacenterVirtualNetworks) Read(ctx context.Context, req data
 }
 
 func (o *dataSourceDatacenterVirtualNetworks) getAllVnIds(ctx context.Context, bp *apstra.TwoStageL3ClosClient, diags *diag.Diagnostics) []attr.Value {
-	ids, err := bp.ListAllVirtualNetworkIds(ctx)
+	ids, err := bp.ListVirtualNetworks(ctx)
 	if err != nil {
 		diags.AddError(
 			fmt.Sprintf("failed to list virtual networks in blueprint %s", bp.Id()), err.Error())
@@ -184,7 +184,7 @@ func (o *dataSourceDatacenterVirtualNetworks) getAllVnIds(ctx context.Context, b
 
 	result := make([]attr.Value, len(ids))
 	for i, id := range ids {
-		result[i] = types.StringValue(id.String())
+		result[i] = types.StringValue(id)
 	}
 
 	return result

--- a/apstra/resource_datacenter_connectivity_template_primitives_test.go
+++ b/apstra/resource_datacenter_connectivity_template_primitives_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/constants"
@@ -60,7 +61,7 @@ func randomCustomStaticRoutes(t testing.TB, ctx context.Context, ipv4Count, ipv6
 	result := make(map[string]resourceDataCenterConnectivityTemplatePrimitiveCustomStaticRoute, ipv4Count+ipv6Count)
 
 	rzName := acctest.RandString(6)
-	rzID, err := client.CreateSecurityZone(ctx, apstra.SecurityZone{
+	rzID, err := client.CreateSecurityZone(ctx, datacenter.SecurityZone{
 		Label:   rzName,
 		Type:    enum.SecurityZoneTypeEVPN,
 		VRFName: rzName,
@@ -710,7 +711,7 @@ func randomVirtualNetworkSingles(t testing.TB, ctx context.Context, count int, c
 	result := make(map[string]resourceDataCenterConnectivityTemplatePrimitiveVirtualNetworkSingle, count)
 	for range count {
 		result[acctest.RandStringFromCharSet(6, acctest.CharSetAlpha)] = resourceDataCenterConnectivityTemplatePrimitiveVirtualNetworkSingle{
-			virtualNetworkId:         testutils.VirtualNetworkVxlan(t, ctx, client, cleanup).String(),
+			virtualNetworkId:         testutils.VirtualNetworkVxlan(t, ctx, client, cleanup),
 			tagged:                   oneOf(true, false),
 			bgpPeeringGenericSystems: randomBgpPeeringGenericSystemPrimitives(t, ctx, rand.IntN(3), client, cleanup),
 			staticRoutes:             randomStaticRoutePrimitives(t, ctx, rand.IntN(3), rand.IntN(3), client, cleanup),
@@ -764,11 +765,11 @@ func randomVirtualNetworkMultiples(t testing.TB, ctx context.Context, count int,
 		var untaggedVnId string
 		if rand.Int()%2 == 0 {
 			for range rand.IntN(3) {
-				taggedVnIds = append(taggedVnIds, testutils.VirtualNetworkVxlan(t, ctx, client, cleanup).String())
+				taggedVnIds = append(taggedVnIds, testutils.VirtualNetworkVxlan(t, ctx, client, cleanup))
 			}
 		}
 		if rand.Int()%2 == 0 || len(taggedVnIds) == 0 {
-			untaggedVnId = testutils.VirtualNetworkVxlan(t, ctx, client, cleanup).String()
+			untaggedVnId = testutils.VirtualNetworkVxlan(t, ctx, client, cleanup)
 		}
 		result[acctest.RandStringFromCharSet(6, acctest.CharSetAlpha)] = resourceDataCenterConnectivityTemplatePrimitiveVirtualNetworkMultiple{
 			taggedVnIds:  taggedVnIds,

--- a/apstra/resource_datacenter_connectivity_templates_assignment_integration_test.go
+++ b/apstra/resource_datacenter_connectivity_templates_assignment_integration_test.go
@@ -27,9 +27,9 @@ resource %q %q {
 }`
 
 type resourceDatacenterConnectivityTemplatesAssignment struct {
-	blueprintId             apstra.ObjectId
-	applicationPointId      apstra.ObjectId
-	connectivityTemplateIds []apstra.ObjectId
+	blueprintId             string
+	applicationPointId      string
+	connectivityTemplateIds []string
 	fetchIpLinkIds          *bool
 }
 
@@ -47,12 +47,12 @@ func (o resourceDatacenterConnectivityTemplatesAssignment) testChecks(t testing.
 	result := newTestChecks(rType + "." + rName)
 
 	// required and computed attributes can always be checked
-	result.append(t, "TestCheckResourceAttr", "blueprint_id", o.blueprintId.String())
-	result.append(t, "TestCheckResourceAttr", "application_point_id", o.applicationPointId.String())
+	result.append(t, "TestCheckResourceAttr", "blueprint_id", o.blueprintId)
+	result.append(t, "TestCheckResourceAttr", "application_point_id", o.applicationPointId)
 	result.append(t, "TestCheckResourceAttr", "connectivity_template_ids.#", strconv.Itoa(len(o.connectivityTemplateIds)))
 
 	for _, connectivityTemplateId := range o.connectivityTemplateIds {
-		result.append(t, "TestCheckTypeSetElemAttr", "connectivity_template_ids.*", connectivityTemplateId.String())
+		result.append(t, "TestCheckTypeSetElemAttr", "connectivity_template_ids.*", connectivityTemplateId)
 	}
 
 	if o.fetchIpLinkIds == nil {
@@ -61,7 +61,7 @@ func (o resourceDatacenterConnectivityTemplatesAssignment) testChecks(t testing.
 		result.append(t, "TestCheckResourceAttr", "fetch_ip_link_ids", strconv.FormatBool(*o.fetchIpLinkIds))
 
 		for _, connectivityTemplateId := range o.connectivityTemplateIds {
-			ctVlans := testutils.DatacenterIpLinkConnectivityTemplateVlans(t, ctx, bp, connectivityTemplateId)
+			ctVlans := testutils.DatacenterIpLinkConnectivityTemplateVlans(t, ctx, bp, apstra.ObjectId(connectivityTemplateId))
 			for _, ctVlan := range ctVlans {
 				result.append(t, "TestCheckResourceAttrSet", fmt.Sprintf(`ip_link_ids.%s.%d`, connectivityTemplateId, ctVlan))
 			}
@@ -79,23 +79,23 @@ func TestAccDatacenterConnectivityTemplatesAssignment(t *testing.T) {
 
 	// Create blueprint, routing zones and connectivity templates
 	bp := testutils.BlueprintA(t, ctx)
-	interfaceCTs := make([]apstra.ObjectId, ifCTCount)
+	interfaceCTs := make([]string, ifCTCount)
 	for i := range interfaceCTs {
 		szId := testutils.SecurityZoneB(t, ctx, bp, true)
 		ctId := testutils.DatacenterConnectivityTemplateA(t, ctx, bp, szId, 101+i)
-		interfaceCTs[i] = ctId
+		interfaceCTs[i] = string(ctId)
 	}
-	systemCTs := make([]apstra.ObjectId, systemCTCount)
+	systemCTs := make([]string, systemCTCount)
 	for i := range systemCTs {
 		szId := testutils.SecurityZoneA(t, ctx, bp, true)
 		ctid := testutils.DatacenterConnectivityTemplateCustomStaticRoute(t, ctx, bp, apstra.ObjectId(szId))
-		systemCTs[i] = ctid
+		systemCTs[i] = string(ctid)
 	}
 
 	interfaceAPIDs := testutils.LeafSwitchGenericSystemInterfaces(t, ctx, bp)
 	require.Equal(t, 8, len(interfaceAPIDs)) // BlueprintA should have 8 single-homed generic systems
 
-	systemAPIDmap := testutils.GetSystemIds(t, ctx, bp, "leaf")
+	systemAPIDmap := testutils.GetSystemIDs(t, ctx, bp, "leaf")
 	systemAPIDs := slices.Collect(maps.Values(systemAPIDmap))
 	require.Equal(t, 4, len(systemAPIDs))
 
@@ -107,36 +107,36 @@ func TestAccDatacenterConnectivityTemplatesAssignment(t *testing.T) {
 		"single_csr_one_step": {
 			steps: []resourceDatacenterConnectivityTemplatesAssignment{
 				{
-					blueprintId:             bp.Id(),
+					blueprintId:             string(bp.Id()),
 					applicationPointId:      systemAPIDs[0],
-					connectivityTemplateIds: []apstra.ObjectId{systemCTs[0]},
+					connectivityTemplateIds: []string{systemCTs[0]},
 				},
 			},
 		},
 		"single_if_one_step": {
 			steps: []resourceDatacenterConnectivityTemplatesAssignment{
 				{
-					blueprintId:             bp.Id(),
-					connectivityTemplateIds: []apstra.ObjectId{interfaceCTs[0]},
-					applicationPointId:      interfaceAPIDs[0],
+					blueprintId:             string(bp.Id()),
+					connectivityTemplateIds: []string{interfaceCTs[0]},
+					applicationPointId:      string(interfaceAPIDs[0]),
 				},
 			},
 		},
 		"multiple_if_one_step": {
 			steps: []resourceDatacenterConnectivityTemplatesAssignment{
 				{
-					blueprintId:             bp.Id(),
+					blueprintId:             string(bp.Id()),
 					connectivityTemplateIds: interfaceCTs,
-					applicationPointId:      interfaceAPIDs[0],
+					applicationPointId:      string(interfaceAPIDs[0]),
 				},
 			},
 		},
 		"single_if_with_fetch": {
 			steps: []resourceDatacenterConnectivityTemplatesAssignment{
 				{
-					blueprintId:             bp.Id(),
+					blueprintId:             string(bp.Id()),
 					connectivityTemplateIds: interfaceCTs,
-					applicationPointId:      interfaceAPIDs[0],
+					applicationPointId:      string(interfaceAPIDs[0]),
 					fetchIpLinkIds:          pointer.To(true),
 				},
 			},
@@ -144,19 +144,19 @@ func TestAccDatacenterConnectivityTemplatesAssignment(t *testing.T) {
 		"simple_if": {
 			steps: []resourceDatacenterConnectivityTemplatesAssignment{
 				{
-					blueprintId:             bp.Id(),
+					blueprintId:             string(bp.Id()),
 					connectivityTemplateIds: interfaceCTs[0:1],
-					applicationPointId:      interfaceAPIDs[1],
+					applicationPointId:      string(interfaceAPIDs[1]),
 				},
 				{
-					blueprintId:             bp.Id(),
+					blueprintId:             string(bp.Id()),
 					connectivityTemplateIds: interfaceCTs[1:3],
-					applicationPointId:      interfaceAPIDs[1],
+					applicationPointId:      string(interfaceAPIDs[1]),
 				},
 				{
-					blueprintId:             bp.Id(),
+					blueprintId:             string(bp.Id()),
 					connectivityTemplateIds: interfaceCTs[3:4],
-					applicationPointId:      interfaceAPIDs[1],
+					applicationPointId:      string(interfaceAPIDs[1]),
 				},
 			},
 		},

--- a/apstra/resource_datacenter_generic_system_integration_test.go
+++ b/apstra/resource_datacenter_generic_system_integration_test.go
@@ -44,7 +44,7 @@ const resourceDataCenterGenericSystemLinkHCL = `
 type resourceDataCenterGenericSystemLink struct {
 	tags                []string
 	lagMode             apstra.RackLinkLagMode
-	targetSwitchId      apstra.ObjectId
+	targetSwitchId      string
 	targetSwitchIf      string
 	targetSwitchTf      int
 	groupLabel          string
@@ -65,7 +65,7 @@ func (o *resourceDataCenterGenericSystemLink) render() string {
 
 func (o *resourceDataCenterGenericSystemLink) addTestChecks(t testing.TB, testChecks *testChecks) {
 	m := map[string]string{
-		"target_switch_id":              o.targetSwitchId.String(),
+		"target_switch_id":              o.targetSwitchId,
 		"target_switch_if_name":         o.targetSwitchIf,
 		"target_switch_if_transform_id": strconv.Itoa(o.targetSwitchTf),
 	}
@@ -253,10 +253,10 @@ func TestResourceDatacenterGenericSystem(t *testing.T) {
 	bp := testutils.BlueprintF(t, ctx)
 
 	// get leaf switch IDs, sorted as in web UI
-	leafNameToId := testutils.GetSystemIds(t, ctx, bp, "leaf")
+	leafNameToId := testutils.GetSystemIDs(t, ctx, bp, "leaf")
 	leafNames := slices.Collect(maps.Keys(leafNameToId))
 	sort.Strings(leafNames)
-	leafSwitchIds := make([]apstra.ObjectId, len(leafNames))
+	leafSwitchIds := make([]string, len(leafNames))
 	for i, leafName := range leafNames {
 		leafSwitchIds[i] = leafNameToId[leafName]
 	}
@@ -282,9 +282,9 @@ func TestResourceDatacenterGenericSystem(t *testing.T) {
 	require.NoError(t, ct.SetUserData())
 	require.NoError(t, bp.CreateConnectivityTemplate(ctx, &ct))
 
-	attachCtToSingleLink := func(t *testing.T, swId apstra.ObjectId, ifName string) {
+	attachCtToSingleLink := func(t *testing.T, swId string, ifName string) {
 		t.Helper()
-		ifId, err := blueprint.IfIdFromSwIdAndIfName(ctx, bp, swId, ifName)
+		ifId, err := blueprint.IfIdFromSwIdAndIfName(ctx, bp, apstra.ObjectId(swId), ifName)
 		require.NoError(t, err)
 		require.NoError(t, bp.SetApplicationPointConnectivityTemplates(ctx, ifId, []apstra.ObjectId{*ct.Id}))
 	}
@@ -611,9 +611,9 @@ func TestResourceDatacenterGenericSystem(t *testing.T) {
 					preApplyResourceActionType: plancheck.ResourceActionNoop,
 					preconfig: func(t *testing.T) { // ensure CT is reattached in previous step
 						// get interface (application point) IDs
-						ifId1, err := blueprint.IfIdFromSwIdAndIfName(ctx, bp, leafSwitchIds[0], "ge-0/0/4") // 4 avoids conflict with other test cases
+						ifId1, err := blueprint.IfIdFromSwIdAndIfName(ctx, bp, apstra.ObjectId(leafSwitchIds[0]), "ge-0/0/4") // 4 avoids conflict with other test cases
 						require.NoError(t, err)
-						ifId2, err := blueprint.IfIdFromSwIdAndIfName(ctx, bp, leafSwitchIds[1], "ge-0/0/4") // 4 avoids conflict with other test cases
+						ifId2, err := blueprint.IfIdFromSwIdAndIfName(ctx, bp, apstra.ObjectId(leafSwitchIds[1]), "ge-0/0/4") // 4 avoids conflict with other test cases
 						require.NoError(t, err)
 
 						// determine attached CTs
@@ -1046,7 +1046,7 @@ func TestResourceDatacenterGenericSystem(t *testing.T) {
 				},
 				{
 					preconfig: func(t *testing.T) {
-						attachCtToLag(t, leafSwitchIds[0], "bar") // 2 avoids conflict with other test cases
+						attachCtToLag(t, apstra.ObjectId(leafSwitchIds[0]), "bar") // 2 avoids conflict with other test cases
 					},
 					config: resourceDataCenterGenericSystem{
 						clearCtsOnDestroy: pointer.To(true),

--- a/apstra/resource_datacenter_ip_link_addressing_integration_test.go
+++ b/apstra/resource_datacenter_ip_link_addressing_integration_test.go
@@ -163,7 +163,7 @@ func TestResourceDatacenterIpLinkAddressing(t *testing.T) {
 			Attributes: &apstra.ConnectivityTemplatePrimitiveAttributesAttachLogicalLink{
 				SecurityZone: (*apstra.ObjectId)(&rzId),
 				Tagged:       true,
-				Vlan:         pointer.To(apstra.VLAN(101 + i)),
+				Vlan:         pointer.To(uint16(101 + i)),
 			},
 		}
 	}

--- a/apstra/resource_datacenter_routing_zone_constraint_integration_test.go
+++ b/apstra/resource_datacenter_routing_zone_constraint_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
@@ -92,7 +93,7 @@ func TestResourceDatacenterRoutingZoneConstraint(t *testing.T) {
 	routingZoneIds := make([]string, acctest.RandIntRange(5, 10))
 	for i := range routingZoneIds {
 		label := acctest.RandString(6)
-		id, err := bp.CreateSecurityZone(ctx, apstra.SecurityZone{
+		id, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 			Label:   label,
 			Type:    enum.SecurityZoneTypeEVPN,
 			VRFName: label,

--- a/apstra/resource_datacenter_routing_zone_loopback_addresses_integration_test.go
+++ b/apstra/resource_datacenter_routing_zone_loopback_addresses_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	tfapstra "github.com/Juniper/terraform-provider-apstra/apstra"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
@@ -117,28 +118,28 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 	rzID := testutils.SecurityZoneB(t, ctx, bp, false)
 
 	// discover leaf switch IDs
-	leafs := testutils.GetSystemIds(t, ctx, bp, "leaf")
+	leafs := testutils.GetSystemIDs(t, ctx, bp, "leaf")
 
 	// create a VN to ensure the leaf switches participate in the RZ
-	vnBindings := make([]apstra.VnBinding, len(leafs))
+	vnBindings := make([]datacenter.VNBinding, len(leafs))
 	var i int
 	for _, leafId := range leafs {
-		vnBindings[i] = apstra.VnBinding{SystemId: leafId}
+		vnBindings[i] = datacenter.VNBinding{SystemID: leafId}
 		i++
 	}
-	_, err = bp.CreateVirtualNetwork(ctx, &apstra.VirtualNetworkData{
+	_, err = bp.CreateVirtualNetwork(ctx, datacenter.VirtualNetwork{
 		Label:          acctest.RandString(6),
-		SecurityZoneId: apstra.ObjectId(rzID),
-		VnType:         enum.VnTypeVxlan,
-		VnBindings:     vnBindings,
+		SecurityZoneID: rzID,
+		Type:           enum.VnTypeVxlan,
+		Bindings:       vnBindings,
 	})
 	require.NoError(t, err)
 
 	// make a slice of leafIds
 	i = 0
-	leafIds := make([]apstra.ObjectId, len(leafs))
+	leafIDs := make([]string, len(leafs))
 	for _, v := range leafs {
-		leafIds[i] = v
+		leafIDs[i] = v
 		i++
 	}
 
@@ -158,7 +159,7 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[0].String(): {
+						leafIDs[0]: {
 							iPv4Addr: "",
 							iPv6Addr: "",
 						},
@@ -168,7 +169,7 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[0].String(): {
+						leafIDs[0]: {
 							iPv4Addr: pointer.To(randomPrefix(t, "10.1.0.0/16", 32)).String(),
 							iPv6Addr: pointer.To(randomPrefix(t, "3fff:1::/32", 128)).String(),
 						},
@@ -178,7 +179,7 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[0].String(): {
+						leafIDs[0]: {
 							iPv4Addr: "",
 							iPv6Addr: "",
 						},
@@ -192,7 +193,7 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[1].String(): {
+						leafIDs[1]: {
 							iPv4Addr: pointer.To(randomPrefix(t, "10.2.0.0/16", 32)).String(),
 							iPv6Addr: pointer.To(randomPrefix(t, "3fff:2::/32", 128)).String(),
 						},
@@ -202,7 +203,7 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[1].String(): {
+						leafIDs[1]: {
 							iPv4Addr: "",
 							iPv6Addr: "",
 						},
@@ -212,7 +213,7 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[1].String(): {
+						leafIDs[1]: {
 							iPv4Addr: pointer.To(randomPrefix(t, "10.2.0.0/16", 32)).String(),
 							iPv6Addr: pointer.To(randomPrefix(t, "3fff:2::/32", 128)).String(),
 						},
@@ -226,11 +227,11 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[2].String(): {
+						leafIDs[2]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.30.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:30::/32", 128)).String(), ""),
 						},
-						leafIds[3].String(): {
+						leafIDs[3]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.31.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:31::/32", 128)).String(), ""),
 						},
@@ -240,11 +241,11 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[2].String(): {
+						leafIDs[2]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.30.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:30::/32", 128)).String(), ""),
 						},
-						leafIds[3].String(): {
+						leafIDs[3]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.31.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:31::/32", 128)).String(), ""),
 						},
@@ -254,11 +255,11 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[2].String(): {
+						leafIDs[2]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.30.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:30::/32", 128)).String(), ""),
 						},
-						leafIds[3].String(): {
+						leafIDs[3]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.31.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:31::/32", 128)).String(), ""),
 						},
@@ -268,11 +269,11 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[2].String(): {
+						leafIDs[2]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.30.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:30::/32", 128)).String(), ""),
 						},
-						leafIds[3].String(): {
+						leafIDs[3]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.31.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:31::/32", 128)).String(), ""),
 						},
@@ -282,11 +283,11 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[2].String(): {
+						leafIDs[2]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.30.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:30::/32", 128)).String(), ""),
 						},
-						leafIds[3].String(): {
+						leafIDs[3]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.31.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:31::/32", 128)).String(), ""),
 						},
@@ -296,11 +297,11 @@ func TestResourceDatacenterRoutingZoneLoopbackAddresses(t *testing.T) {
 					blueprintID:   bp.Id().String(),
 					routingZoneID: rzID,
 					loopbacks: map[string]resourceDatacenterRoutingZoneLoopbackAddress{
-						leafIds[2].String(): {
+						leafIDs[2]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.30.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:30::/32", 128)).String(), ""),
 						},
-						leafIds[3].String(): {
+						leafIDs[3]: {
 							iPv4Addr: oneOf(pointer.To(randomPrefix(t, "10.31.0.0/16", 32)).String(), ""),
 							iPv6Addr: oneOf(pointer.To(randomPrefix(t, "3fff:31::/32", 128)).String(), ""),
 						},

--- a/apstra/resource_datacenter_security_policy.go
+++ b/apstra/resource_datacenter_security_policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -12,10 +13,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ resource.ResourceWithConfigure = &resourceDatacenterSecurityPolicy{}
-var _ resource.ResourceWithImportState = &resourceDatacenterSecurityPolicy{}
-var _ resourceWithSetDcBpClientFunc = &resourceDatacenterSecurityPolicy{}
-var _ resourceWithSetBpLockFunc = &resourceDatacenterSecurityPolicy{}
+var (
+	_ resource.ResourceWithConfigure   = &resourceDatacenterSecurityPolicy{}
+	_ resource.ResourceWithImportState = &resourceDatacenterSecurityPolicy{}
+	_ resourceWithSetDcBpClientFunc    = &resourceDatacenterSecurityPolicy{}
+	_ resourceWithSetBpLockFunc        = &resourceDatacenterSecurityPolicy{}
+)
 
 type resourceDatacenterSecurityPolicy struct {
 	getBpClientFunc func(context.Context, string) (*apstra.TwoStageL3ClosClient, error)
@@ -137,7 +140,7 @@ func (o *resourceDatacenterSecurityPolicy) Create(ctx context.Context, req resou
 	}
 
 	// set the ID into the plan object and provisionally set state
-	plan.Id = types.StringValue(id.String())
+	plan.Id = types.StringValue(id)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 
 	// read the policy back from the API to get the rule IDs
@@ -220,7 +223,7 @@ func (o *resourceDatacenterSecurityPolicy) Update(ctx context.Context, req resou
 	}
 
 	// update the security policy
-	err = bp.UpdatePolicy(ctx, apstra.ObjectId(plan.Id.ValueString()), request)
+	err = bp.UpdatePolicy(ctx, request)
 	if err != nil {
 		resp.Diagnostics.AddError("error creating security policy", err.Error())
 		return
@@ -267,7 +270,7 @@ func (o *resourceDatacenterSecurityPolicy) Delete(ctx context.Context, req resou
 	}
 
 	// Delete the security policy
-	err = bp.DeletePolicy(ctx, apstra.ObjectId(state.Id.ValueString()))
+	err = bp.DeletePolicy(ctx, state.Id.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
 			return // 404 is okay

--- a/apstra/resource_datacenter_security_policy_test.go
+++ b/apstra/resource_datacenter_security_policy_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	testutils "github.com/Juniper/terraform-provider-apstra/apstra/test_utils"
 	"github.com/Juniper/terraform-provider-apstra/internal/rosetta"
@@ -52,17 +53,17 @@ resource "apstra_datacenter_security_policy" "test" {
 )
 
 type testCaseResourceSecurityPolicy struct {
-	config     apstra.PolicyData
+	config     datacenter.Policy
 	checks     []resource.TestCheckFunc
 	minVersion *version.Version
 }
 
 func (o testCaseResourceSecurityPolicy) renderConfig(bpId apstra.ObjectId) string {
-	renderPort := func(port apstra.PortRange) string {
+	renderPort := func(port datacenter.PortRange) string {
 		return fmt.Sprintf(resourceDataCenterSecurityPolicyRulePortHCL, port.First, port.Last)
 	}
 
-	renderPorts := func(ports apstra.PortRanges) string {
+	renderPorts := func(ports datacenter.PortRanges) string {
 		if len(ports) == 0 {
 			return "null"
 		}
@@ -84,19 +85,19 @@ func (o testCaseResourceSecurityPolicy) renderConfig(bpId apstra.ObjectId) strin
 		return strconv.FormatBool(*tsq == enum.TcpStateQualifierEstablished)
 	}
 
-	renderRule := func(rule apstra.PolicyRule) string {
+	renderRule := func(rule datacenter.PolicyRule) string {
 		return fmt.Sprintf(resourceDataCenterSecurityPolicyRuleHCL,
-			rule.Data.Label,
-			stringOrNull(rule.Data.Description),
-			rule.Data.Action.Value,
-			rosetta.StringersToFriendlyString(rule.Data.Protocol),
-			renderPorts(rule.Data.SrcPort),
-			renderPorts(rule.Data.DstPort),
-			renderEstablished(rule.Data.TcpStateQualifier),
+			rule.Label,
+			stringOrNull(rule.Description),
+			rule.Action.Value,
+			rosetta.StringersToFriendlyString(rule.Protocol),
+			renderPorts(rule.SrcPort),
+			renderPorts(rule.DstPort),
+			renderEstablished(rule.TcpStateQualifier),
 		)
 	}
 
-	renderRules := func(rules []apstra.PolicyRule) string {
+	renderRules := func(rules []datacenter.PolicyRule) string {
 		if len(rules) == 0 {
 			return "null"
 		}
@@ -108,14 +109,6 @@ func (o testCaseResourceSecurityPolicy) renderConfig(bpId apstra.ObjectId) strin
 		}
 		sb.WriteString("    ]\n")
 		return sb.String()
-	}
-
-	renderApplicationPoint := func(p *apstra.PolicyApplicationPointData) string {
-		if p == nil {
-			return "null"
-		}
-
-		return `"` + p.Id.String() + `"`
 	}
 
 	renderTags := func(s []string) string {
@@ -130,8 +123,8 @@ func (o testCaseResourceSecurityPolicy) renderConfig(bpId apstra.ObjectId) strin
 		o.config.Label,
 		stringOrNull(o.config.Description),
 		strconv.FormatBool(o.config.Enabled),
-		renderApplicationPoint(o.config.SrcApplicationPoint),
-		renderApplicationPoint(o.config.DstApplicationPoint),
+		stringPtrOrNull(o.config.SrcApplicationPoint),
+		stringPtrOrNull(o.config.DstApplicationPoint),
 		renderTags(o.config.Tags),
 		renderRules(o.config.Rules),
 	)
@@ -146,13 +139,13 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 	leafIds := systemIds(ctx, t, bpClient, "leaf")
 
 	// create virtual networks
-	vnIds := make([]apstra.ObjectId, 2)
+	vnIds := make([]string, 2)
 	for i := range vnIds {
-		id, err := bpClient.CreateVirtualNetwork(ctx, &apstra.VirtualNetworkData{
-			Ipv4Enabled: true,
+		id, err := bpClient.CreateVirtualNetwork(ctx, datacenter.VirtualNetwork{
+			IPv4Enabled: true,
 			Label:       acctest.RandString(5),
-			VnBindings:  []apstra.VnBinding{{SystemId: apstra.ObjectId(leafIds[i])}},
-			VnType:      enum.VnTypeVlan,
+			Bindings:    []datacenter.VNBinding{{SystemID: leafIds[i]}},
+			Type:        enum.VnTypeVlan,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -162,7 +155,7 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 
 	tests := []testCaseResourceSecurityPolicy{
 		{
-			config: apstra.PolicyData{
+			config: datacenter.Policy{
 				Label: "1",
 			},
 			checks: []resource.TestCheckFunc{
@@ -172,7 +165,7 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			config: apstra.PolicyData{
+			config: datacenter.Policy{
 				Label:       "2",
 				Enabled:     true,
 				Description: "two",
@@ -190,7 +183,7 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			config: apstra.PolicyData{
+			config: datacenter.Policy{
 				Label:   "3",
 				Enabled: false,
 			},
@@ -201,47 +194,45 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			config: apstra.PolicyData{
+			config: datacenter.Policy{
 				Label:               "4",
 				Enabled:             true,
-				SrcApplicationPoint: &apstra.PolicyApplicationPointData{Id: vnIds[0]},
-				DstApplicationPoint: &apstra.PolicyApplicationPointData{Id: vnIds[1]},
+				SrcApplicationPoint: &vnIds[0],
+				DstApplicationPoint: &vnIds[1],
 			},
 			checks: []resource.TestCheckFunc{
 				resource.TestCheckResourceAttrSet(resourceDataCenterSecurityPolicyRefName, "id"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "name", "4"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "enabled", "true"),
-				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "source_application_point_id", vnIds[0].String()),
-				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "destination_application_point_id", vnIds[1].String()),
+				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "source_application_point_id", vnIds[0]),
+				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "destination_application_point_id", vnIds[1]),
 			},
 		},
 		{
-			config: apstra.PolicyData{
+			config: datacenter.Policy{
 				Label:               "5",
 				Enabled:             false,
-				SrcApplicationPoint: &apstra.PolicyApplicationPointData{Id: vnIds[1]},
-				DstApplicationPoint: &apstra.PolicyApplicationPointData{Id: vnIds[0]},
+				SrcApplicationPoint: &vnIds[1],
+				DstApplicationPoint: &vnIds[0],
 			},
 			checks: []resource.TestCheckFunc{
 				resource.TestCheckResourceAttrSet(resourceDataCenterSecurityPolicyRefName, "id"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "name", "5"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "enabled", "false"),
-				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "source_application_point_id", vnIds[1].String()),
-				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "destination_application_point_id", vnIds[0].String()),
+				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "source_application_point_id", vnIds[1]),
+				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "destination_application_point_id", vnIds[0]),
 			},
 		},
 		{
-			config: apstra.PolicyData{
+			config: datacenter.Policy{
 				Label:   "6",
 				Enabled: true,
-				Rules: []apstra.PolicyRule{
+				Rules: []datacenter.PolicyRule{
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:       "60",
-							Description: "",
-							Protocol:    enum.PolicyRuleProtocolIcmp,
-							Action:      enum.PolicyRuleActionDeny,
-						},
+						Label:       "60",
+						Description: "",
+						Protocol:    enum.PolicyRuleProtocolIcmp,
+						Action:      enum.PolicyRuleActionDeny,
 					},
 				},
 			},
@@ -256,17 +247,15 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			config: apstra.PolicyData{
+			config: datacenter.Policy{
 				Label:   "7",
 				Enabled: false,
-				Rules: []apstra.PolicyRule{
+				Rules: []datacenter.PolicyRule{
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:       "70",
-							Description: "seventy",
-							Protocol:    enum.PolicyRuleProtocolIp,
-							Action:      enum.PolicyRuleActionDenyLog,
-						},
+						Label:       "70",
+						Description: "seventy",
+						Protocol:    enum.PolicyRuleProtocolIp,
+						Action:      enum.PolicyRuleActionDenyLog,
 					},
 				},
 			},
@@ -282,44 +271,38 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			config: apstra.PolicyData{
+			config: datacenter.Policy{
 				Label:               "8",
 				Enabled:             true,
-				SrcApplicationPoint: &apstra.PolicyApplicationPointData{Id: vnIds[0]},
-				DstApplicationPoint: &apstra.PolicyApplicationPointData{Id: vnIds[1]},
-				Rules: []apstra.PolicyRule{
+				SrcApplicationPoint: &vnIds[0],
+				DstApplicationPoint: &vnIds[1],
+				Rules: []datacenter.PolicyRule{
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:       "80",
-							Description: "eighty",
-							Protocol:    enum.PolicyRuleProtocolUdp,
-							Action:      enum.PolicyRuleActionPermit,
-						},
+						Label:       "80",
+						Description: "eighty",
+						Protocol:    enum.PolicyRuleProtocolUdp,
+						Action:      enum.PolicyRuleActionPermit,
 					},
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:       "81",
-							Description: "eightyone",
-							Protocol:    enum.PolicyRuleProtocolTcp,
-							Action:      enum.PolicyRuleActionPermitLog,
-						},
+						Label:       "81",
+						Description: "eightyone",
+						Protocol:    enum.PolicyRuleProtocolTcp,
+						Action:      enum.PolicyRuleActionPermitLog,
 					},
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:             "82",
-							Description:       "eightytwo",
-							Protocol:          enum.PolicyRuleProtocolTcp,
-							Action:            enum.PolicyRuleActionPermit,
-							TcpStateQualifier: &enum.TcpStateQualifierEstablished,
-							SrcPort: apstra.PortRanges{
-								{First: 1, Last: 1},
-								{First: 3, Last: 5},
-								{First: 7, Last: 9},
-								{First: 11, Last: 11},
-							},
-							DstPort: apstra.PortRanges{
-								{First: 50, Last: 50},
-							},
+						Label:             "82",
+						Description:       "eightytwo",
+						Protocol:          enum.PolicyRuleProtocolTcp,
+						Action:            enum.PolicyRuleActionPermit,
+						TcpStateQualifier: &enum.TcpStateQualifierEstablished,
+						SrcPort: datacenter.PortRanges{
+							{First: 1, Last: 1},
+							{First: 3, Last: 5},
+							{First: 7, Last: 9},
+							{First: 11, Last: 11},
+						},
+						DstPort: datacenter.PortRanges{
+							{First: 50, Last: 50},
 						},
 					},
 				},
@@ -328,8 +311,8 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 				resource.TestCheckResourceAttrSet(resourceDataCenterSecurityPolicyRefName, "id"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "name", "8"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "enabled", "true"),
-				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "source_application_point_id", vnIds[0].String()),
-				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "destination_application_point_id", vnIds[1].String()),
+				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "source_application_point_id", vnIds[0]),
+				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "destination_application_point_id", vnIds[1]),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "rules.#", "3"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "rules.0.name", "80"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "rules.0.description", "eighty"),
@@ -350,44 +333,38 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			config: apstra.PolicyData{
+			config: datacenter.Policy{
 				Label:               "9",
 				Enabled:             true,
-				SrcApplicationPoint: &apstra.PolicyApplicationPointData{Id: vnIds[0]},
-				DstApplicationPoint: &apstra.PolicyApplicationPointData{Id: vnIds[1]},
-				Rules: []apstra.PolicyRule{
+				SrcApplicationPoint: &vnIds[0],
+				DstApplicationPoint: &vnIds[1],
+				Rules: []datacenter.PolicyRule{
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:       "90",
-							Description: "ninety",
-							Protocol:    enum.PolicyRuleProtocolUdp,
-							Action:      enum.PolicyRuleActionPermit,
-						},
+						Label:       "90",
+						Description: "ninety",
+						Protocol:    enum.PolicyRuleProtocolUdp,
+						Action:      enum.PolicyRuleActionPermit,
 					},
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:       "91",
-							Description: "ninetyone",
-							Protocol:    enum.PolicyRuleProtocolTcp,
-							Action:      enum.PolicyRuleActionPermitLog,
-						},
+						Label:       "91",
+						Description: "ninetyone",
+						Protocol:    enum.PolicyRuleProtocolTcp,
+						Action:      enum.PolicyRuleActionPermitLog,
 					},
 					{
-						Data: &apstra.PolicyRuleData{
-							Label:             "92",
-							Description:       "ninetytwo",
-							Protocol:          enum.PolicyRuleProtocolTcp,
-							Action:            enum.PolicyRuleActionPermit,
-							TcpStateQualifier: &enum.TcpStateQualifierEstablished,
-							SrcPort: apstra.PortRanges{
-								{First: 1, Last: 1},
-								{First: 7, Last: 9},
-								{First: 11, Last: 11},
-							},
-							DstPort: apstra.PortRanges{
-								{First: 50, Last: 50},
-								{First: 3, Last: 5},
-							},
+						Label:             "92",
+						Description:       "ninetytwo",
+						Protocol:          enum.PolicyRuleProtocolTcp,
+						Action:            enum.PolicyRuleActionPermit,
+						TcpStateQualifier: &enum.TcpStateQualifierEstablished,
+						SrcPort: datacenter.PortRanges{
+							{First: 1, Last: 1},
+							{First: 7, Last: 9},
+							{First: 11, Last: 11},
+						},
+						DstPort: datacenter.PortRanges{
+							{First: 50, Last: 50},
+							{First: 3, Last: 5},
 						},
 					},
 				},
@@ -396,8 +373,8 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 				resource.TestCheckResourceAttrSet(resourceDataCenterSecurityPolicyRefName, "id"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "name", "9"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "enabled", "true"),
-				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "source_application_point_id", vnIds[0].String()),
-				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "destination_application_point_id", vnIds[1].String()),
+				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "source_application_point_id", vnIds[0]),
+				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "destination_application_point_id", vnIds[1]),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "rules.#", "3"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "rules.0.name", "90"),
 				resource.TestCheckResourceAttr(resourceDataCenterSecurityPolicyRefName, "rules.0.description", "ninety"),
@@ -418,7 +395,7 @@ func TestResourceDatacenterSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			config: apstra.PolicyData{
+			config: datacenter.Policy{
 				Label:   "10",
 				Enabled: false,
 			},

--- a/apstra/resource_datacenter_virtual_network.go
+++ b/apstra/resource_datacenter_virtual_network.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/terraform-provider-apstra/apstra/blueprint"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/Juniper/terraform-provider-apstra/apstra/utils"
@@ -215,6 +216,7 @@ func (o *resourceDatacenterVirtualNetwork) Create(ctx context.Context, req resou
 	}
 
 	// set tags, if any
+	// todo: skip setting tags when talking to Apstra 6.2+ (#1257)
 	if !plan.Tags.IsNull() {
 		var tags []string
 		resp.Diagnostics.Append(plan.Tags.ElementsAs(ctx, &tags, false)...)
@@ -222,7 +224,7 @@ func (o *resourceDatacenterVirtualNetwork) Create(ctx context.Context, req resou
 			return
 		}
 
-		err = bp.SetNodeTags(ctx, id, tags)
+		err = bp.SetNodeTags(ctx, apstra.ObjectId(id), tags)
 		if err != nil {
 			resp.Diagnostics.AddError("error setting tags", err.Error())
 			return
@@ -232,11 +234,11 @@ func (o *resourceDatacenterVirtualNetwork) Create(ctx context.Context, req resou
 	// update the plan with the received ObjectId and set the partial state in
 	// case we have to bail due to error soon.
 	plan.HadPriorVniConfig = types.BoolValue(!plan.Vni.IsUnknown())
-	plan.Id = types.StringValue(id.String())
+	plan.Id = types.StringValue(id)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 
 	// fetch the virtual network to learn apstra-assigned VLAN assignments
-	var api *apstra.VirtualNetwork
+	var api datacenter.VirtualNetwork
 	retryMax := 25
 	for {
 		if retryMax == 0 {
@@ -251,11 +253,11 @@ func (o *resourceDatacenterVirtualNetwork) Create(ctx context.Context, req resou
 			return
 		}
 
-		if plan.IPv4ConnectivityEnabled.ValueBool() && api.Data.Ipv4Subnet == nil {
+		if plan.IPv4ConnectivityEnabled.ValueBool() && api.IPv4Subnet == nil {
 			time.Sleep(200 * time.Millisecond)
 			continue // try again
 		}
-		if plan.IPv6ConnectivityEnabled.ValueBool() && api.Data.Ipv6Subnet == nil {
+		if plan.IPv6ConnectivityEnabled.ValueBool() && api.IPv6Subnet == nil {
 			time.Sleep(200 * time.Millisecond)
 			continue // try again
 		}
@@ -267,10 +269,9 @@ func (o *resourceDatacenterVirtualNetwork) Create(ctx context.Context, req resou
 	// instantiating a new object here because #170 (a creation race condition
 	// in the API) means we can't completely rely on the API response.
 	var state blueprint.DatacenterVirtualNetwork
-	state.Id = types.StringValue(id.String())
 	state.BlueprintId = plan.BlueprintId
 	state.HadPriorVniConfig = plan.HadPriorVniConfig
-	state.LoadApiData(ctx, api.Data, &resp.Diagnostics)
+	state.LoadApiData(ctx, api, &resp.Diagnostics)
 
 	// Don't rely on the API response for these values (#170). If the config
 	// supplied a value, use it when setting state.
@@ -321,7 +322,7 @@ func (o *resourceDatacenterVirtualNetwork) Read(ctx context.Context, req resourc
 	}
 
 	// retrieve the virtual network
-	vn, err := bp.GetVirtualNetwork(ctx, apstra.ObjectId(state.Id.ValueString()))
+	vn, err := bp.GetVirtualNetwork(ctx, state.Id.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
 			resp.State.RemoveResource(ctx)
@@ -333,7 +334,7 @@ func (o *resourceDatacenterVirtualNetwork) Read(ctx context.Context, req resourc
 	bindingsShouldBeNull := state.Bindings.IsNull()
 
 	// load the API response
-	state.LoadApiData(ctx, vn.Data, &resp.Diagnostics)
+	state.LoadApiData(ctx, vn, &resp.Diagnostics)
 
 	// wipe out the bindings if none were recorded in the state (bindings created some other way)
 	if bindingsShouldBeNull && !state.Bindings.IsNull() {
@@ -396,13 +397,14 @@ func (o *resourceDatacenterVirtualNetwork) Update(ctx context.Context, req resou
 		!plan.ImportRouteTargets.Equal(state.ImportRouteTargets) ||
 		!plan.ExportRouteTargets.Equal(state.ExportRouteTargets) {
 
-		err = bp.UpdateVirtualNetwork(ctx, apstra.ObjectId(plan.Id.ValueString()), request)
+		err = bp.UpdateVirtualNetwork(ctx, request)
 		if err != nil {
 			resp.Diagnostics.AddError("error updating virtual network", err.Error())
 		}
 	}
 
 	// update tags, if necessary
+	// todo: skip setting tags when talking to Apstra 6.2+ (#1257)
 	if !plan.Tags.Equal(state.Tags) {
 		var tags []string
 		resp.Diagnostics.Append(plan.Tags.ElementsAs(ctx, &tags, false)...)
@@ -417,7 +419,7 @@ func (o *resourceDatacenterVirtualNetwork) Update(ctx context.Context, req resou
 	}
 
 	// fetch the virtual network to learn apstra-assigned VLAN assignments
-	api, err := bp.GetVirtualNetwork(ctx, apstra.ObjectId(plan.Id.ValueString()))
+	api, err := bp.GetVirtualNetwork(ctx, plan.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("error fetching just-updated virtual network %q", plan.Id.ValueString()),
@@ -429,10 +431,9 @@ func (o *resourceDatacenterVirtualNetwork) Update(ctx context.Context, req resou
 	// instantiating a new object here because #170 (a creation race condition
 	// in the API) means we can't completely rely on the API response.
 	var stateOut blueprint.DatacenterVirtualNetwork
-	stateOut.Id = plan.Id
 	stateOut.BlueprintId = plan.BlueprintId
 	stateOut.HadPriorVniConfig = types.BoolValue(!plan.Vni.IsUnknown())
-	stateOut.LoadApiData(ctx, api.Data, &resp.Diagnostics)
+	stateOut.LoadApiData(ctx, api, &resp.Diagnostics)
 
 	// Don't rely on the API response for these values (#170). If the config
 	// supplied a value, use that when setting state.
@@ -495,7 +496,7 @@ func (o *resourceDatacenterVirtualNetwork) Delete(ctx context.Context, req resou
 	}
 
 	// Delete the virtual network
-	err = bp.DeleteVirtualNetwork(ctx, apstra.ObjectId(state.Id.ValueString()))
+	err = bp.DeleteVirtualNetwork(ctx, state.Id.ValueString())
 	if err != nil {
 		if utils.IsApstra404(err) {
 			return // 404 is okay

--- a/apstra/test_utils/blueprint.go
+++ b/apstra/test_utils/blueprint.go
@@ -269,10 +269,10 @@ func BlueprintF(t testing.TB, ctx context.Context) *apstra.TwoStageL3ClosClient 
 	require.NoError(t, err)
 
 	// set interface map on all leafs
-	leafs := GetSystemIds(t, ctx, bpClient, "leaf")
+	leafs := GetSystemIDs(t, ctx, bpClient, "leaf")
 	assignents := make(apstra.SystemIdToInterfaceMapAssignment, len(leafs))
 	for _, leaf := range leafs {
-		assignents[leaf.String()] = "Juniper_QFX5100-48S__AOS-48x10_6x40-2"
+		assignents[leaf] = "Juniper_QFX5100-48S__AOS-48x10_6x40-2"
 	}
 	err = bpClient.SetInterfaceMapAssignments(ctx, assignents)
 	require.NoError(t, err)
@@ -332,10 +332,10 @@ func BlueprintI(t testing.TB, ctx context.Context) *apstra.TwoStageL3ClosClient 
 	require.NoError(t, err)
 
 	// assign leaf interface maps
-	leafIds := GetSystemIds(t, ctx, bpClient, "leaf")
+	leafIds := GetSystemIDs(t, ctx, bpClient, "leaf")
 	mappings := make(apstra.SystemIdToInterfaceMapAssignment, len(leafIds))
 	for _, leafId := range leafIds {
-		mappings[leafId.String()] = "Juniper_vQFX__AOS-7x10-Leaf"
+		mappings[leafId] = "Juniper_vQFX__AOS-7x10-Leaf"
 	}
 	err = bpClient.SetInterfaceMapAssignments(ctx, mappings)
 	require.NoError(t, err)

--- a/apstra/test_utils/connectivity_template_ip_link.go
+++ b/apstra/test_utils/connectivity_template_ip_link.go
@@ -27,7 +27,7 @@ func DatacenterConnectivityTemplateA(t testing.TB, ctx context.Context, bp *apst
 					Label:              acctest.RandString(10),
 					SecurityZone:       (*apstra.ObjectId)(&szID),
 					Tagged:             true,
-					Vlan:               pointer.To(apstra.VLAN(tag)),
+					Vlan:               pointer.To(uint16(tag)),
 					IPv4AddressingType: apstra.CtPrimitiveIPv4AddressingTypeNumbered,
 				},
 			},

--- a/apstra/test_utils/leaf_switches.go
+++ b/apstra/test_utils/leaf_switches.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func leafSwitches(t testing.TB, ctx context.Context, client *apstra.TwoStageL3ClosClient) []apstra.ObjectId {
+func leafSwitches(t testing.TB, ctx context.Context, client *apstra.TwoStageL3ClosClient) []string {
 	query := new(apstra.PathQuery).
 		SetBlueprintId(client.Id()).
 		SetClient(client.Client()).
@@ -21,14 +21,14 @@ func leafSwitches(t testing.TB, ctx context.Context, client *apstra.TwoStageL3Cl
 	var queryResponse struct {
 		Items []struct {
 			System struct {
-				Id apstra.ObjectId `json:"id"`
+				Id string `json:"id"`
 			} `json:"n_system"`
 		} `json:"items"`
 	}
 
 	require.NoError(t, query.Do(ctx, &queryResponse))
 
-	result := make([]apstra.ObjectId, len(queryResponse.Items))
+	result := make([]string, len(queryResponse.Items))
 	for i, item := range queryResponse.Items {
 		result[i] = item.System.Id
 	}

--- a/apstra/test_utils/routing_zone.go
+++ b/apstra/test_utils/routing_zone.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/terraform-provider-apstra/apstra/compatibility"
 	"github.com/hashicorp/go-version"
@@ -16,7 +17,7 @@ func SecurityZoneA(t testing.TB, ctx context.Context, client *apstra.TwoStageL3C
 	t.Helper()
 
 	name := acctest.RandString(10)
-	id, err := client.CreateSecurityZone(ctx, apstra.SecurityZone{
+	id, err := client.CreateSecurityZone(ctx, datacenter.SecurityZone{
 		Label:           name,
 		Type:            enum.SecurityZoneTypeEVPN,
 		VRFName:         name,
@@ -51,7 +52,7 @@ func SecurityZoneB(t testing.TB, ctx context.Context, client *apstra.TwoStageL3C
 	if compatibility.BPDefaultRoutingZoneAddressingOK.Check(version.Must(version.NewVersion(client.Client().ApiVersion()))) {
 		as = &enum.AddressingSchemeIPv6
 	}
-	id, err := client.CreateSecurityZone(ctx, apstra.SecurityZone{
+	id, err := client.CreateSecurityZone(ctx, datacenter.SecurityZone{
 		Label:             name,
 		Type:              enum.SecurityZoneTypeEVPN,
 		VRFName:           name,

--- a/apstra/test_utils/test_utils.go
+++ b/apstra/test_utils/test_utils.go
@@ -122,7 +122,8 @@ func TestCfgFileToEnv(t testing.TB) {
 	t.Setenv(constants.EnvTlsNoVerify, strconv.FormatBool(testCfg.TlsValidationDisabled))
 }
 
-func GetSystemIds(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosClient, role string) map[string]apstra.ObjectId {
+// GetSystemIDs returns system node IDs keyed by node label
+func GetSystemIDs(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosClient, role string) map[string]string {
 	t.Helper()
 
 	leafQuery := new(apstra.PathQuery).
@@ -138,8 +139,8 @@ func GetSystemIds(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosCl
 	var leafQueryResult struct {
 		Items []struct {
 			System struct {
-				Id    apstra.ObjectId `json:"id"`
-				Label string          `json:"label"`
+				ID    string `json:"id"`
+				Label string `json:"label"`
 			} `json:"n_system"`
 		} `json:"items"`
 	}
@@ -147,9 +148,9 @@ func GetSystemIds(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosCl
 	err := leafQuery.Do(ctx, &leafQueryResult)
 	require.NoError(t, err)
 
-	result := make(map[string]apstra.ObjectId, len(leafQueryResult.Items))
+	result := make(map[string]string, len(leafQueryResult.Items))
 	for _, item := range leafQueryResult.Items {
-		result[item.System.Label] = item.System.Id
+		result[item.System.Label] = item.System.ID
 	}
 
 	return result

--- a/apstra/test_utils/virtual_network.go
+++ b/apstra/test_utils/virtual_network.go
@@ -6,24 +6,25 @@ import (
 	"time"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/stretchr/testify/require"
 )
 
-func VirtualNetworkVxlan(t testing.TB, ctx context.Context, client *apstra.TwoStageL3ClosClient, cleanup bool) apstra.ObjectId {
+func VirtualNetworkVxlan(t testing.TB, ctx context.Context, client *apstra.TwoStageL3ClosClient, cleanup bool) string {
 	leafIds := leafSwitches(t, ctx, client)
-	vnBindings := make([]apstra.VnBinding, len(leafIds))
+	vnBindings := make([]datacenter.VNBinding, len(leafIds))
 	for i, leafId := range leafIds {
-		vnBindings[i] = apstra.VnBinding{SystemId: leafId}
+		vnBindings[i] = datacenter.VNBinding{SystemID: leafId}
 	}
 
-	id, err := client.CreateVirtualNetwork(ctx, &apstra.VirtualNetworkData{
-		Ipv4Enabled:    true,
+	id, err := client.CreateVirtualNetwork(ctx, datacenter.VirtualNetwork{
+		IPv4Enabled:    true,
 		Label:          acctest.RandString(6),
-		SecurityZoneId: apstra.ObjectId(SecurityZoneA(t, ctx, client, cleanup)),
-		VnBindings:     vnBindings,
-		VnType:         enum.VnTypeVxlan,
+		SecurityZoneID: SecurityZoneA(t, ctx, client, cleanup),
+		Bindings:       vnBindings,
+		Type:           enum.VnTypeVxlan,
 	})
 	require.NoError(t, err)
 	if cleanup {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace gopkg.in/yaml.v3 => github.com/go-yaml/yaml/v3 v3.0.1
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20260528181704-a27916309791
+	github.com/Juniper/apstra-go-sdk v0.0.0-20260626182247-a56a9bf449b0
 	github.com/chrismarget-j/version-constraints v0.0.0-20250911132047-1122a37b27ae
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-version v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20260528181704-a27916309791 h1:h9FxzzGQwDXn07aMObsoKOUu5D8arTqHfyeLDKSNaHg=
-github.com/Juniper/apstra-go-sdk v0.0.0-20260528181704-a27916309791/go.mod h1:IXhtfYsKJAfSwUgvi1roB+DN+InkGyGb/ely7LOOF/0=
+github.com/Juniper/apstra-go-sdk v0.0.0-20260626182247-a56a9bf449b0 h1:biff+oKeFAMxn7DUwsQ83liw8gtkfJvX9kRjJBk2Kd0=
+github.com/Juniper/apstra-go-sdk v0.0.0-20260626182247-a56a9bf449b0/go.mod h1:IXhtfYsKJAfSwUgvi1roB+DN+InkGyGb/ely7LOOF/0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=

--- a/internal/value/terraform_plugin_framework_value_creation.go
+++ b/internal/value/terraform_plugin_framework_value_creation.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"reflect"
 
-	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/iptypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -95,10 +94,6 @@ func Int64OrNull(_ context.Context, in any, diags *diag.Diagnostics) types.Int64
 	}
 
 	switch in := in.(type) {
-	case *apstra.VNI:
-		return types.Int64Value(int64(*in))
-	case *apstra.VLAN:
-		return types.Int64Value(int64(*in))
 	case *int:
 		return types.Int64Value(int64(*in))
 	case *int8:
@@ -119,10 +114,6 @@ func Int64OrNull(_ context.Context, in any, diags *diag.Diagnostics) types.Int64
 		return types.Int64Value(int64(*in))
 	case *uint64:
 		return types.Int64Value(int64(*in))
-	case apstra.VNI:
-		return types.Int64Value(int64(in))
-	case apstra.VLAN:
-		return types.Int64Value(int64(in))
 	case int:
 		return types.Int64Value(int64(in))
 	case int8:


### PR DESCRIPTION
This PR bumps the SDK to include the recent avalanche of changes.

It depends on [SDK #748](https://github.com/Juniper/apstra-go-sdk/pull/748) and everything before it.

No logic changes in here, other than:
- Minor changes to accomodate various SDK `Update()` methods which expect an embedded object ID, rather than separate ID and payload parameters
- Logic which generated Security Policy Application Point structs has been removed (the SDK now deals only in Application Point _IDs_, rather than the informational structs which probably should have been relegated to a "web experience" API)

What _is_ in here includes:
- Capitalization changes of various structs and attributes as now required by the SDK
- Sourcing various objects from the SDK's `datacenter` package, rather than `apstra`
- Removal of the SDK's `VLAN` and `VNI` types
- Elimination of the "pointer-by-default" object passing strategy (initiated with the SDK, and carried through various `Request()` and `LoadAPIData()` functions
- Replacing instances of `apstra.ObjectId` with `string`

All tests passing with Apstra versions:
- 6.1.2
- 6.1.1
- 6.1.0
- 6.0.0
- 5.1.0
- 5.0.1
- 5.0.0
- 4.2.2
- 4.2.1.1
- 4.2.1
- 4.2.0