### PR TITLE
Update `goreleaser.yml`: string quoting and build targets

### DIFF
--- a/.changes/unreleased/internal-20260827-144520.yaml
+++ b/.changes/unreleased/internal-20260827-144520.yaml
@@ -1,0 +1,3 @@
+kind: internal
+body: Update build targets in `goreleaser.yml`
+time: 2026-08-27T14:45:20.747643-04:00

--- a/tools/goreleaser/.goreleaser.yml
+++ b/tools/goreleaser/.goreleaser.yml
@@ -27,13 +27,22 @@ builds:
     ldflags:
       - '-s -w -X github.com/Juniper/terraform-provider-apstra/apstra.gitTag={{.Version}} -X github.com/Juniper/terraform-provider-apstra/apstra.gitCommit={{.Commit}}'
     goos:
-      - windows
-      - linux
-      - darwin
+      - 'darwin'
+      - 'freebsd'
+      - 'linux'
+      - 'windows'
     goarch:
-      - amd64
       - '386'
-      - arm64
+      - 'amd64'
+      - 'arm'
+      - 'arm64'
+    ignore:
+      - goos: 'darwin'
+        goarch: '386'
+      - goos: 'darwin'
+        goarch: 'arm'
+      - goos: 'windows'
+        goarch: 'arm'
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   -


### PR DESCRIPTION
This PR updates `goreleaser.yml`:
- consistent string quoting in the `build` section
- add builds for freebsd and 32-bit ARM platforms (supported OS+arch combinations up from 9 to 13)

Closes #1312