### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/3rd_party_license_checks.yml
+++ b/.github/workflows/3rd_party_license_checks.yml
@@ -1,0 +1,19 @@
+name: Go code checks
+
+on: [push]
+
+jobs:
+  go-tools:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.9'
+
+      - name: 3rd party license compliance check
+        run: make compliance-check

--- a/.github/workflows/3rd_party_license_checks.yml
+++ b/.github/workflows/3rd_party_license_checks.yml
@@ -1,4 +1,4 @@
-name: Go code checks
+name: Check 3rd party license compliance
 
 on: [push]
 

--- a/.github/workflows/go_code_checks.yml
+++ b/.github/workflows/go_code_checks.yml
@@ -1,4 +1,4 @@
-name: Go package
+name: Go code checks
 
 on: [push]
 
@@ -7,10 +7,13 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
 
       - name: Set up Go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25.9'
 
@@ -19,7 +22,7 @@ jobs:
 
       - name: gofumpt
         run: |
-          git fetch origin main --depth 1
+#          git fetch origin main --depth 1 # may be covered by actions/checkout fetch-depth
           make gofumpt
 
       - name: go vet
@@ -27,9 +30,3 @@ jobs:
 
       - name: staticcheck
         run: make staticcheck
-
-      - name: tfplugindocs
-        run: make docs-check
-
-      - name: compliance
-        run: make compliance-check

--- a/.github/workflows/go_code_checks.yml
+++ b/.github/workflows/go_code_checks.yml
@@ -1,4 +1,4 @@
-name: Go code checks
+name: Check Go code
 
 on: [push]
 
@@ -7,10 +7,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
+      - name: Check out repository with full history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -22,7 +22,6 @@ jobs:
 
       - name: gofumpt
         run: |
-#          git fetch origin main --depth 1 # may be covered by actions/checkout fetch-depth
           make gofumpt
 
       - name: go vet

--- a/.github/workflows/tfplugindocs_check.yml
+++ b/.github/workflows/tfplugindocs_check.yml
@@ -1,0 +1,18 @@
+name: Go code checks
+
+on: [push]
+
+jobs:
+  go-tools:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.9'
+
+      - name: tfplugindocs check
+        run: make docs-check

--- a/.github/workflows/tfplugindocs_check.yml
+++ b/.github/workflows/tfplugindocs_check.yml
@@ -1,4 +1,4 @@
-name: Go code checks
+name: Check provider docs
 
 on: [push]
 
@@ -7,7 +7,8 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0


### PR DESCRIPTION
This PR splits our CI workflow into 3 different workflows:
- `3rd_party_license_checks.yml`
- `go_code_checks.yml`
- `tfplugindocs_check.yml`

Each uses the latest releases of `actions/checkout` and `actions/setup-go`.

The `gofumpt` step requires more than the shallow clone provided by `actions/checkout`. It was previously handled by a CLI command (`git fetch origin main --depth 1`) but now is handled by the `fetch-depth: 0` option to `actions/setup-go`.

Closes #1285