### PR TITLE
Allow multiple `changie` fragments per PR

### DIFF
--- a/.changes/unreleased/internal-20260817-154745.yaml
+++ b/.changes/unreleased/internal-20260817-154745.yaml
@@ -1,0 +1,3 @@
+kind: internal
+body: Update `changie` validation to permit multiple fragments per PR.
+time: 2026-08-17T15:47:45.652215-04:00

--- a/scripts/changie_normal_pr_check.sh
+++ b/scripts/changie_normal_pr_check.sh
@@ -74,8 +74,8 @@ while IFS= read -r -d '' status && IFS= read -r -d '' path; do
     esac
 done < <(git diff -z --name-status --no-renames "$BASE_REF"...HEAD)
 
-if [ "$new_fragment_count" -ne 1 ]; then
-    fail "normal PR must add exactly one change fragment under $UNRELEASED_DIR/ (found $new_fragment_count)"
+if [ "$new_fragment_count" -le 0 ]; then
+    fail "normal PR must add at least one change fragment under $UNRELEASED_DIR/ (found $new_fragment_count)"
 fi
 
 echo "Validating $new_fragment_path with changie..."


### PR DESCRIPTION
A single PR should be allowed to introduce multiple `changie` fragments. This PR allows that in the CI checks.