### PR TITLE
Update CI workflows

### DIFF
--- a/.changes/unreleased/internal-20260821-131051.yaml
+++ b/.changes/unreleased/internal-20260821-131051.yaml
@@ -1,0 +1,3 @@
+kind: internal
+body: Rename CI workflow/job/steps; remove superflous read access
+time: 2026-08-21T13:10:51.285775-04:00

--- a/.github/workflows/3rd_party_license_checks.yml
+++ b/.github/workflows/3rd_party_license_checks.yml
@@ -1,9 +1,9 @@
-name: Check 3rd party license compliance
+name: 3rd party license compliance
 
 on: [push]
 
 jobs:
-  go-tools:
+  check:
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/changie_checks.yml
+++ b/.github/workflows/changie_checks.yml
@@ -1,4 +1,4 @@
-name: Changie Checks
+name: Changie
 
 on:
   pull_request:
@@ -10,12 +10,9 @@ on:
       - unlabeled
       - ready_for_review
 
-permissions:
-  contents: read
-
 jobs:
-  changie-checks:
-    name: Changie PR checks
+  checks:
+    name: PR checks
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/go_code_checks.yml
+++ b/.github/workflows/go_code_checks.yml
@@ -1,9 +1,9 @@
-name: Check Go code
+name: Go code
 
 on: [push]
 
 jobs:
-  go-tools:
+  check:
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tfplugindocs_check.yml
+++ b/.github/workflows/tfplugindocs_check.yml
@@ -1,9 +1,9 @@
-name: Check provider docs
+name: Documentation
 
 on: [push]
 
 jobs:
-  go-tools:
+  check:
 
     runs-on: ubuntu-latest
     steps:
@@ -15,5 +15,5 @@ jobs:
         with:
           go-version: '1.25.9'
 
-      - name: tfplugindocs check
+      - name: tfplugindocs
         run: make docs-check


### PR DESCRIPTION
Some of the CI workflows had labels which were copy/pasted directly from other workflows.

This PR improves the names of elements in the workflows and removes a superflous read permission which *I think* was introduced because a previous revision of the workflow did a `git pull` because it wanted to compare `HEAD` against `main`.

That fetch is now handled by the `checkout` action's `fetch-depth` parameter.

Closes #1298