### PR TITLE
Bugfix #1240: `apstra_datacenter_device_allocation` must clear tags in `Create()`

### DIFF
--- a/.changes/unreleased/bugfix-20260825-100604.yaml
+++ b/.changes/unreleased/bugfix-20260825-100604.yaml
@@ -1,0 +1,3 @@
+kind: bugfix
+body: '`apstra_datacenter_device_allocation` will remove existing tags if `system_attributes.tags == null` during create phase.'
+time: 2026-08-25T10:06:04.917665-04:00

--- a/apstra/blueprint/device_allocation.go
+++ b/apstra/blueprint/device_allocation.go
@@ -776,11 +776,19 @@ func (o *DeviceAllocation) SetSystemAttributes(ctx context.Context, state *Devic
 		}
 	}
 
-	// did the user configure `system_attributes`?
+	// did the user omit `system_attributes`?
 	if !utils.HasValue(o.SystemAttributes) {
 		// `system_attributes` not configured - we may need to clear existing tags
-		if stateSA != nil && len(stateSA.Tags.Elements()) > 0 {
-			// tags exist. clear them.
+		if state == nil || // State is nil, indicating we are called by Create()?
+			(stateSA != nil && len(stateSA.Tags.Elements()) > 0) { // Tags found in state?
+			// If we get here, either we're in Create(), or tags were deleted from the configuration.
+			// In either case, we need to clear tags.
+			//
+			// We clear tags in Create() because tags may have propagated through from the design
+			// API during the blueprint scaffolding process. This resource, by virtue of its
+			// existence is now authoritative on tags, and must control. Failure to delete tags
+			// propagated via the template will provoke a "inconsistent result after apply" error.
+			// Rather than check-then-clear-if-necessary, we clear tags unconditionally.
 			err := bp.SetNodeTags(ctx, apstra.ObjectId(o.NodeId.ValueString()), []string{})
 			if err != nil {
 				diags.AddError(fmt.Sprintf("failed clearing tags from system node %s", o.NodeId), err.Error())

--- a/apstra/blueprint/device_allocation_system_attributes.go
+++ b/apstra/blueprint/device_allocation_system_attributes.go
@@ -96,10 +96,11 @@ func (o DeviceAllocationSystemAttributes) ResourceAttributes() map[string]resour
 		},
 		"tags": resourceSchema.SetAttribute{
 			MarkdownDescription: "Tag labels to be applied to the System node. If a Tag doesn't exist " +
-				"in the Blueprint it will be created automatically.",
+				"in the Blueprint it will be created automatically. Note that this resource takes control " +
+				"of Tags. Any tags applied in the design phase will be overwritten by this resource, even if " +
+				"this attribute is omitted.",
 			ElementType: types.StringType,
 			Optional:    true,
-			Computed:    false, // the user controls this field directly
 			Validators: []validator.Set{
 				setvalidator.SizeAtLeast(1),
 				setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),

--- a/docs/resources/datacenter_device_allocation.md
+++ b/docs/resources/datacenter_device_allocation.md
@@ -107,7 +107,7 @@ Optional:
 - `loopback_ipv4` (String) IPv4 address of loopback interface in CIDR notation, must use 32-bit mask. Setting loopback addresses is supported only for Spine and Leaf switches.
 - `loopback_ipv6` (String) IPv6 address of loopback interface in CIDR notation, must use 128-bit mask. Setting loopback addresses is supported only for Spine and Leaf switches. IPv6 must be enabled in the Blueprint to use this attribute.
 - `name` (String) Web UI label for the system node.
-- `tags` (Set of String) Tag labels to be applied to the System node. If a Tag doesn't exist in the Blueprint it will be created automatically.
+- `tags` (Set of String) Tag labels to be applied to the System node. If a Tag doesn't exist in the Blueprint it will be created automatically. Note that this resource takes control of Tags. Any tags applied in the design phase will be overwritten by this resource, even if this attribute is omitted.
 
 
 


### PR DESCRIPTION
Prior to this PR, the `apstra_datacenter_device_allocation` resource only set Tags during `Create()` if its `system_attributes.tags` is non-null, indicating that the user specified some tags.

Tags which existed before this resource was created would survive, leading to state churn (non-empty plan after apply) or "Provider produced inconsistent result after apply" (depending on the framework version?)

Regardless of the outcome, this resource should control tags. Unwanted tags should be cleared.

This PR ensures that when planned tags are `null` during `Create()`, the tags are always cleared by invoking the `SetNodeTags()` function with an empty slice.