### PR TITLE
Improve `SomeOf()` and `TestSomeOfBounds()`

### DIFF
--- a/.changes/unreleased/internal-20260826-075132.yaml
+++ b/.changes/unreleased/internal-20260826-075132.yaml
@@ -1,0 +1,3 @@
+kind: internal
+body: 'Use `min()` function in `SomeOf()`; Rewrite `TestSomeOfBounds()` for better handling of negative test cases.'
+time: 2026-08-26T07:51:32.551008-04:00

--- a/internal/test_utils/random/some_of.go
+++ b/internal/test_utils/random/some_of.go
@@ -19,10 +19,7 @@ func SomeOf[T any](t []T, min_max ...uint16) []T {
 	}
 
 	if len(min_max) > 1 { // did we gat a max parameter?
-		maxCount = int(min_max[1])
-		if maxCount > len(t) {
-			maxCount = len(t)
-		}
+		maxCount = min(int(min_max[1]), len(t))
 	}
 
 	count := BetweenInclusive(minCount, maxCount)

--- a/internal/test_utils/random/some_of_test.go
+++ b/internal/test_utils/random/some_of_test.go
@@ -14,7 +14,6 @@ func TestSomeOfBounds(t *testing.T) {
 	testCases := map[string]struct {
 		input     []string
 		args      []uint16
-		want      *int
 		wantMin   *int
 		wantMax   *int
 		wantPanic bool
@@ -31,9 +30,10 @@ func TestSomeOfBounds(t *testing.T) {
 			wantMax: pointer.To(3),
 		},
 		"bounded_exact value": {
-			input: []string{"a", "b", "c", "d"},
-			args:  []uint16{3, 3},
-			want:  pointer.To(3),
+			input:   []string{"a", "b", "c", "d"},
+			args:    []uint16{3, 3},
+			wantMin: pointer.To(3),
+			wantMax: pointer.To(3),
 		},
 		"min_above_slice_length_panics": {
 			input:     []string{"a", "b", "c", "d"},
@@ -55,9 +55,6 @@ func TestSomeOfBounds(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if tc.want != nil && (tc.wantMin != nil || tc.wantMax != nil) {
-				panic("test case set want along with wantMin or wantMax")
-			}
 			if tc.wantPanic {
 				require.Panics(t, func() { random.SomeOf(tc.input, tc.args...) })
 				return
@@ -68,9 +65,6 @@ func TestSomeOfBounds(t *testing.T) {
 			require.LessOrEqual(t, len(got), len(tc.input))
 			require.Subset(t, tc.input, got)
 
-			if tc.want != nil {
-				require.Len(t, got, *tc.want)
-			}
 			if tc.wantMin != nil {
 				require.LessOrEqual(t, *tc.wantMin, len(got))
 			}

--- a/internal/test_utils/random/some_of_test.go
+++ b/internal/test_utils/random/some_of_test.go
@@ -5,50 +5,60 @@ package random_test
 import (
 	"testing"
 
+	"github.com/Juniper/terraform-provider-apstra/internal/pointer"
 	"github.com/Juniper/terraform-provider-apstra/internal/test_utils/random"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSomeOfBounds(t *testing.T) {
 	testCases := map[string]struct {
-		input []string
-		args  []uint16
-		want  int
+		input     []string
+		args      []uint16
+		want      *int
+		wantMin   *int
+		wantMax   *int
+		wantPanic bool
 	}{
 		"no_bounds": {
-			input: []string{"a", "b", "c", "d"},
-			want:  -1,
+			input:   []string{"a", "b", "c", "d"},
+			wantMin: pointer.To(0),
+			wantMax: pointer.To(4),
 		},
 		"bounded_within_slice": {
-			input: []string{"a", "b", "c", "d"},
-			args:  []uint16{2, 3},
-			want:  -1,
+			input:   []string{"a", "b", "c", "d"},
+			args:    []uint16{2, 3},
+			wantMin: pointer.To(2),
+			wantMax: pointer.To(3),
 		},
 		"bounded_exact value": {
 			input: []string{"a", "b", "c", "d"},
 			args:  []uint16{3, 3},
-			want:  3,
+			want:  pointer.To(3),
 		},
 		"min_above_slice_length_panics": {
-			input: []string{"a", "b", "c", "d"},
-			args:  []uint16{10},
-			want:  -2,
+			input:     []string{"a", "b", "c", "d"},
+			args:      []uint16{10},
+			wantPanic: true,
 		},
 		"max_above_slice_length_clamps": {
-			input: []string{"a", "b", "c", "d"},
-			args:  []uint16{3, 10},
-			want:  3,
+			input:   []string{"a", "b", "c", "d"},
+			args:    []uint16{2, 10},
+			wantMin: pointer.To(2),
+			wantMax: pointer.To(4),
 		},
 		"both_bounds_above_slice_length_panics": {
-			input: []string{"a", "b", "c", "d"},
-			args:  []uint16{10, 12},
-			want:  -2,
+			input:     []string{"a", "b", "c", "d"},
+			args:      []uint16{10, 12},
+			wantPanic: true,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if tc.want == -2 {
+			if tc.want != nil && (tc.wantMin != nil || tc.wantMax != nil) {
+				panic("test case set want along with wantMin or wantMax")
+			}
+			if tc.wantPanic {
 				require.Panics(t, func() { random.SomeOf(tc.input, tc.args...) })
 				return
 			}
@@ -58,8 +68,14 @@ func TestSomeOfBounds(t *testing.T) {
 			require.LessOrEqual(t, len(got), len(tc.input))
 			require.Subset(t, tc.input, got)
 
-			if tc.want >= 0 {
-				require.Len(t, got, tc.want)
+			if tc.want != nil {
+				require.Len(t, got, *tc.want)
+			}
+			if tc.wantMin != nil {
+				require.LessOrEqual(t, *tc.wantMin, len(got))
+			}
+			if tc.wantMax != nil {
+				require.GreaterOrEqual(t, *tc.wantMax, len(got))
 			}
 		})
 	}


### PR DESCRIPTION
`TestSomeOfBounds()` was trying to be too clever by using negative values in `testCase.want` to express various conditions:
- -1: unknown expected length
- -2: expect panic

I've replaced `testCase.want int` with these:
- `testCase.want *int` (when the expected value is known)
- `testCase.wantMin *int` (when the expected value has a minimum bound)
- `testCase.wantMax *int` (when the expected value has a maximum bound)
- `testCase.wantPanic bool` (when the request is expected to panic)

Also, tightened up `SomeOf()` by using the `min()` function in place of a conditional which adjusts the value as needed.