### PR TITLE
Add support for new Resource Pool assignment types

### DIFF
--- a/.changes/unreleased/feature-20260911-160615.yaml
+++ b/.changes/unreleased/feature-20260911-160615.yaml
@@ -1,0 +1,3 @@
+kind: feature
+body: 'Introduced support for new roles in the `apstra_datacenter_resource_pool_allocation` resource: `access_l3_peer_links_ipv6`, `access_loopback_ips_ipv6`, `external_vn_local_vnis` and `vtep_ips_ipv6`'
+time: 2026-09-11T16:06:15.795705-04:00

--- a/docs/resources/datacenter_resource_pool_allocation.md
+++ b/docs/resources/datacenter_resource_pool_allocation.md
@@ -68,8 +68,11 @@ resource "apstra_datacenter_resource_pool_allocation" "ipv4" {
 - `role` (String) Fabric Role (Apstra Resource Group Name) must be one of:
   - access_asns
   - access_l3_peer_link_link_ips
+  - access_l3_peer_links_ipv6
   - access_loopback_ips
+  - access_loopback_ips_ipv6
   - evpn_l3_vnis
+  - external_vn_local_vnis
   - generic_asns
   - generic_loopback_ips
   - generic_loopback_ips_ipv6
@@ -98,6 +101,7 @@ resource "apstra_datacenter_resource_pool_allocation" "ipv4" {
   - virtual_network_svi_subnets_ipv6
   - vni_virtual_network_ids
   - vtep_ips
+  - vtep_ips_ipv6
 
 ### Optional
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace gopkg.in/yaml.v3 => github.com/go-yaml/yaml/v3 v3.0.1
 
 require (
 	github.com/IBM/netaddr v1.5.0
-	github.com/Juniper/apstra-go-sdk v0.0.0-20260908183150-0cff1fe85fc3
+	github.com/Juniper/apstra-go-sdk v0.0.0-20260911190651-cec1c412cd03
 	github.com/chrismarget-j/version-constraints v0.0.0-20250911132047-1122a37b27ae
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-version v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
 github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
-github.com/Juniper/apstra-go-sdk v0.0.0-20260908183150-0cff1fe85fc3 h1:skVGsal+ojNEi+/yHFvyikZcJX59qgQTa3eP/iU3obs=
-github.com/Juniper/apstra-go-sdk v0.0.0-20260908183150-0cff1fe85fc3/go.mod h1:AI3GMajKxSycUNAuBpTdl56TGfIxU+9hxAZ1rSbnSeg=
+github.com/Juniper/apstra-go-sdk v0.0.0-20260911190651-cec1c412cd03 h1:6WwTgIXeQJf5zd/fiDPuUJEoM5nmnqoDIGHiWZov2ho=
+github.com/Juniper/apstra-go-sdk v0.0.0-20260911190651-cec1c412cd03/go.mod h1:AI3GMajKxSycUNAuBpTdl56TGfIxU+9hxAZ1rSbnSeg=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=

--- a/internal/rosetta/rosetta.go
+++ b/internal/rosetta/rosetta.go
@@ -283,8 +283,8 @@ func storageSchemaPathToFriendlyString(in enum.StorageSchemaPath) string {
 
 func resourceGroupNameToFriendlyString(in apstra.ResourceGroupName) string {
 	switch in {
-	//case apstra.ResourceGroupNameAccessAccessIp4: // todo save this for v1.0.0
-	//	return resourceGroupNameAccessAccessLinkIp4 // todo save this for v1.0.0
+	// case apstra.ResourceGroupNameAccessAccessIp4: // todo save this for v1.0.0
+	//	return resourceGroupNameAccessAccessLinkIp4  // todo save this for v1.0.0
 	case apstra.ResourceGroupNameAccessAccessIp6:
 		return resourceGroupNameAccessAccessLinkIp6
 	case apstra.ResourceGroupNameLeafL3PeerLinkLinkIp4:
@@ -500,7 +500,7 @@ func resourceGroupNameFromFriendlyString(target *apstra.ResourceGroupName, in ..
 	}
 
 	switch in[0] {
-	//case resourceGroupNameAccessAccessLinkIp4:          // todo save this for v1.0.0
+	// case resourceGroupNameAccessAccessLinkIp4:         // todo save this for v1.0.0
 	//	*target = apstra.ResourceGroupNameAccessAccessIp4 // todo save this for v1.0.0
 	case resourceGroupNameAccessAccessLinkIp6:
 		*target = apstra.ResourceGroupNameAccessAccessIp6

--- a/internal/rosetta/rosetta.go
+++ b/internal/rosetta/rosetta.go
@@ -28,6 +28,8 @@ const (
 	nodeDeployModeNotSet = "not_set"
 
 	resourceGroupNameVxlanVnIds          = "vni_virtual_network_ids"
+	resourceGroupNameAccessAccessLinkIp4 = "access_l3_peer_links"
+	resourceGroupNameAccessAccessLinkIp6 = "access_l3_peer_links_ipv6"
 	resourceGroupNameLeafL3PeerLinksIpv4 = "leaf_l3_peer_links"
 	resourceGroupNameLeafL3PeerLinksIpv6 = "leaf_l3_peer_links_ipv6"
 
@@ -281,6 +283,10 @@ func storageSchemaPathToFriendlyString(in enum.StorageSchemaPath) string {
 
 func resourceGroupNameToFriendlyString(in apstra.ResourceGroupName) string {
 	switch in {
+	//case apstra.ResourceGroupNameAccessAccessIp4: // todo save this for v1.0.0
+	//	return resourceGroupNameAccessAccessLinkIp4 // todo save this for v1.0.0
+	case apstra.ResourceGroupNameAccessAccessIp6:
+		return resourceGroupNameAccessAccessLinkIp6
 	case apstra.ResourceGroupNameLeafL3PeerLinkLinkIp4:
 		return resourceGroupNameLeafL3PeerLinksIpv4
 	case apstra.ResourceGroupNameLeafL3PeerLinkLinkIp6:
@@ -494,6 +500,10 @@ func resourceGroupNameFromFriendlyString(target *apstra.ResourceGroupName, in ..
 	}
 
 	switch in[0] {
+	//case resourceGroupNameAccessAccessLinkIp4:          // todo save this for v1.0.0
+	//	*target = apstra.ResourceGroupNameAccessAccessIp4 // todo save this for v1.0.0
+	case resourceGroupNameAccessAccessLinkIp6:
+		*target = apstra.ResourceGroupNameAccessAccessIp6
 	case resourceGroupNameLeafL3PeerLinksIpv4:
 		*target = apstra.ResourceGroupNameLeafL3PeerLinkLinkIp4
 	case resourceGroupNameLeafL3PeerLinksIpv6:


### PR DESCRIPTION
This PR bumps the SDK for new `apstra.ResourceGroupName`s, and normalizes a couple of them via the `rosetta` package.

Depends on [SDK #775](https://github.com/Juniper/apstra-go-sdk/pull/775)